### PR TITLE
Specify the Main class in the generated Jar

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -123,6 +123,18 @@
                   </execution>
               </executions>
           </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <configuration>
+                  <archive>
+                      <manifest>
+                          <addClasspath>true</addClasspath>
+                          <mainClass>io.apicurio.codegen.cli.GenerateJavaSources</mainClass>
+                      </manifest>
+                  </archive>
+              </configuration>
+          </plugin>
     </plugins>
 
     </build>


### PR DESCRIPTION
This will enable running the CLI as a Jar from `jbang`