### PR TITLE
Replace javapoet with Roaster for JAX-RS object generation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,9 +83,22 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup</groupId>
-            <artifactId>javapoet</artifactId>
-            <version>${version.com.squareup.javapoet}</version>
+            <groupId>org.jboss.forge.roaster</groupId>
+            <artifactId>roaster-api</artifactId>
+            <version>${version.roaster}</version>
+        </dependency>
+
+        <dependency>
+             <groupId>org.jboss.forge.roaster</groupId>
+             <artifactId>roaster-jdt</artifactId>
+             <version>${version.roaster}</version>
+             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.21.0</version>
         </dependency>
 
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,6 +13,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <io.apicurio.codegen.dumptest>false</io.apicurio.codegen.dumptest>
+    </properties>
+
     <dependencies>
         <!-- Apicurio Data Model -->
         <dependency>
@@ -177,6 +181,16 @@
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
                     <fork>true</fork>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.maven-surefire-plugin}</version>
+                <configuration>
+                    <systemProperties>
+                        <io.apicurio.codegen.dumptest>${io.apicurio.codegen.dumptest}</io.apicurio.codegen.dumptest>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/core/src/main/java/io/apicurio/hub/api/codegen/OpenApi2Quarkus.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/OpenApi2Quarkus.java
@@ -28,7 +28,7 @@ import io.apicurio.hub.api.codegen.beans.CodegenInfo;
 
 /**
  * Class used to generate a Quarkus JAX-RS project from an OpenAPI document.
- * 
+ *
  * @author eric.wittmann@gmail.com
  */
 public class OpenApi2Quarkus extends OpenApi2JaxRs {
@@ -39,7 +39,7 @@ public class OpenApi2Quarkus extends OpenApi2JaxRs {
     public OpenApi2Quarkus() {
         super();
     }
-    
+
     /**
      * @see io.apicurio.hub.api.codegen.OpenApi2JaxRs#generateAll(io.apicurio.hub.api.codegen.beans.CodegenInfo, java.lang.StringBuilder, java.util.zip.ZipOutputStream)
      */
@@ -67,12 +67,12 @@ public class OpenApi2Quarkus extends OpenApi2JaxRs {
             zipOutput.closeEntry();
         }
     }
-    
+
     /**
      * @see io.apicurio.hub.api.codegen.OpenApi2JaxRs#generateJaxRsApplication()
      */
     @Override
-    protected String generateJaxRsApplication() throws IOException {
+    protected String generateJaxRsApplication() {
         // Don't need one of these for Quarkus.
         return null;
     }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiByteSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiByteSimpleTypeProcessor.java
@@ -16,9 +16,7 @@
 
 package io.apicurio.hub.api.codegen.pre;
 
-import com.squareup.javapoet.ArrayTypeName;
 import io.apicurio.datamodels.combined.visitors.CombinedVisitorAdapter;
-import io.apicurio.datamodels.core.models.Extension;
 import io.apicurio.datamodels.core.models.common.IDefinition;
 import io.apicurio.datamodels.core.models.common.IPropertySchema;
 import io.apicurio.datamodels.core.models.common.Schema;
@@ -26,7 +24,6 @@ import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Schema.Oas30AnyOfSchema;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Schema.Oas30NotSchema;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Schema.Oas30OneOfSchema;
-import io.apicurio.hub.api.codegen.CodegenExtensions;
 
 /**
  * @author eric.wittmann@gmail.com

--- a/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2JaxRsTest.java
+++ b/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2JaxRsTest.java
@@ -16,19 +16,22 @@
 
 package io.apicurio.hub.api.codegen;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.jboss.forge.roaster.Roaster;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.Properties;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -241,25 +244,26 @@ public class OpenApi2JaxRsTest {
                         System.out.println("----- UNEXPECTED ERROR LOG -----");
                     }
                     Assert.assertNotNull("Could not find expected file for entry: " + name, expectedFile);
-                    String expected = IOUtils.toString(expectedFile, Charset.forName("UTF-8"));
+                    String expected = normalize(OpenApi2JaxRs.getFormatterProperties(), IOUtils.toString(expectedFile, Charset.forName("UTF-8")));
+                    String actual = normalize(OpenApi2JaxRs.getFormatterProperties(), IOUtils.toString(zipInputStream, Charset.forName("UTF-8")));
 
-                    String actual = IOUtils.toString(zipInputStream, Charset.forName("UTF-8"));
                     if (debug) {
                         System.out.println("-----");
                         System.out.println(actual);
                         System.out.println("-----");
                     }
-                    Assert.assertEquals("Expected vs. actual failed for entry: " + name, normalizeString(expected), normalizeString(actual));
+                    Assert.assertEquals("Expected vs. actual failed for entry: " + name, expected, actual);
                 }
                 zipEntry = zipInputStream.getNextEntry();
             }
         }
     }
 
-    private static String normalizeString(String value) {
-        value = value.replaceAll("\\r\\n", "\n");
-        value = value.replaceAll("\\r", "\n");
-        return value;
+    private static String normalize(Properties formatting, String value) {
+        return Roaster.format(formatting, value)
+            .lines()
+            .map(String::stripTrailing)
+            .collect(Collectors.joining("\n"));
     }
 
 }

--- a/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2QuarkusTest.java
+++ b/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2QuarkusTest.java
@@ -16,24 +16,14 @@
 
 package io.apicurio.hub.api.codegen;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApi2QuarkusTest {
+public class OpenApi2QuarkusTest extends OpenApi2TestBase {
 
     /**
      * Test method for {@link io.apicurio.hub.api.codegen.OpenApi2Quarkus#generate()}.
@@ -50,7 +40,7 @@ public class OpenApi2QuarkusTest {
     public void testGitHubApisFull() throws IOException {
         doFullTest("OpenApi2QuarkusTest/github-apis-deref.json", false, "_expected-github/generated-api", false);
     }
-    
+
     /**
      * Shared test method.
      * @param apiDef
@@ -63,53 +53,7 @@ public class OpenApi2QuarkusTest {
         OpenApi2Quarkus generator = new OpenApi2Quarkus();
         generator.setUpdateOnly(updateOnly);
         generator.setOpenApiDocument(getClass().getClassLoader().getResource(apiDef));
-        ByteArrayOutputStream outputStream = generator.generate();
-        
-        if (debug) {
-            File tempFile = File.createTempFile("api", ".zip");
-            FileUtils.writeByteArrayToFile(tempFile, outputStream.toByteArray());
-            System.out.println("Generated ZIP (debug) can be found here: " + tempFile.getAbsolutePath());
-        }
-
-        // Validate the result
-        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(outputStream.toByteArray()))) {
-            ZipEntry zipEntry = zipInputStream.getNextEntry();
-            while (zipEntry != null) {
-                if (!zipEntry.isDirectory()) {
-                    String name = zipEntry.getName();
-                    if (debug) {
-                        System.out.println(name);
-                    }
-                    Assert.assertNotNull(name);
-                    
-                    URL expectedFile = getClass().getClassLoader().getResource(getClass().getSimpleName() + "/" + expectedFilesPath + "/" + name);
-                    if (expectedFile == null && "PROJECT_GENERATION_FAILED.txt".equals(name)) {
-                        String errorLog = IOUtils.toString(zipInputStream, Charset.forName("UTF-8"));
-                        System.out.println("----- UNEXPECTED ERROR LOG -----");
-                        System.out.println(errorLog);
-                        System.out.println("----- UNEXPECTED ERROR LOG -----");
-                    }
-                    Assert.assertNotNull("Could not find expected file for entry: " + name, expectedFile);
-                    String expected = IOUtils.toString(expectedFile, Charset.forName("UTF-8"));
-
-                    String actual = IOUtils.toString(zipInputStream, Charset.forName("UTF-8"));
-                    if (debug) {
-                        System.out.println("-----");
-                        System.out.println(actual);
-                        System.out.println("-----");
-                    }
-
-                    Assert.assertEquals("Expected vs. actual failed for entry: " + name, normalizeString(expected), normalizeString(actual));
-                }
-                zipEntry = zipInputStream.getNextEntry();
-            }
-        }
-    }
-
-    private static String normalizeString(String value) {
-        value = value.replaceAll("\\r\\n", "\n");
-        value = value.replaceAll("\\r", "\n");
-        return value;
+        super.doFullTest(generator, expectedFilesPath, debug);
     }
 
 }

--- a/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2TestBase.java
+++ b/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2TestBase.java
@@ -1,0 +1,119 @@
+package io.apicurio.hub.api.codegen;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+class OpenApi2TestBase {
+
+    protected void doFullTest(OpenApi2JaxRs generator, String expectedFilesPath, boolean debug) throws IOException {
+        ByteArrayOutputStream outputStream = generator.generate();
+
+        if (debug) {
+            File tempFile = File.createTempFile("api", ".zip");
+            FileUtils.writeByteArrayToFile(tempFile, outputStream.toByteArray());
+            System.out.println("Generated ZIP (debug) can be found here: " + tempFile.getAbsolutePath());
+        }
+
+        if (Boolean.getBoolean("io.apicurio.codegen.dumptest")) {
+            dumpOutput(outputStream.toByteArray(), new File("./target/generated-test-data/" + getClass().getSimpleName() + "/" + expectedFilesPath));
+        }
+
+        // Validate the result
+        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(outputStream.toByteArray()))) {
+            ZipEntry zipEntry = zipInputStream.getNextEntry();
+            while (zipEntry != null) {
+                if (!zipEntry.isDirectory()) {
+                    String name = zipEntry.getName();
+                    if (debug) {
+                        System.out.println(name);
+                    }
+                    Assert.assertNotNull(name);
+
+                    URL expectedFile = getClass().getClassLoader().getResource(getClass().getSimpleName() + "/" + expectedFilesPath + "/" + name);
+                    if (expectedFile == null && "PROJECT_GENERATION_FAILED.txt".equals(name)) {
+                        String errorLog = IOUtils.toString(zipInputStream, Charset.forName("UTF-8"));
+                        System.out.println("----- UNEXPECTED ERROR LOG -----");
+                        System.out.println(errorLog);
+                        System.out.println("----- UNEXPECTED ERROR LOG -----");
+                    }
+                    Assert.assertNotNull("Could not find expected file for entry: " + name, expectedFile);
+                    String expected = IOUtils.toString(expectedFile, Charset.forName("UTF-8"));
+                    String actual = IOUtils.toString(zipInputStream, Charset.forName("UTF-8"));
+
+                    if (debug) {
+                        System.out.println("-----");
+                        System.out.println(actual);
+                        System.out.println("-----");
+                    }
+
+                    Assert.assertEquals("Expected vs. actual failed for entry: " + name, normalizeLines(expected), normalizeLines(actual));
+                }
+                zipEntry = zipInputStream.getNextEntry();
+            }
+        }
+    }
+
+    private static String normalizeLines(String value) {
+        return value.lines()
+            .map(String::stripTrailing)
+            .collect(Collectors.joining("\n"));
+    }
+
+    static void dumpOutput(byte[] rawArchive, File outputPath) throws IOException {
+        byte[] buffer = new byte[1024];
+
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(rawArchive))) {
+            ZipEntry zipEntry = zis.getNextEntry();
+
+            while (zipEntry != null) {
+                File newFile = newFile(outputPath, zipEntry);
+
+                if (zipEntry.isDirectory()) {
+                    if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                        throw new IOException("Failed to create directory " + newFile);
+                    }
+                } else {
+                    // fix for Windows-created archives
+                    File parent = newFile.getParentFile();
+                    if (!parent.isDirectory() && !parent.mkdirs()) {
+                        throw new IOException("Failed to create directory " + parent);
+                    }
+
+                    // write file content
+                    FileOutputStream fos = new FileOutputStream(newFile);
+                    int len;
+                    while ((len = zis.read(buffer)) > 0) {
+                        fos.write(buffer, 0, len);
+                    }
+                    fos.close();
+                }
+                zipEntry = zis.getNextEntry();
+            }
+        }
+    }
+
+    static File newFile(File outputPath, ZipEntry zipEntry) throws IOException {
+        File destFile = new File(outputPath, zipEntry.getName());
+
+        String destDirPath = outputPath.getCanonicalPath();
+        String destFilePath = destFile.getCanonicalPath();
+
+        if (!destFilePath.startsWith(destDirPath + File.separator)) {
+            throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+        }
+
+        return destFile;
+    }
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-context-root/generated-api/src/main/java/org/example/api/WidgetsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-context-root/generated-api/src/main/java/org/example/api/WidgetsResource.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.Produces;
 import java.util.List;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/api/v3/widgets")
 public interface WidgetsResource {

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-custom-response-type/generated-api/src/main/java/org/example/api/WidgetsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-custom-response-type/generated-api/src/main/java/org/example/api/WidgetsResource.java
@@ -13,26 +13,35 @@ import java.util.List;
 import org.example.api.beans.Widget;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/widgets")
 public interface WidgetsResource {
   /**
-   * Gets a list of all `Widget` entities.
+   * <p>
+   * Gets a list of all <code>Widget</code> entities.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Widget> getWidgets();
 
   /**
-   * Creates a new instance of a `Widget`.
+   * <p>
+   * Creates a new instance of a <code>Widget</code>.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")
   void createWidget(Widget data);
 
   /**
-   * Gets the details of a single instance of a `Widget`.
+   * <p>
+   * Gets the details of a single instance of a <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @GET
@@ -40,7 +49,10 @@ public interface WidgetsResource {
   Response getWidget(@PathParam("widgetId") String widgetId);
 
   /**
-   * Updates an existing `Widget`.
+   * <p>
+   * Updates an existing <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @PUT
@@ -48,7 +60,10 @@ public interface WidgetsResource {
   void updateWidget(@PathParam("widgetId") String widgetId, Widget data);
 
   /**
-   * Deletes an existing `Widget`.
+   * <p>
+   * Deletes an existing <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @DELETE

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-full-with-ci/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-full-with-ci/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -12,12 +12,15 @@ import java.util.List;
 import org.example.api.beans.Beer;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/beers")
 public interface BeersResource {
   /**
+   * <p>
    * Returns full information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @GET
@@ -25,7 +28,10 @@ public interface BeersResource {
   Beer getBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Updates information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @PUT
@@ -33,21 +39,30 @@ public interface BeersResource {
   void updateBeer(@PathParam("beerId") int beerId, Beer data);
 
   /**
+   * <p>
    * Removes a single beer from the data set.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @DELETE
   void deleteBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Returns all of the beers in the database.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Beer> listAllBeers();
 
   /**
+   * <p>
    * Adds a single beer to the dataset.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-full-with-ci/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-full-with-ci/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -13,26 +13,35 @@ import org.example.api.beans.Beer;
 import org.example.api.beans.Brewery;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/breweries")
 public interface BreweriesResource {
   /**
+   * <p>
    * Returns a list of all the breweries.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Brewery> listAllBreweries();
 
   /**
+   * <p>
    * Adds a single brewery to the data set.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")
   void addBrewery(Brewery data);
 
   /**
+   * <p>
    * Returns full information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @GET
@@ -40,7 +49,10 @@ public interface BreweriesResource {
   Brewery getBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Updates information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @PUT
@@ -48,14 +60,20 @@ public interface BreweriesResource {
   void updateBrewery(@PathParam("breweryId") int breweryId, Brewery data);
 
   /**
+   * <p>
    * Removes a single brewery from the data set.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @DELETE
   void deleteBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Returns all of the beers made by the brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @GET
@@ -63,7 +81,10 @@ public interface BreweriesResource {
   List<Beer> listBreweryBeers(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @POST

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -12,12 +12,15 @@ import java.util.List;
 import org.example.api.beans.Beer;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/beers")
 public interface BeersResource {
   /**
+   * <p>
    * Returns full information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @GET
@@ -25,7 +28,10 @@ public interface BeersResource {
   Beer getBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Updates information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @PUT
@@ -33,21 +39,30 @@ public interface BeersResource {
   void updateBeer(@PathParam("beerId") int beerId, Beer data);
 
   /**
+   * <p>
    * Removes a single beer from the data set.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @DELETE
   void deleteBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Returns all of the beers in the database.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Beer> listAllBeers();
 
   /**
+   * <p>
    * Adds a single beer to the dataset.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -13,26 +13,35 @@ import org.example.api.beans.Beer;
 import org.example.api.beans.Brewery;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/breweries")
 public interface BreweriesResource {
   /**
+   * <p>
    * Returns a list of all the breweries.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Brewery> listAllBreweries();
 
   /**
+   * <p>
    * Adds a single brewery to the data set.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")
   void addBrewery(Brewery data);
 
   /**
+   * <p>
    * Returns full information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @GET
@@ -40,7 +49,10 @@ public interface BreweriesResource {
   Brewery getBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Updates information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @PUT
@@ -48,14 +60,20 @@ public interface BreweriesResource {
   void updateBrewery(@PathParam("breweryId") int breweryId, Brewery data);
 
   /**
+   * <p>
    * Removes a single brewery from the data set.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @DELETE
   void deleteBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Returns all of the beers made by the brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @GET
@@ -63,7 +81,10 @@ public interface BreweriesResource {
   List<Beer> listBreweryBeers(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @POST

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ApisResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ApisResource.java
@@ -5,12 +5,15 @@ import jakarta.ws.rs.Path;
 import org.example.api.beans.API;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/apis")
 public interface ApisResource {
   /**
+   * <p>
    * Publish an API and make it immediately available on the gateway.
+   * </p>
+   * 
    */
   @PUT
   void publishAnAPI(API body);

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ClientsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ClientsResource.java
@@ -5,12 +5,15 @@ import jakarta.ws.rs.Path;
 import org.example.api.beans.Client;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/clients")
 public interface ClientsResource {
   /**
+   * <p>
    * Register a Client and make it immediately available on the gateway.
+   * </p>
+   * 
    */
   @PUT
   void registerAClient(Client body);

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/SystemResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/SystemResource.java
@@ -5,12 +5,18 @@ import jakarta.ws.rs.Path;
 import org.example.api.beans.SystemStatus;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/system")
 public interface SystemResource {
   /**
-   * Get current gateway status. Useful for determining whether a given gateway is responding correctly (routing, finished booting, error, etc) and verifying that provided auth credentials are correct, and/or the auth server is reachable (if applicable).
+   * <p>
+   * Get current gateway status. Useful for determining whether a given gateway is
+   * responding correctly (routing, finished booting, error, etc) and verifying
+   * that provided auth credentials are correct, and/or the auth server is
+   * reachable (if applicable).
+   * </p>
+   * 
    */
   @Path("/status")
   @GET

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-inheritance/generated-api/src/main/java/org/example/api/WidgetsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-inheritance/generated-api/src/main/java/org/example/api/WidgetsResource.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Produces;
 import java.util.List;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/widgets")
 public interface WidgetsResource {

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-issue885Api-full/generated-api/src/main/java/org/example/api/TestResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-issue885Api-full/generated-api/src/main/java/org/example/api/TestResource.java
@@ -4,12 +4,15 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/test")
 public interface TestResource {
   /**
+   * <p>
    * 测试中文字符
+   * </p>
+   * 
    */
   @Path("/chinese/character")
   @GET

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-mas-studio/generated-api/src/main/java/org/example/api/TeamsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-mas-studio/generated-api/src/main/java/org/example/api/TeamsResource.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.example.api.beans.Team;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/apis/studio/v1/teams")
 public interface TeamsResource {

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-mmt-full/generated-api/src/main/java/org/example/api/WidgetsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-mmt-full/generated-api/src/main/java/org/example/api/WidgetsResource.java
@@ -16,34 +16,45 @@ import org.example.api.beans.Widgetv1;
 import org.example.api.beans.Widgetv2;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/widgets")
 public interface WidgetsResource {
   /**
-   * Gets a list of all `Widget` entities.
+   * <p>
+   * Gets a list of all <code>Widget</code> entities.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
-  List<Widget> getWidgets(@QueryParam("description") String description,
-      @QueryParam("contentId") Long contentId);
+  List<Widget> getWidgets(@QueryParam("description") String description, @QueryParam("contentId") Long contentId);
 
   /**
-   * Creates a new instance of a `Widget`.
+   * <p>
+   * Creates a new instance of a <code>Widget</code>.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json+v1")
   void createWidget(Widgetv1 data);
 
   /**
-   * Creates a new instance of a `Widget`.
+   * <p>
+   * Creates a new instance of a <code>Widget</code>.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json+v2")
   void createWidget(Widgetv2 data);
 
   /**
-   * Gets the details of a single instance of a `Widget`.
+   * <p>
+   * Gets the details of a single instance of a <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @GET
@@ -51,7 +62,10 @@ public interface WidgetsResource {
   Widget getWidget(@PathParam("widgetId") String widgetId);
 
   /**
-   * Updates an existing `Widget`.
+   * <p>
+   * Updates an existing <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @PUT
@@ -59,7 +73,10 @@ public interface WidgetsResource {
   void updateWidget(@PathParam("widgetId") String widgetId, Widget data);
 
   /**
-   * Updates an existing `Widget`.
+   * <p>
+   * Updates an existing <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @PUT
@@ -67,7 +84,10 @@ public interface WidgetsResource {
   void updateWidget(@PathParam("widgetId") String widgetId, InputStream data);
 
   /**
-   * Deletes an existing `Widget`.
+   * <p>
+   * Deletes an existing <code>Widget</code>.
+   * </p>
+   * 
    */
   @Path("/{widgetId}")
   @DELETE

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-nzdax/generated-api/src/main/java/org/example/api/ExchangeResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-nzdax/generated-api/src/main/java/org/example/api/ExchangeResource.java
@@ -22,12 +22,16 @@ import org.example.api.beans.TickerResponse;
 import org.example.api.beans.TradeResponse;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/exchange")
 public interface ExchangeResource {
   /**
-   * Retreives the current exchange connection details given the {exchangeName} and access token in the header
+   * <p>
+   * Retreives the current exchange connection details given the {exchangeName}
+   * and access token in the header
+   * </p>
+   * 
    */
   @Path("/{exchangeName}")
   @GET
@@ -35,17 +39,22 @@ public interface ExchangeResource {
   ExchangeResponse getConnection(@PathParam("exchangeName") Exchange exchangeName);
 
   /**
+   * <p>
    * Creates a private connection to the exchange referenced in {exchangeName}
+   * </p>
+   * 
    */
   @Path("/{exchangeName}")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  AccessToken createPrivateConnection(@PathParam("exchangeName") Exchange exchangeName,
-      ExchangeConfig data);
+  AccessToken createPrivateConnection(@PathParam("exchangeName") Exchange exchangeName, ExchangeConfig data);
 
   /**
+   * <p>
    * Delete the exchange connection referenced by access token in the header
+   * </p>
+   * 
    */
   @Path("/{exchangeName}")
   @DELETE
@@ -53,9 +62,15 @@ public interface ExchangeResource {
   ExchangeResponse deletePrivateConnection(@PathParam("exchangeName") Exchange exchangeName);
 
   /**
+   * <p>
    * Get the markets of the exchange referenced by the {exchangeName}.
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/markets")
   @GET
@@ -63,9 +78,16 @@ public interface ExchangeResource {
   List<MarketResponse> markets(@PathParam("exchangeName") Exchange exchangeName);
 
   /**
-   * Get the order book of the exchange referenced by the {exchangeName} and `?symbol=`. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the order book of the exchange referenced by the {exchangeName} and
+   * <code>?symbol=</code>.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/orderBook")
   @GET
@@ -75,9 +97,16 @@ public interface ExchangeResource {
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the Level 2 Order Book of the exchange referenced by the {exchangeName} and `?symbol=`.
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the Level 2 Order Book of the exchange referenced by the {exchangeName}
+   * and <code>?symbol=</code>.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/l2OrderBook")
   @GET
@@ -87,46 +116,71 @@ public interface ExchangeResource {
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the trades of the exchange referenced by the {exchangeName} and `?symbol=`.
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the trades of the exchange referenced by the {exchangeName} and
+   * <code>?symbol=</code>.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/trades")
   @GET
   @Produces("application/json")
-  List<TradeResponse> trades(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol, @QueryParam("since") String since,
-      @QueryParam("limit") Number limit,
+  List<TradeResponse> trades(@PathParam("exchangeName") Exchange exchangeName, @QueryParam("symbol") String symbol,
+      @QueryParam("since") String since, @QueryParam("limit") Number limit,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the ticker of the exchange referenced by the {exchangeName} and `?symbol=`.
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the ticker of the exchange referenced by the {exchangeName} and
+   * <code>?symbol=</code>.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/ticker")
   @GET
   @Produces("application/json")
-  TickerResponse ticker(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol, @QueryParam("exchangeSymbol") String exchangeSymbol,
+  TickerResponse ticker(@PathParam("exchangeName") Exchange exchangeName, @QueryParam("symbol") String symbol,
+      @QueryParam("exchangeSymbol") String exchangeSymbol,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the tickers of the exchange referenced by the {exchangeName} and `?symbol=`.
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the tickers of the exchange referenced by the {exchangeName} and
+   * <code>?symbol=</code>.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/tickers")
   @GET
   @Produces("application/json")
-  List<TickerResponse> tickers(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol,
+  List<TickerResponse> tickers(@PathParam("exchangeName") Exchange exchangeName, @QueryParam("symbol") String symbol,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the balances of the exchange referenced by the {exchangeName}. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the balances of the exchange referenced by the {exchangeName}.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/balances")
   @GET
@@ -135,59 +189,82 @@ public interface ExchangeResource {
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the orders of the exchange referenced by the {exchangeName}. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the orders of the exchange referenced by the {exchangeName}.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/orders")
   @GET
   @Produces("application/json")
-  List<OrderResponse> fetchOrders(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol, @QueryParam("since") String since,
-      @QueryParam("limit") Number limit,
+  List<OrderResponse> fetchOrders(@PathParam("exchangeName") Exchange exchangeName, @QueryParam("symbol") String symbol,
+      @QueryParam("since") String since, @QueryParam("limit") Number limit,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get the open orders of the exchange referenced by the {exchangeName}. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get the open orders of the exchange referenced by the {exchangeName}.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/orders/open")
   @GET
   @Produces("application/json")
   List<OrderResponse> fetchOpenOrders(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol, @QueryParam("since") String since,
-      @QueryParam("limit") Number limit,
+      @QueryParam("symbol") String symbol, @QueryParam("since") String since, @QueryParam("limit") Number limit,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
+   * <p>
    * Get the closed orders of the exchange referenced by the {exchangeName}.
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/orders/closed")
   @GET
   @Produces("application/json")
   List<OrderResponse> fetchClosedOrders(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol, @QueryParam("since") String since,
-      @QueryParam("limit") Number limit,
+      @QueryParam("symbol") String symbol, @QueryParam("since") String since, @QueryParam("limit") Number limit,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Get my trades of the exchange referenced by the {exchangeName}. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Get my trades of the exchange referenced by the {exchangeName}.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/trades/mine")
   @GET
   @Produces("application/json")
   List<TradeResponse> fetchMyTrades(@PathParam("exchangeName") Exchange exchangeName,
-      @QueryParam("symbol") String symbol, @QueryParam("since") String since,
-      @QueryParam("limit") Number limit,
+      @QueryParam("symbol") String symbol, @QueryParam("since") String since, @QueryParam("limit") Number limit,
       @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
+   * <p>
    * Create an order on the exchange referenced by the {exchangeName}
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/order")
   @POST
@@ -196,26 +273,38 @@ public interface ExchangeResource {
   OrderResponse createOrder(@PathParam("exchangeName") Exchange exchangeName, OrderPlacement data);
 
   /**
-   * Retrieves the information of an order on the exchange referenced by the {exchangeName} and {orderId}. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Retrieves the information of an order on the exchange referenced by the
+   * {exchangeName} and {orderId}.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/order/{orderId}")
   @GET
   @Produces("application/json")
-  OrderResponse fetchOrder(@PathParam("exchangeName") Exchange exchangeName,
-      @PathParam("orderId") String orderId, @QueryParam("symbol") String symbol,
-      @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
+  OrderResponse fetchOrder(@PathParam("exchangeName") Exchange exchangeName, @PathParam("orderId") String orderId,
+      @QueryParam("symbol") String symbol, @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 
   /**
-   * Cancel an open order on the exchange referenced by the {exchangeName} and {orderId}. 
-   *
-   * <br/> *Parameters listed here are common to all exchanges. But any other parameter passed would be forwarded as well into the exchange.*
+   * <p>
+   * Cancel an open order on the exchange referenced by the {exchangeName} and
+   * {orderId}.
+   * </p>
+   * <p>
+   * <br/>
+   * <em>Parameters listed here are common to all exchanges. But any other
+   * parameter passed would be forwarded as well into the exchange.</em>
+   * </p>
+   * 
    */
   @Path("/{exchangeName}/order/{orderId}")
   @DELETE
   @Produces("application/json")
-  OrderResponse cancelOrder(@PathParam("exchangeName") Exchange exchangeName,
-      @PathParam("orderId") String orderId, @QueryParam("symbol") String symbol,
-      @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
+  OrderResponse cancelOrder(@PathParam("exchangeName") Exchange exchangeName, @PathParam("orderId") String orderId,
+      @QueryParam("symbol") String symbol, @QueryParam("exchangeSpecificParams") Object exchangeSpecificParams);
 }

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-nzdax/generated-api/src/main/java/org/example/api/ExchangesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-nzdax/generated-api/src/main/java/org/example/api/ExchangesResource.java
@@ -7,12 +7,15 @@ import java.util.List;
 import org.example.api.beans.Exchange;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/exchanges")
 public interface ExchangesResource {
   /**
+   * <p>
    * List all support exchanges by this server
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-reactive-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-reactive-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -13,12 +13,15 @@ import java.util.concurrent.CompletionStage;
 import org.example.api.beans.Beer;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/beers")
 public interface BeersResource {
   /**
+   * <p>
    * Returns full information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @GET
@@ -26,7 +29,10 @@ public interface BeersResource {
   CompletionStage<Beer> getBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Updates information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @PUT
@@ -34,21 +40,30 @@ public interface BeersResource {
   void updateBeer(@PathParam("beerId") int beerId, Beer data);
 
   /**
+   * <p>
    * Removes a single beer from the data set.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @DELETE
   void deleteBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Returns all of the beers in the database.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   CompletionStage<List<Beer>> listAllBeers();
 
   /**
+   * <p>
    * Adds a single beer to the dataset.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-reactive-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-reactive-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -14,26 +14,35 @@ import org.example.api.beans.Beer;
 import org.example.api.beans.Brewery;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/breweries")
 public interface BreweriesResource {
   /**
+   * <p>
    * Returns a list of all the breweries.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   CompletionStage<List<Brewery>> listAllBreweries();
 
   /**
+   * <p>
    * Adds a single brewery to the data set.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")
   void addBrewery(Brewery data);
 
   /**
+   * <p>
    * Returns full information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @GET
@@ -41,7 +50,10 @@ public interface BreweriesResource {
   CompletionStage<Brewery> getBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Updates information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @PUT
@@ -49,14 +61,20 @@ public interface BreweriesResource {
   void updateBrewery(@PathParam("breweryId") int breweryId, Brewery data);
 
   /**
+   * <p>
    * Removes a single brewery from the data set.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @DELETE
   void deleteBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Returns all of the beers made by the brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @GET
@@ -64,7 +82,10 @@ public interface BreweriesResource {
   CompletionStage<List<Beer>> listBreweryBeers(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @POST

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/AdminResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/AdminResource.java
@@ -15,17 +15,21 @@ import org.example.api.beans.NamedLogConfiguration;
 import org.example.api.beans.Rule;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/v2/admin")
 public interface AdminResource {
   /**
+   * <p>
    * Gets a list of all the currently configured global rules (if any).
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/rules")
   @GET
@@ -33,14 +37,18 @@ public interface AdminResource {
   List<RuleType> listGlobalRules();
 
   /**
+   * <p>
    * Adds a rule to the list of globally configured rules.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * The rule type is unknown (HTTP error `400`)
-   * * The rule already exists (HTTP error `409`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>The rule type is unknown (HTTP error <code>400</code>)</li>
+   * <li>The rule already exists (HTTP error <code>409</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/rules")
   @POST
@@ -48,26 +56,35 @@ public interface AdminResource {
   void createGlobalRule(Rule data);
 
   /**
+   * <p>
    * Deletes all globally configured rules.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/rules")
   @DELETE
   void deleteAllGlobalRules();
 
   /**
+   * <p>
    * Returns information about the named globally configured rule.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Invalid rule name/type (HTTP error `400`)
-   * * No rule with name/type `rule` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Invalid rule name/type (HTTP error <code>400</code>)</li>
+   * <li>No rule with name/type <code>rule</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/rules/{rule}")
   @GET
@@ -75,14 +92,19 @@ public interface AdminResource {
   Rule getGlobalRuleConfig(@PathParam("rule") RuleType rule);
 
   /**
+   * <p>
    * Updates the configuration for a globally configured rule.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Invalid rule name/type (HTTP error `400`)
-   * * No rule with name/type `rule` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Invalid rule name/type (HTTP error <code>400</code>)</li>
+   * <li>No rule with name/type <code>rule</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/rules/{rule}")
   @PUT
@@ -91,24 +113,32 @@ public interface AdminResource {
   Rule updateGlobalRuleConfig(@PathParam("rule") RuleType rule, Rule data);
 
   /**
-   * Deletes a single global rule.  If this is the only rule configured, this is the same
-   * as deleting **all** rules.
-   *
+   * <p>
+   * Deletes a single global rule. If this is the only rule configured, this is
+   * the same as deleting <strong>all</strong> rules.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Invalid rule name/type (HTTP error `400`)
-   * * No rule with name/type `rule` exists (HTTP error `404`)
-   * * Rule cannot be deleted (HTTP error `409`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Invalid rule name/type (HTTP error <code>400</code>)</li>
+   * <li>No rule with name/type <code>rule</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>Rule cannot be deleted (HTTP error <code>409</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/rules/{rule}")
   @DELETE
   void deleteGlobalRule(@PathParam("rule") RuleType rule);
 
   /**
-   * List all of the configured logging levels.  These override the default
-   * logging configuration.
+   * <p>
+   * List all of the configured logging levels. These override the default logging
+   * configuration.
+   * </p>
+   * 
    */
   @Path("/loggers")
   @GET
@@ -116,7 +146,12 @@ public interface AdminResource {
   List<NamedLogConfiguration> listLogConfigurations();
 
   /**
-   * Returns the configured logger configuration for the provided logger name, if no logger configuration is persisted it will return the current default log configuration in the system.
+   * <p>
+   * Returns the configured logger configuration for the provided logger name, if
+   * no logger configuration is persisted it will return the current default log
+   * configuration in the system.
+   * </p>
+   * 
    */
   @Path("/loggers/{logger}")
   @GET
@@ -124,17 +159,23 @@ public interface AdminResource {
   NamedLogConfiguration getLogConfiguration(@PathParam("logger") String logger);
 
   /**
-   * Configures the logger referenced by the provided logger name with the given configuration.
+   * <p>
+   * Configures the logger referenced by the provided logger name with the given
+   * configuration.
+   * </p>
+   * 
    */
   @Path("/loggers/{logger}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  NamedLogConfiguration setLogConfiguration(@PathParam("logger") String logger,
-      LogConfiguration data);
+  NamedLogConfiguration setLogConfiguration(@PathParam("logger") String logger, LogConfiguration data);
 
   /**
+   * <p>
    * Removes the configured logger configuration (if any) for the given logger.
+   * </p>
+   * 
    */
   @Path("/loggers/{logger}")
   @DELETE

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/GroupsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/GroupsResource.java
@@ -28,43 +28,59 @@ import org.example.api.beans.VersionMetaData;
 import org.example.api.beans.VersionSearchResults;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/v2/groups")
 public interface GroupsResource {
   /**
-   * Returns the latest version of the artifact in its raw form.  The `Content-Type` of the
-   * response depends on the artifact type.  In most cases, this is `application/json`, but 
-   * for some types it may be different (for example, `PROTOBUF`).
-   *
+   * <p>
+   * Returns the latest version of the artifact in its raw form. The
+   * <code>Content-Type</code> of the response depends on the artifact type. In
+   * most cases, this is <code>application/json</code>, but for some types it may
+   * be different (for example, <code>PROTOBUF</code>).
+   * </p>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}")
   @GET
   @Produces({"application/json", "application/graphql", "application/x-protobuf", "application/x-protobuffer"})
-  Response getLatestArtifact(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId);
+  Response getLatestArtifact(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId);
 
   /**
-   * Updates an artifact by uploading new content.  The body of the request should
-   * be the raw content of the artifact.  This is typically in JSON format for *most*
-   * of the supported types, but may be in another format for a few (for example, `PROTOBUF`).
-   * The type of the content should be compatible with the artifact's type (it would be
-   * an error to update an `AVRO` artifact with new `OPENAPI` content, for example).
-   *
+   * <p>
+   * Updates an artifact by uploading new content. The body of the request should
+   * be the raw content of the artifact. This is typically in JSON format for
+   * <em>most</em> of the supported types, but may be in another format for a few
+   * (for example, <code>PROTOBUF</code>). The type of the content should be
+   * compatible with the artifact's type (it would be an error to update an
+   * <code>AVRO</code> artifact with new <code>OPENAPI</code> content, for
+   * example).
+   * </p>
+   * <p>
    * The update could fail for a number of reasons including:
-   *
-   * * Provided content (request body) was empty (HTTP error `400`)
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * The new content violates one of the rules configured for the artifact (HTTP error `409`)
-   * * A server error occurred (HTTP error `500`)
-   *
-   * When successful, this creates a new version of the artifact, making it the most recent
-   * (and therefore official) version of the artifact.
+   * </p>
+   * <ul>
+   * <li>Provided content (request body) was empty (HTTP error
+   * <code>400</code>)</li>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>The new content violates one of the rules configured for the artifact
+   * (HTTP error <code>409</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * <p>
+   * When successful, this creates a new version of the artifact, making it the
+   * most recent (and therefore official) version of the artifact.
+   * </p>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}")
   @PUT
@@ -74,25 +90,36 @@ public interface GroupsResource {
       @PathParam("artifactId") String artifactId, InputStream data);
 
   /**
-   * Deletes an artifact completely, resulting in all versions of the artifact also being
-   * deleted.  This may fail for one of the following reasons:
-   *
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * <p>
+   * Deletes an artifact completely, resulting in all versions of the artifact
+   * also being deleted. This may fail for one of the following reasons:
+   * </p>
+   * <ul>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}")
   @DELETE
-  void deleteArtifact(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId);
+  void deleteArtifact(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId);
 
   /**
-   * Gets the metadata for an artifact in the registry.  The returned metadata includes
-   * both generated (read-only) and editable metadata (such as name and description).
-   *
+   * <p>
+   * Gets the metadata for an artifact in the registry. The returned metadata
+   * includes both generated (read-only) and editable metadata (such as name and
+   * description).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/meta")
   @GET
@@ -101,218 +128,303 @@ public interface GroupsResource {
       @PathParam("artifactId") String artifactId);
 
   /**
-   * Updates the editable parts of the artifact's metadata.  Not all metadata fields can
-   * be updated.  For example, `createdOn` and `createdBy` are both read-only properties.
-   *
+   * <p>
+   * Updates the editable parts of the artifact's metadata. Not all metadata
+   * fields can be updated. For example, <code>createdOn</code> and
+   * <code>createdBy</code> are both read-only properties.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/meta")
   @PUT
   @Consumes("*/*")
-  void updateArtifactMetaData(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, EditableMetaData data);
+  void updateArtifactMetaData(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      EditableMetaData data);
 
   /**
-   * Gets the metadata for an artifact that matches the raw content.  Searches the registry
-   * for a version of the given artifact matching the content provided in the body of the
-   * POST.
-   *
+   * <p>
+   * Gets the metadata for an artifact that matches the raw content. Searches the
+   * registry for a version of the given artifact matching the content provided in
+   * the body of the POST.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Provided content (request body) was empty (HTTP error `400`)
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * No artifact version matching the provided content exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Provided content (request body) was empty (HTTP error
+   * <code>400</code>)</li>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No artifact version matching the provided content exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/meta")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
   VersionMetaData getArtifactVersionMetaDataByContent(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @QueryParam("canonical") Boolean canonical,
-      InputStream data);
+      @PathParam("artifactId") String artifactId, @QueryParam("canonical") Boolean canonical, InputStream data);
 
   /**
-   * Returns a list of all rules configured for the artifact.  The set of rules determines
-   * how the content of an artifact can evolve over time.  If no rules are configured for
-   * an artifact, the set of globally configured rules are used.  If no global rules 
-   * are defined, there are no restrictions on content evolution.
-   *
+   * <p>
+   * Returns a list of all rules configured for the artifact. The set of rules
+   * determines how the content of an artifact can evolve over time. If no rules
+   * are configured for an artifact, the set of globally configured rules are
+   * used. If no global rules are defined, there are no restrictions on content
+   * evolution.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/rules")
   @GET
   @Produces("application/json")
-  List<RuleType> listArtifactRules(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId);
+  List<RuleType> listArtifactRules(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId);
 
   /**
-   * Adds a rule to the list of rules that get applied to the artifact when adding new
-   * versions.  All configured rules must pass to successfully add a new artifact version.
-   *
+   * <p>
+   * Adds a rule to the list of rules that get applied to the artifact when adding
+   * new versions. All configured rules must pass to successfully add a new
+   * artifact version.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * Rule (named in the request body) is unknown (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>Rule (named in the request body) is unknown (HTTP error
+   * <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/rules")
   @POST
   @Consumes("application/json")
-  void createArtifactRule(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, Rule data);
+  void createArtifactRule(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId, Rule data);
 
   /**
-   * Deletes all of the rules configured for the artifact.  After this is done, the global
-   * rules apply to the artifact again.
-   *
+   * <p>
+   * Deletes all of the rules configured for the artifact. After this is done, the
+   * global rules apply to the artifact again.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/rules")
   @DELETE
-  void deleteArtifactRules(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId);
+  void deleteArtifactRules(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId);
 
   /**
-   * Returns information about a single rule configured for an artifact.  This is useful
-   * when you want to know what the current configuration settings are for a specific rule.
-   *
+   * <p>
+   * Returns information about a single rule configured for an artifact. This is
+   * useful when you want to know what the current configuration settings are for
+   * a specific rule.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No rule with this name/type is configured for this artifact (HTTP error `404`)
-   * * Invalid rule type (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No rule with this name/type is configured for this artifact (HTTP error
+   * <code>404</code>)</li>
+   * <li>Invalid rule type (HTTP error <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/rules/{rule}")
   @GET
   @Produces("application/json")
-  Rule getArtifactRuleConfig(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("rule") RuleType rule);
+  Rule getArtifactRuleConfig(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("rule") RuleType rule);
 
   /**
-   * Updates the configuration of a single rule for the artifact.  The configuration data
-   * is specific to each rule type, so the configuration of the `COMPATIBILITY` rule 
-   * is in a different format from the configuration of the `VALIDITY` rule.
-   *
+   * <p>
+   * Updates the configuration of a single rule for the artifact. The
+   * configuration data is specific to each rule type, so the configuration of the
+   * <code>COMPATIBILITY</code> rule is in a different format from the
+   * configuration of the <code>VALIDITY</code> rule.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No rule with this name/type is configured for this artifact (HTTP error `404`)
-   * * Invalid rule type (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No rule with this name/type is configured for this artifact (HTTP error
+   * <code>404</code>)</li>
+   * <li>Invalid rule type (HTTP error <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/rules/{rule}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Rule updateArtifactRuleConfig(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("rule") RuleType rule, Rule data);
+  Rule updateArtifactRuleConfig(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("rule") RuleType rule, Rule data);
 
   /**
-   * Deletes a rule from the artifact.  This results in the rule no longer applying for
-   * this artifact.  If this is the only rule configured for the artifact, this is the 
-   * same as deleting **all** rules, and the globally configured rules now apply to
-   * this artifact.
-   *
+   * <p>
+   * Deletes a rule from the artifact. This results in the rule no longer applying
+   * for this artifact. If this is the only rule configured for the artifact, this
+   * is the same as deleting <strong>all</strong> rules, and the globally
+   * configured rules now apply to this artifact.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No rule with this name/type is configured for this artifact (HTTP error `404`)
-   * * Invalid rule type (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No rule with this name/type is configured for this artifact (HTTP error
+   * <code>404</code>)</li>
+   * <li>Invalid rule type (HTTP error <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/rules/{rule}")
   @DELETE
-  void deleteArtifactRule(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("rule") RuleType rule);
+  void deleteArtifactRule(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("rule") RuleType rule);
 
   /**
-   * Updates the state of the artifact.  For example, you can use this to mark the latest
-   * version of an artifact as `DEPRECATED`.  The operation changes the state of the latest 
-   * version of the artifact.  If multiple versions exist, only the most recent is changed.
-   *
+   * <p>
+   * Updates the state of the artifact. For example, you can use this to mark the
+   * latest version of an artifact as <code>DEPRECATED</code>. The operation
+   * changes the state of the latest version of the artifact. If multiple versions
+   * exist, only the most recent is changed.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/state")
   @PUT
   @Consumes("application/json")
-  void updateArtifactState(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, UpdateState data);
+  void updateArtifactState(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      UpdateState data);
 
   /**
-   * Tests whether an update to the artifact's content *would* succeed for the provided content.
-   * Ultimately, this applies any rules configured for the artifact against the given content
-   * to determine whether the rules would pass or fail, but without actually updating the artifact
-   * content.
-   *
-   * The body of the request should be the raw content of the artifact.  This is typically in 
-   * JSON format for *most* of the supported types, but may be in another format for a few 
-   * (for example, `PROTOBUF`).
-   *
+   * <p>
+   * Tests whether an update to the artifact's content <em>would</em> succeed for
+   * the provided content. Ultimately, this applies any rules configured for the
+   * artifact against the given content to determine whether the rules would pass
+   * or fail, but without actually updating the artifact content.
+   * </p>
+   * <p>
+   * The body of the request should be the raw content of the artifact. This is
+   * typically in JSON format for <em>most</em> of the supported types, but may be
+   * in another format for a few (for example, <code>PROTOBUF</code>).
+   * </p>
+   * <p>
    * The update could fail for a number of reasons including:
-   *
-   * * Provided content (request body) was empty (HTTP error `400`)
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * The new content violates one of the rules configured for the artifact (HTTP error `409`)
-   * * The provided artifact type is not recognized (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
-   * When successful, this operation simply returns a *No Content* response.  This response
-   * indicates that the content is valid against the configured content rules for the 
-   * artifact (or the global rules if no artifact rules are enabled).
+   * </p>
+   * <ul>
+   * <li>Provided content (request body) was empty (HTTP error
+   * <code>400</code>)</li>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>The new content violates one of the rules configured for the artifact
+   * (HTTP error <code>409</code>)</li>
+   * <li>The provided artifact type is not recognized (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * <p>
+   * When successful, this operation simply returns a <em>No Content</em>
+   * response. This response indicates that the content is valid against the
+   * configured content rules for the artifact (or the global rules if no artifact
+   * rules are enabled).
+   * </p>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/test")
   @PUT
   @Consumes("*/*")
-  void testUpdateArtifact(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, InputStream data);
+  void testUpdateArtifact(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      InputStream data);
 
   /**
-   * Retrieves a single version of the artifact content.  Both the `artifactId` and the
-   * unique `version` number must be provided.  The `Content-Type` of the response depends 
-   * on the artifact type.  In most cases, this is `application/json`, but for some types 
-   * it may be different (for example, `PROTOBUF`).
-   *
+   * <p>
+   * Retrieves a single version of the artifact content. Both the
+   * <code>artifactId</code> and the unique <code>version</code> number must be
+   * provided. The <code>Content-Type</code> of the response depends on the
+   * artifact type. In most cases, this is <code>application/json</code>, but for
+   * some types it may be different (for example, <code>PROTOBUF</code>).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions/{version}")
   @GET
   @Produces({"application/json", "application/graphql", "application/x-protobuf", "application/x-protobuffer"})
-  Response getArtifactVersion(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("version") String version);
+  Response getArtifactVersion(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("version") String version);
 
   /**
-   * Retrieves the metadata for a single version of the artifact.  The version metadata is 
-   * a subset of the artifact metadata and only includes the metadata that is specific to
-   * the version (for example, this doesn't include `modifiedOn`).
-   *
+   * <p>
+   * Retrieves the metadata for a single version of the artifact. The version
+   * metadata is a subset of the artifact metadata and only includes the metadata
+   * that is specific to the version (for example, this doesn't include
+   * <code>modifiedOn</code>).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
   @GET
@@ -321,66 +433,87 @@ public interface GroupsResource {
       @PathParam("artifactId") String artifactId, @PathParam("version") String version);
 
   /**
-   * Updates the user-editable portion of the artifact version's metadata.  Only some of 
-   * the metadata fields are editable by the user.  For example, `description` is editable, 
-   * but `createdOn` is not.
-   *
+   * <p>
+   * Updates the user-editable portion of the artifact version's metadata. Only
+   * some of the metadata fields are editable by the user. For example,
+   * <code>description</code> is editable, but <code>createdOn</code> is not.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
   @PUT
   @Consumes("application/json")
-  void updateArtifactVersionMetaData(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("version") String version,
-      EditableMetaData data);
+  void updateArtifactVersionMetaData(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("version") String version, EditableMetaData data);
 
   /**
-   * Deletes the user-editable metadata properties of the artifact version.  Any properties
-   * that are not user-editable are preserved.
-   *
+   * <p>
+   * Deletes the user-editable metadata properties of the artifact version. Any
+   * properties that are not user-editable are preserved.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions/{version}/meta")
   @DELETE
-  void deleteArtifactVersionMetaData(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("version") String version);
+  void deleteArtifactVersionMetaData(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("version") String version);
 
   /**
-   * Updates the state of a specific version of an artifact.  For example, you can use 
-   * this operation to disable a specific version.
-   *
+   * <p>
+   * Updates the state of a specific version of an artifact. For example, you can
+   * use this operation to disable a specific version.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions/{version}/state")
   @PUT
   @Consumes("application/json")
-  void updateArtifactVersionState(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId, @PathParam("version") String version,
-      UpdateState data);
+  void updateArtifactVersionState(@PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId,
+      @PathParam("version") String version, UpdateState data);
 
   /**
-   * Returns a list of all versions of the artifact.  The result set is paged.
-   *
+   * <p>
+   * Returns a list of all versions of the artifact. The result set is paged.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions")
   @GET
@@ -390,94 +523,130 @@ public interface GroupsResource {
       @QueryParam("limit") Integer limit);
 
   /**
-   * Creates a new version of the artifact by uploading new content.  The configured rules for
-   * the artifact are applied, and if they all pass, the new content is added as the most recent 
-   * version of the artifact.  If any of the rules fail, an error is returned.
-   *
-   * The body of the request should be the raw content of the new artifact version, and the type
-   * of that content should match the artifact's type (for example if the artifact type is `AVRO`
-   * then the content of the request should be an Apache Avro document).
-   *
+   * <p>
+   * Creates a new version of the artifact by uploading new content. The
+   * configured rules for the artifact are applied, and if they all pass, the new
+   * content is added as the most recent version of the artifact. If any of the
+   * rules fail, an error is returned.
+   * </p>
+   * <p>
+   * The body of the request should be the raw content of the new artifact
+   * version, and the type of that content should match the artifact's type (for
+   * example if the artifact type is <code>AVRO</code> then the content of the
+   * request should be an Apache Avro document).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Provided content (request body) was empty (HTTP error `400`)
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * The new content violates one of the rules configured for the artifact (HTTP error `409`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Provided content (request body) was empty (HTTP error
+   * <code>400</code>)</li>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>The new content violates one of the rules configured for the artifact
+   * (HTTP error <code>409</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts/{artifactId}/versions")
   @POST
   @Produces("application/json")
   @Consumes("*/*")
   CompletionStage<VersionMetaData> createArtifactVersion(@PathParam("groupId") String groupId,
-      @PathParam("artifactId") String artifactId,
-      @HeaderParam("X-Registry-Version") String xRegistryVersion, InputStream data);
+      @PathParam("artifactId") String artifactId, @HeaderParam("X-Registry-Version") String xRegistryVersion,
+      InputStream data);
 
   /**
-   * Returns a list of all artifacts in the group.  This list is paged.
+   * <p>
+   * Returns a list of all artifacts in the group. This list is paged.
+   * </p>
+   * 
    */
   @Path("/{groupId}/artifacts")
   @GET
   @Produces("application/json")
-  ArtifactSearchResults listArtifactsInGroup(@PathParam("groupId") String groupId,
-      @QueryParam("limit") Integer limit, @QueryParam("offset") Integer offset,
-      @QueryParam("order") SortOrder order, @QueryParam("orderby") SortBy orderby);
+  ArtifactSearchResults listArtifactsInGroup(@PathParam("groupId") String groupId, @QueryParam("limit") Integer limit,
+      @QueryParam("offset") Integer offset, @QueryParam("order") SortOrder order,
+      @QueryParam("orderby") SortBy orderby);
 
   /**
-   * Creates a new artifact by posting the artifact content.  The body of the request should
-   * be the raw content of the artifact.  This is typically in JSON format for *most* of the 
-   * supported types, but may be in another format for a few (for example, `PROTOBUF`).
-   *
-   * The registry attempts to figure out what kind of artifact is being added from the
-   * following supported list:
-   *
-   * * Avro (`AVRO`)
-   * * Protobuf (`PROTOBUF`)
-   * * Protobuf File Descriptor (`PROTOBUF_FD`)
-   * * JSON Schema (`JSON`)
-   * * Kafka Connect (`KCONNECT`)
-   * * OpenAPI (`OPENAPI`)
-   * * AsyncAPI (`ASYNCAPI`)
-   * * GraphQL (`GRAPHQL`)
-   * * Web Services Description Language (`WSDL`)
-   * * XML Schema (`XSD`)
-   *
-   * Alternatively, you can specify the artifact type using the `X-Registry-ArtifactType` 
-   * HTTP request header, or include a hint in the request's `Content-Type`.  For example:
-   *
-   * ```
-   * Content-Type: application/json; artifactType=AVRO
-   * ```
-   *
-   * An artifact is created using the content provided in the body of the request.  This
-   * content is created under a unique artifact ID that can be provided in the request
-   * using the `X-Registry-ArtifactId` request header.  If not provided in the request,
-   * the server generates a unique ID for the artifact.  It is typically recommended
-   * that callers provide the ID, because this is typically a meaningful identifier, 
-   * and for most use cases should be supplied by the caller.
-   *
-   * If an artifact with the provided artifact ID already exists, the default behavior
-   * is for the server to reject the content with a 409 error.  However, the caller can
-   * supply the `ifExists` query parameter to alter this default behavior. The `ifExists`
-   * query parameter can have one of the following values:
-   *
-   * * `FAIL` (*default*) - server rejects the content with a 409 error
-   * * `UPDATE` - server updates the existing artifact and returns the new metadata
-   * * `RETURN` - server does not create or add content to the server, but instead 
-   * returns the metadata for the existing artifact
-   * * `RETURN_OR_UPDATE` - server returns an existing **version** that matches the 
-   * provided content if such a version exists, otherwise a new version is created
-   *
+   * <p>
+   * Creates a new artifact by posting the artifact content. The body of the
+   * request should be the raw content of the artifact. This is typically in JSON
+   * format for <em>most</em> of the supported types, but may be in another format
+   * for a few (for example, <code>PROTOBUF</code>).
+   * </p>
+   * <p>
+   * The registry attempts to figure out what kind of artifact is being added from
+   * the following supported list:
+   * </p>
+   * <ul>
+   * <li>Avro (<code>AVRO</code>)</li>
+   * <li>Protobuf (<code>PROTOBUF</code>)</li>
+   * <li>Protobuf File Descriptor (<code>PROTOBUF_FD</code>)</li>
+   * <li>JSON Schema (<code>JSON</code>)</li>
+   * <li>Kafka Connect (<code>KCONNECT</code>)</li>
+   * <li>OpenAPI (<code>OPENAPI</code>)</li>
+   * <li>AsyncAPI (<code>ASYNCAPI</code>)</li>
+   * <li>GraphQL (<code>GRAPHQL</code>)</li>
+   * <li>Web Services Description Language (<code>WSDL</code>)</li>
+   * <li>XML Schema (<code>XSD</code>)</li>
+   * </ul>
+   * <p>
+   * Alternatively, you can specify the artifact type using the
+   * <code>X-Registry-ArtifactType</code> HTTP request header, or include a hint
+   * in the request's <code>Content-Type</code>. For example:
+   * </p>
+   * 
+   * <pre>
+   * <code>Content-Type: application/json; artifactType=AVRO
+  </code>
+   * </pre>
+   * <p>
+   * An artifact is created using the content provided in the body of the request.
+   * This content is created under a unique artifact ID that can be provided in
+   * the request using the <code>X-Registry-ArtifactId</code> request header. If
+   * not provided in the request, the server generates a unique ID for the
+   * artifact. It is typically recommended that callers provide the ID, because
+   * this is typically a meaningful identifier, and for most use cases should be
+   * supplied by the caller.
+   * </p>
+   * <p>
+   * If an artifact with the provided artifact ID already exists, the default
+   * behavior is for the server to reject the content with a 409 error. However,
+   * the caller can supply the <code>ifExists</code> query parameter to alter this
+   * default behavior. The <code>ifExists</code> query parameter can have one of
+   * the following values:
+   * </p>
+   * <ul>
+   * <li><code>FAIL</code> (<em>default</em>) - server rejects the content with a
+   * 409 error</li>
+   * <li><code>UPDATE</code> - server updates the existing artifact and returns
+   * the new metadata</li>
+   * <li><code>RETURN</code> - server does not create or add content to the
+   * server, but instead returns the metadata for the existing artifact</li>
+   * <li><code>RETURN_OR_UPDATE</code> - server returns an existing
+   * <strong>version</strong> that matches the provided content if such a version
+   * exists, otherwise a new version is created</li>
+   * </ul>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * An invalid `ArtifactType` was indicated (HTTP error `400`)
-   * * No `ArtifactType` was indicated and the server could not determine one from the content (HTTP error `400`)
-   * * Provided content (request body) was empty (HTTP error `400`)
-   * * An artifact with the provided ID already exists (HTTP error `409`)
-   * * The content violates one of the configured global rules (HTTP error `409`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>An invalid <code>ArtifactType</code> was indicated (HTTP error
+   * <code>400</code>)</li>
+   * <li>No <code>ArtifactType</code> was indicated and the server could not
+   * determine one from the content (HTTP error <code>400</code>)</li>
+   * <li>Provided content (request body) was empty (HTTP error
+   * <code>400</code>)</li>
+   * <li>An artifact with the provided ID already exists (HTTP error
+   * <code>409</code>)</li>
+   * <li>The content violates one of the configured global rules (HTTP error
+   * <code>409</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{groupId}/artifacts")
   @POST
@@ -486,12 +655,14 @@ public interface GroupsResource {
   CompletionStage<ArtifactMetaData> createArtifact(@PathParam("groupId") String groupId,
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType,
       @HeaderParam("X-Registry-ArtifactId") String xRegistryArtifactId,
-      @HeaderParam("X-Registry-Version") String xRegistryVersion,
-      @QueryParam("ifExists") IfExists ifExists, @QueryParam("canonical") Boolean canonical,
-      InputStream data);
+      @HeaderParam("X-Registry-Version") String xRegistryVersion, @QueryParam("ifExists") IfExists ifExists,
+      @QueryParam("canonical") Boolean canonical, InputStream data);
 
   /**
+   * <p>
    * Deletes all of the artifacts that exist in a given group.
+   * </p>
+   * 
    */
   @Path("/{groupId}/artifacts")
   @DELETE

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/IdsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/IdsResource.java
@@ -8,20 +8,26 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/v2/ids")
 public interface IdsResource {
   /**
-   * Gets the content for an artifact version in the registry using the unique content
-   * identifier for that content.  This content ID may be shared by multiple artifact
-   * versions in the case where the artifact versions are identical.
-   *
+   * <p>
+   * Gets the content for an artifact version in the registry using the unique
+   * content identifier for that content. This content ID may be shared by
+   * multiple artifact versions in the case where the artifact versions are
+   * identical.
+   * </p>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * No content with this `contentId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No content with this <code>contentId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/contentIds/{contentId}/")
   @GET
@@ -29,14 +35,19 @@ public interface IdsResource {
   Response getContentById(@PathParam("contentId") long contentId);
 
   /**
-   * Gets the content for an artifact version in the registry using its globally unique
-   * identifier.
-   *
+   * <p>
+   * Gets the content for an artifact version in the registry using its globally
+   * unique identifier.
+   * </p>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * No artifact version with this `globalId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact version with this <code>globalId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/globalIds/{globalId}")
   @GET
@@ -44,19 +55,24 @@ public interface IdsResource {
   Response getContentByGlobalId(@PathParam("globalId") long globalId);
 
   /**
-   * Gets the content for an artifact version in the registry using the unique content
-   * identifier for that content.  This content ID may be shared by multiple artifact
-   * versions in the case where the artifact versions are identical.
-   *
+   * <p>
+   * Gets the content for an artifact version in the registry using the unique
+   * content identifier for that content. This content ID may be shared by
+   * multiple artifact versions in the case where the artifact versions are
+   * identical.
+   * </p>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * No content with this `contentId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No content with this <code>contentId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/contentHashes/{contentHash}/")
   @GET
   @Produces("*/*")
-  Response getContentByHash(@PathParam("contentHash") long contentHash,
-      @QueryParam("canonical") Boolean canonical);
+  Response getContentByHash(@PathParam("contentHash") long contentHash, @QueryParam("canonical") Boolean canonical);
 }

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/SearchResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-registry-api-v2/generated-api/src/main/java/org/example/api/SearchResource.java
@@ -13,34 +13,37 @@ import org.example.api.beans.SortBy;
 import org.example.api.beans.SortOrder;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/v2/search")
 public interface SearchResource {
   /**
-   * Returns a paginated list of all artifacts that match the provided filter criteria.
-   *
+   * <p>
+   * Returns a paginated list of all artifacts that match the provided filter
+   * criteria.
+   * </p>
+   * 
    */
   @Path("/artifacts")
   @GET
   @Produces("application/json")
-  ArtifactSearchResults searchArtifacts(@QueryParam("name") String name,
-      @QueryParam("offset") Integer offset, @QueryParam("limit") Integer limit,
-      @QueryParam("order") SortOrder order, @QueryParam("orderby") SortBy orderby,
+  ArtifactSearchResults searchArtifacts(@QueryParam("name") String name, @QueryParam("offset") Integer offset,
+      @QueryParam("limit") Integer limit, @QueryParam("order") SortOrder order, @QueryParam("orderby") SortBy orderby,
       @QueryParam("labels") List<String> labels, @QueryParam("properties") List<String> properties,
-      @QueryParam("description") String description,
-      @QueryParam("artifactgroup") String artifactgroup);
+      @QueryParam("description") String description, @QueryParam("artifactgroup") String artifactgroup);
 
   /**
-   * Returns a paginated list of all artifacts with at least one version that matches the
-   * posted content.
-   *
+   * <p>
+   * Returns a paginated list of all artifacts with at least one version that
+   * matches the posted content.
+   * </p>
+   * 
    */
   @Path("/artifacts")
   @POST
   @Produces("application/json")
   @Consumes("*/*")
   ArtifactSearchResults searchArtifactsByContent(@QueryParam("offset") Integer offset,
-      @QueryParam("limit") Integer limit, @QueryParam("order") SortOrder order,
-      @QueryParam("orderby") SortBy orderby, InputStream data);
+      @QueryParam("limit") Integer limit, @QueryParam("order") SortOrder order, @QueryParam("orderby") SortBy orderby,
+      InputStream data);
 }

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-registryApi-full/generated-api/src/main/java/org/example/api/ArtifactsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-registryApi-full/generated-api/src/main/java/org/example/api/ArtifactsResource.java
@@ -21,37 +21,48 @@ import org.example.api.beans.Rule;
 import org.example.api.beans.VersionMetaData;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/artifacts")
 public interface ArtifactsResource {
   /**
-   * Creates a new artifact by POSTing the artifact content.  The body of the request should
-   * be the raw content of the artifact.  This will typically be in JSON format for *most*
-   * of the supported types, but may be in another format for a few (e.g. Protobuff).
-   *
-   * The registry will attempt to figure out what kind of artifact is being added from the
-   * following supported list:
-   *
-   * * Avro (AVRO)
-   * * Protobuff (PROTOBUFF)
-   * * JSON Schema (JSON)
-   * * OpenAPI (OPENAPI)
-   * * AsyncAPI (ASYNCAPI)
-   *
-   * Alternatively, the artifact type can be indicated by either explicitly specifying the 
-   * type via the `X-Registry-ArtifactType` HTTP Request Header or by including a hint in the 
-   * Request's `Content-Type`.  For example:
-   *
-   * ```
-   * Content-Type: application/json; artifactType=AVRO
-   * ```
-   *
+   * <p>
+   * Creates a new artifact by POSTing the artifact content. The body of the
+   * request should be the raw content of the artifact. This will typically be in
+   * JSON format for <em>most</em> of the supported types, but may be in another
+   * format for a few (e.g. Protobuff).
+   * </p>
+   * <p>
+   * The registry will attempt to figure out what kind of artifact is being added
+   * from the following supported list:
+   * </p>
+   * <ul>
+   * <li>Avro (AVRO)</li>
+   * <li>Protobuff (PROTOBUFF)</li>
+   * <li>JSON Schema (JSON)</li>
+   * <li>OpenAPI (OPENAPI)</li>
+   * <li>AsyncAPI (ASYNCAPI)</li>
+   * </ul>
+   * <p>
+   * Alternatively, the artifact type can be indicated by either explicitly
+   * specifying the type via the <code>X-Registry-ArtifactType</code> HTTP Request
+   * Header or by including a hint in the Request's <code>Content-Type</code>. For
+   * example:
+   * </p>
+   * 
+   * <pre>
+   * <code>Content-Type: application/json; artifactType=AVRO
+  </code>
+   * </pre>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * An invalid `ArtifactType` was indicated (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>An invalid <code>ArtifactType</code> was indicated (HTTP error
+   * <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @POST
   @Produces("application/json")
@@ -61,15 +72,21 @@ public interface ArtifactsResource {
       @HeaderParam("X-Registry-ArtifactId") String xRegistryArtifactId, InputStream data);
 
   /**
-   * Returns the latest version of the artifact in its raw form.  The `Content-Type` of the
-   * response will depend on what type of artifact it is.  In most cases this will be
-   * `application/json` but for some types it may be different (e.g. *protobuff*).
-   *
+   * <p>
+   * Returns the latest version of the artifact in its raw form. The
+   * <code>Content-Type</code> of the response will depend on what type of
+   * artifact it is. In most cases this will be <code>application/json</code> but
+   * for some types it may be different (e.g. <em>protobuff</em>).
+   * </p>
+   * <p>
    * This operation may fail for one of the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}")
   @GET
@@ -77,36 +94,51 @@ public interface ArtifactsResource {
   Response getLatestArtifact(@PathParam("artifactId") String artifactId);
 
   /**
-   * Updates an artifact by uploading new content.  The body of the request should
-   * be the raw content of the artifact.  This will typically be in JSON format for *most*
-   * of the supported types, but may be in another format for a few (e.g. Protobuff).
-   *
-   * The registry will attempt to figure out what kind of artifact is being added from the
-   * following supported list:
-   *
-   * * Avro (AVRO)
-   * * Protobuff (PROTOBUFF)
-   * * JSON Schema (JSON)
-   * * OpenAPI (OPENAPI)
-   * * AsyncAPI (ASYNCAPI)
-   *
-   * Alternatively, the artifact type can be indicated by either explicitly specifying the 
-   * type via the `X-Registry-ArtifactType` HTTP Request Header or by including a hint in the 
-   * Request's `Content-Type`.  For example:
-   *
-   * ```
-   * Content-Type: application/json; artifactType=AVRO
-   * ```
-   *
+   * <p>
+   * Updates an artifact by uploading new content. The body of the request should
+   * be the raw content of the artifact. This will typically be in JSON format for
+   * <em>most</em> of the supported types, but may be in another format for a few
+   * (e.g. Protobuff).
+   * </p>
+   * <p>
+   * The registry will attempt to figure out what kind of artifact is being added
+   * from the following supported list:
+   * </p>
+   * <ul>
+   * <li>Avro (AVRO)</li>
+   * <li>Protobuff (PROTOBUFF)</li>
+   * <li>JSON Schema (JSON)</li>
+   * <li>OpenAPI (OPENAPI)</li>
+   * <li>AsyncAPI (ASYNCAPI)</li>
+   * </ul>
+   * <p>
+   * Alternatively, the artifact type can be indicated by either explicitly
+   * specifying the type via the <code>X-Registry-ArtifactType</code> HTTP Request
+   * Header or by including a hint in the Request's <code>Content-Type</code>. For
+   * example:
+   * </p>
+   * 
+   * <pre>
+   * <code>Content-Type: application/json; artifactType=AVRO
+  </code>
+   * </pre>
+   * <p>
    * The update could fail for a number of reasons including:
-   *
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * The new content violates one of the rules configured for the artifact (HTTP error `400`)
-   * * The provided Artifact Type is not recognized (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
-   * When successful, this creates a new version of the artifact, making it the most recent
-   * (and therefore official) version of the artifact.
+   * </p>
+   * <ul>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>The new content violates one of the rules configured for the artifact
+   * (HTTP error <code>400</code>)</li>
+   * <li>The provided Artifact Type is not recognized (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * <p>
+   * When successful, this creates a new version of the artifact, making it the
+   * most recent (and therefore official) version of the artifact.
+   * </p>
+   * 
    */
   @Path("/{artifactId}")
   @PUT
@@ -116,24 +148,36 @@ public interface ArtifactsResource {
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, InputStream data);
 
   /**
-   * Deletes an artifact completely, resulting in all versions of the artifact also being
-   * deleted.  This may fail for one of the following reasons:
-   *
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * <p>
+   * Deletes an artifact completely, resulting in all versions of the artifact
+   * also being deleted. This may fail for one of the following reasons:
+   * </p>
+   * <ul>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}")
   @DELETE
   void deleteArtifact(@PathParam("artifactId") String artifactId);
 
   /**
-   * Gets the meta-data for an artifact in the registry.  The returned meta-data will include
-   * both generated (read-only) and editable meta-data (such as name and description).
-   *
+   * <p>
+   * Gets the meta-data for an artifact in the registry. The returned meta-data
+   * will include both generated (read-only) and editable meta-data (such as name
+   * and description).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/meta")
   @GET
@@ -141,13 +185,20 @@ public interface ArtifactsResource {
   ArtifactMetaData getArtifactMetaData(@PathParam("artifactId") String artifactId);
 
   /**
-   * Updates the editable parts of the artifact's meta-data.  Not all meta-data fields can
-   * be updated.  For example `createdOn` and `createdBy` are both read-only properties.
-   *
+   * <p>
+   * Updates the editable parts of the artifact's meta-data. Not all meta-data
+   * fields can be updated. For example <code>createdOn</code> and
+   * <code>createdBy</code> are both read-only properties.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with the `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with the <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/meta")
   @PUT
@@ -155,68 +206,92 @@ public interface ArtifactsResource {
   void updateArtifactMetaData(@PathParam("artifactId") String artifactId, EditableMetaData data);
 
   /**
-   * Returns information about a single rule configured for an artifact.  This is useful
-   * when you want to know what the current configuration settings are for a specific rule.
-   *
+   * <p>
+   * Returns information about a single rule configured for an artifact. This is
+   * useful when you want to know what the current configuration settings are for
+   * a specific rule.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No rule with this name/type is configured for this artifact (HTTP error `404`)
-   * * Invalid rule type (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No rule with this name/type is configured for this artifact (HTTP error
+   * <code>404</code>)</li>
+   * <li>Invalid rule type (HTTP error <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/rules/{rule}")
   @GET
   @Produces("application/json")
-  Rule getArtifactRuleConfig(@PathParam("rule") String rule,
-      @PathParam("artifactId") String artifactId);
+  Rule getArtifactRuleConfig(@PathParam("rule") String rule, @PathParam("artifactId") String artifactId);
 
   /**
-   * Updates the configuration of a single rule for the artifact.  The configuration data
-   * is specific to each rule type, so the configuration of the **Compatibility** rule 
-   * will be of a different format than the configuration of the **Validation** rule.
-   *
+   * <p>
+   * Updates the configuration of a single rule for the artifact. The
+   * configuration data is specific to each rule type, so the configuration of the
+   * <strong>Compatibility</strong> rule will be of a different format than the
+   * configuration of the <strong>Validation</strong> rule.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No rule with this name/type is configured for this artifact (HTTP error `404`)
-   * * Invalid rule type (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No rule with this name/type is configured for this artifact (HTTP error
+   * <code>404</code>)</li>
+   * <li>Invalid rule type (HTTP error <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/rules/{rule}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Rule updateArtifactRuleConfig(@PathParam("rule") String rule,
-      @PathParam("artifactId") String artifactId, Rule data);
+  Rule updateArtifactRuleConfig(@PathParam("rule") String rule, @PathParam("artifactId") String artifactId, Rule data);
 
   /**
-   * Deletes a rule from the artifact.  This results in the rule no longer applying for
-   * this artifact.  If this is the only rule configured for the artifact, then this is
-   * the same as deleting **all** rules:  the globally configured rules will now apply to
-   * this artifact.
-   *
+   * <p>
+   * Deletes a rule from the artifact. This results in the rule no longer applying
+   * for this artifact. If this is the only rule configured for the artifact, then
+   * this is the same as deleting <strong>all</strong> rules: the globally
+   * configured rules will now apply to this artifact.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No rule with this name/type is configured for this artifact (HTTP error `404`)
-   * * Invalid rule type (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No rule with this name/type is configured for this artifact (HTTP error
+   * <code>404</code>)</li>
+   * <li>Invalid rule type (HTTP error <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/rules/{rule}")
   @DELETE
-  void deleteArtifactRule(@PathParam("rule") String rule,
-      @PathParam("artifactId") String artifactId);
+  void deleteArtifactRule(@PathParam("rule") String rule, @PathParam("artifactId") String artifactId);
 
   /**
+   * <p>
    * Returns a list of all version numbers for the artifact.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions")
   @GET
@@ -224,39 +299,50 @@ public interface ArtifactsResource {
   List<Long> listArtifactVersions(@PathParam("artifactId") String artifactId);
 
   /**
-   * Creates a new version of the artifact by uploading new content.  The configured rules for
-   * the artifact will be applied, and if they all pass then the new content will be added
-   * as the most recent version of the artifact.  If any of the rules fail then an error 
-   * will be returned.
-   *
-   * The body of the request should be the raw content of the new artifact version.  This 
-   * will typically be in JSON format for *most* of the supported types, but may be in another 
-   * format for a few (e.g. Protobuff).
-   *
-   * The registry will attempt to figure out what kind of artifact is being added from the
-   * following supported list:
-   *
-   * * Avro (AVRO)
-   * * Protobuff (PROTOBUFF)
-   * * JSON Schema (JSON)
-   * * OpenAPI (OPENAPI)
-   * * AsyncAPI (ASYNCAPI)
-   *
-   * Alternatively, the artifact type can be indicated by either explicitly specifying the 
-   * type via the `X-Registry-ArtifactType` HTTP Request Header or by including a hint in the 
-   * Request's `Content-Type`.
-   *
+   * <p>
+   * Creates a new version of the artifact by uploading new content. The
+   * configured rules for the artifact will be applied, and if they all pass then
+   * the new content will be added as the most recent version of the artifact. If
+   * any of the rules fail then an error will be returned.
+   * </p>
+   * <p>
+   * The body of the request should be the raw content of the new artifact
+   * version. This will typically be in JSON format for <em>most</em> of the
+   * supported types, but may be in another format for a few (e.g. Protobuff).
+   * </p>
+   * <p>
+   * The registry will attempt to figure out what kind of artifact is being added
+   * from the following supported list:
+   * </p>
+   * <ul>
+   * <li>Avro (AVRO)</li>
+   * <li>Protobuff (PROTOBUFF)</li>
+   * <li>JSON Schema (JSON)</li>
+   * <li>OpenAPI (OPENAPI)</li>
+   * <li>AsyncAPI (ASYNCAPI)</li>
+   * </ul>
+   * <p>
+   * Alternatively, the artifact type can be indicated by either explicitly
+   * specifying the type via the <code>X-Registry-ArtifactType</code> HTTP Request
+   * Header or by including a hint in the Request's <code>Content-Type</code>.
+   * </p>
+   * <p>
    * For example:
-   *
-   * ```
-   * Content-Type: application/json; artifactType=AVRO
-   * ```
-   *
+   * </p>
+   * 
+   * <pre>
+   * <code>Content-Type: application/json; artifactType=AVRO
+  </code>
+   * </pre>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions")
   @POST
@@ -266,52 +352,72 @@ public interface ArtifactsResource {
       @HeaderParam("X-Registry-ArtifactType") ArtifactType xRegistryArtifactType, InputStream data);
 
   /**
-   * Retrieves a single version of the artifact content.  Both the `artifactId` and the
-   * unique `version` number must be provided.  The `Content-Type` of the
-   * response will depend on what type of artifact it is.  In most cases this will be
-   * `application/json` but for some types it may be different (e.g. *protobuff*).
-   *
+   * <p>
+   * Retrieves a single version of the artifact content. Both the
+   * <code>artifactId</code> and the unique <code>version</code> number must be
+   * provided. The <code>Content-Type</code> of the response will depend on what
+   * type of artifact it is. In most cases this will be
+   * <code>application/json</code> but for some types it may be different (e.g.
+   * <em>protobuff</em>).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions/{version}")
   @GET
   @Produces({"application/json", "application/x-yaml"})
-  Response getArtifactVersion(@PathParam("version") Integer version,
-      @PathParam("artifactId") String artifactId);
+  Response getArtifactVersion(@PathParam("version") Integer version, @PathParam("artifactId") String artifactId);
 
   /**
-   * Deletes a single version of the artifact.  Both the `artifactId` and the unique `version`
-   * are needed.  If this is the only version of the artifact, then this operation is the same
-   * as deleting the entire artifact.
-   *
+   * <p>
+   * Deletes a single version of the artifact. Both the <code>artifactId</code>
+   * and the unique <code>version</code> are needed. If this is the only version
+   * of the artifact, then this operation is the same as deleting the entire
+   * artifact.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions/{version}")
   @DELETE
-  void deleteArtifactVersion(@PathParam("version") Integer version,
-      @PathParam("artifactId") String artifactId);
+  void deleteArtifactVersion(@PathParam("version") Integer version, @PathParam("artifactId") String artifactId);
 
   /**
-   * Retrieves the meta-data for a single version of the artifact.  The version meta-data
-   * is a subset of the artifact meta-data - it is only the meta-data that is specific to
-   * the version (and so doesn't include e.g. `modifiedOn`).
-   *
+   * <p>
+   * Retrieves the meta-data for a single version of the artifact. The version
+   * meta-data is a subset of the artifact meta-data - it is only the meta-data
+   * that is specific to the version (and so doesn't include e.g.
+   * <code>modifiedOn</code>).
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions/{version}/meta")
   @GET
@@ -320,49 +426,67 @@ public interface ArtifactsResource {
       @PathParam("artifactId") String artifactId);
 
   /**
-   * Updates the user-editable portion of the artifact version's meta-data.  Only some of 
-   * the meta-data fields are editable by the user.  For example the `description` is editable
-   * but the `createdOn` is not.
-   *
+   * <p>
+   * Updates the user-editable portion of the artifact version's meta-data. Only
+   * some of the meta-data fields are editable by the user. For example the
+   * <code>description</code> is editable but the <code>createdOn</code> is not.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions/{version}/meta")
   @PUT
   @Consumes("application/json")
-  void updateArtifactVersionMetaData(@PathParam("version") Integer version,
-      @PathParam("artifactId") String artifactId, EditableMetaData data);
+  void updateArtifactVersionMetaData(@PathParam("version") Integer version, @PathParam("artifactId") String artifactId,
+      EditableMetaData data);
 
   /**
-   * Deletes the user-editable meta-data properties of the artifact version.  Any properties
-   * that are not user-editable will be preserved.
-   *
+   * <p>
+   * Deletes the user-editable meta-data properties of the artifact version. Any
+   * properties that are not user-editable will be preserved.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * No version with this `version` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>No version with this <code>version</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/versions/{version}/meta")
   @DELETE
-  void deleteArtifactVersionMetaData(@PathParam("version") Integer version,
-      @PathParam("artifactId") String artifactId);
+  void deleteArtifactVersionMetaData(@PathParam("version") Integer version, @PathParam("artifactId") String artifactId);
 
   /**
-   * Returns a list of all rules configured for the artifact.  The set of rules determines
-   * how the content of an artifact can evolve over time.  If no rules are configured for
-   * an artifact, then the set of globally configured rules will be used.  If no global
-   * rules are defined then there are no restrictions on content evolution.
-   *
+   * <p>
+   * Returns a list of all rules configured for the artifact. The set of rules
+   * determines how the content of an artifact can evolve over time. If no rules
+   * are configured for an artifact, then the set of globally configured rules
+   * will be used. If no global rules are defined then there are no restrictions
+   * on content evolution.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/rules")
   @GET
@@ -370,15 +494,22 @@ public interface ArtifactsResource {
   List<RuleType> listArtifactRules(@PathParam("artifactId") String artifactId);
 
   /**
-   * Adds a rule to the list of rules that get applied to the artifact when adding new
-   * versions.  All configured rules must pass in order to successfully add a new artifact
-   * version.
-   *
+   * <p>
+   * Adds a rule to the list of rules that get applied to the artifact when adding
+   * new versions. All configured rules must pass in order to successfully add a
+   * new artifact version.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * Rule (named in the request body) is unknown (HTTP error `400`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>Rule (named in the request body) is unknown (HTTP error
+   * <code>400</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/rules")
   @POST
@@ -386,13 +517,19 @@ public interface ArtifactsResource {
   void createArtifactRule(@PathParam("artifactId") String artifactId, Rule data);
 
   /**
-   * Deletes all of the rules configured for the artifact.  After this is done, the global
-   * rules will once again apply to the artifact.
-   *
+   * <p>
+   * Deletes all of the rules configured for the artifact. After this is done, the
+   * global rules will once again apply to the artifact.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * No artifact with this `artifactId` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
+   * </p>
+   * <ul>
+   * <li>No artifact with this <code>artifactId</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{artifactId}/rules")
   @DELETE

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-registryApi-full/generated-api/src/main/java/org/example/api/RulesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-registryApi-full/generated-api/src/main/java/org/example/api/RulesResource.java
@@ -13,19 +13,24 @@ import java.util.List;
 import org.example.api.beans.Rule;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/rules")
 public interface RulesResource {
   /**
+   * <p>
    * Returns information about the named globally configured rule.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Invalid rule name/type (HTTP error `400`)
-   * * No rule with name/type `rule` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Invalid rule name/type (HTTP error <code>400</code>)</li>
+   * <li>No rule with name/type <code>rule</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{rule}")
   @GET
@@ -33,14 +38,19 @@ public interface RulesResource {
   Rule getGlobalRuleConfig(@PathParam("rule") String rule);
 
   /**
+   * <p>
    * Updates the configuration for a globally configured rule.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Invalid rule name/type (HTTP error `400`)
-   * * No rule with name/type `rule` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Invalid rule name/type (HTTP error <code>400</code>)</li>
+   * <li>No rule with name/type <code>rule</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{rule}")
   @PUT
@@ -49,53 +59,70 @@ public interface RulesResource {
   Rule updateGlobalRuleConfig(@PathParam("rule") String rule, Rule data);
 
   /**
-   * Deletes a single global rule.  If this is the only rule configured, this is the same
-   * as deleting **all** rules.
-   *
+   * <p>
+   * Deletes a single global rule. If this is the only rule configured, this is
+   * the same as deleting <strong>all</strong> rules.
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * Invalid rule name/type (HTTP error `400`)
-   * * No rule with name/type `rule` exists (HTTP error `404`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>Invalid rule name/type (HTTP error <code>400</code>)</li>
+   * <li>No rule with name/type <code>rule</code> exists (HTTP error
+   * <code>404</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @Path("/{rule}")
   @DELETE
   void deleteGlobalRule(@PathParam("rule") String rule);
 
   /**
+   * <p>
    * Gets a list of all the currently configured global rules (if any).
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @GET
   @Produces("application/json")
   List<RuleType> listGlobalRules();
 
   /**
+   * <p>
    * Adds a rule to the list of globally configured rules.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * The rule type is unknown (HTTP error `400`)
-   * * The rule already exists (HTTP error `409`)
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>The rule type is unknown (HTTP error <code>400</code>)</li>
+   * <li>The rule already exists (HTTP error <code>409</code>)</li>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @POST
   @Consumes("application/json")
   void createGlobalRule(Rule data);
 
   /**
+   * <p>
    * Deletes all globally configured rules.
-   *
+   * </p>
+   * <p>
    * This operation can fail for the following reasons:
-   *
-   * * A server error occurred (HTTP error `500`)
-   *
+   * </p>
+   * <ul>
+   * <li>A server error occurred (HTTP error <code>500</code>)</li>
+   * </ul>
+   * 
    */
   @DELETE
   void deleteAllGlobalRules();

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-simple-type/generated-api/src/main/java/org/example/api/WidgetsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-simple-type/generated-api/src/main/java/org/example/api/WidgetsResource.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/widgets")
 public interface WidgetsResource {

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -12,12 +12,15 @@ import java.util.List;
 import org.example.api.beans.Beer;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/beers")
 public interface BeersResource {
   /**
+   * <p>
    * Returns full information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @GET
@@ -25,7 +28,10 @@ public interface BeersResource {
   Beer getBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Updates information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @PUT
@@ -33,21 +39,30 @@ public interface BeersResource {
   void updateBeer(@PathParam("beerId") int beerId, Beer data);
 
   /**
+   * <p>
    * Removes a single beer from the data set.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @DELETE
   void deleteBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Returns all of the beers in the database.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Beer> listAllBeers();
 
   /**
+   * <p>
    * Adds a single beer to the dataset.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -13,26 +13,35 @@ import org.example.api.beans.Beer;
 import org.example.api.beans.Brewery;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/breweries")
 public interface BreweriesResource {
   /**
+   * <p>
    * Returns a list of all the breweries.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Brewery> listAllBreweries();
 
   /**
+   * <p>
    * Adds a single brewery to the data set.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")
   void addBrewery(Brewery data);
 
   /**
+   * <p>
    * Returns full information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @GET
@@ -40,7 +49,10 @@ public interface BreweriesResource {
   Brewery getBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Updates information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @PUT
@@ -48,14 +60,20 @@ public interface BreweriesResource {
   void updateBrewery(@PathParam("breweryId") int breweryId, Brewery data);
 
   /**
+   * <p>
    * Removes a single brewery from the data set.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @DELETE
   void deleteBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Returns all of the beers made by the brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @GET
@@ -63,7 +81,10 @@ public interface BreweriesResource {
   List<Beer> listBreweryBeers(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @POST

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/AppResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/AppResource.java
@@ -13,62 +13,124 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/app")
 public interface AppResource {
   /**
-   * **Note:** Suspending a GitHub App installation is currently in beta and subject to change. Before you can suspend a GitHub App, the app owner must enable suspending installations for the app by opting-in to the beta. For more information, see "[Suspending a GitHub App installation](https://developer.github.com/apps/managing-github-apps/suspending-a-github-app-installation/)."
-   *
-   * Suspends a GitHub App on a user, organization, or business account, which blocks the app from accessing the account's resources. When a GitHub App is suspended, the app's access to the GitHub API or webhook events is blocked for that account.
-   *
-   * To suspend a GitHub App, you must be an account owner or have admin permissions in the repository or organization where the app is installed.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * <strong>Note:</strong> Suspending a GitHub App installation is currently in
+   * beta and subject to change. Before you can suspend a GitHub App, the app
+   * owner must enable suspending installations for the app by opting-in to the
+   * beta. For more information, see &quot;<a href=
+   * "https://developer.github.com/apps/managing-github-apps/suspending-a-github-app-installation/">Suspending
+   * a GitHub App installation</a>.&quot;
+   * </p>
+   * <p>
+   * Suspends a GitHub App on a user, organization, or business account, which
+   * blocks the app from accessing the account's resources. When a GitHub App is
+   * suspended, the app's access to the GitHub API or webhook events is blocked
+   * for that account.
+   * </p>
+   * <p>
+   * To suspend a GitHub App, you must be an account owner or have admin
+   * permissions in the repository or organization where the app is installed.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}/suspended")
   @PUT
   void apps_suspend_installation(@PathParam("installation_id") Integer installationId);
 
   /**
-   * **Note:** Suspending a GitHub App installation is currently in beta and subject to change. Before you can suspend a GitHub App, the app owner must enable suspending installations for the app by opting-in to the beta. For more information, see "[Suspending a GitHub App installation](https://developer.github.com/apps/managing-github-apps/suspending-a-github-app-installation/)."
-   *
+   * <p>
+   * <strong>Note:</strong> Suspending a GitHub App installation is currently in
+   * beta and subject to change. Before you can suspend a GitHub App, the app
+   * owner must enable suspending installations for the app by opting-in to the
+   * beta. For more information, see &quot;<a href=
+   * "https://developer.github.com/apps/managing-github-apps/suspending-a-github-app-installation/">Suspending
+   * a GitHub App installation</a>.&quot;
+   * </p>
+   * <p>
    * Removes a GitHub App installation suspension.
-   *
-   * To unsuspend a GitHub App, you must be an account owner or have admin permissions in the repository or organization where the app is installed and suspended.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * </p>
+   * <p>
+   * To unsuspend a GitHub App, you must be an account owner or have admin
+   * permissions in the repository or organization where the app is installed and
+   * suspended.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}/suspended")
   @DELETE
   void apps_unsuspend_installation(@PathParam("installation_id") Integer installationId);
 
   /**
-   * Creates an installation access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token. By default the installation token has access to all repositories that the installation can access. To restrict the access to specific repositories, you can provide the `repository_ids` when creating the token. When you omit `repository_ids`, the response does not contain the `repositories` key.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Creates an installation access token that enables a GitHub App to make
+   * authenticated API requests for the app's installation on an organization or
+   * individual account. Installation tokens expire one hour from the time you
+   * create them. Using an expired token produces a status code of
+   * <code>401 - Unauthorized</code>, and requires creating a new installation
+   * token. By default the installation token has access to all repositories that
+   * the installation can access. To restrict the access to specific repositories,
+   * you can provide the <code>repository_ids</code> when creating the token. When
+   * you omit <code>repository_ids</code>, the response does not contain the
+   * <code>repositories</code> key.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}/access_tokens")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response apps_create_installation_access_token(
-      @PathParam("installation_id") Integer installationId, InputStream data);
+  Response apps_create_installation_access_token(@PathParam("installation_id") Integer installationId,
+      InputStream data);
 
   /**
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
-   *
-   * The permissions the installation has are included under the `permissions` key.
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * <p>
+   * The permissions the installation has are included under the
+   * <code>permissions</code> key.
+   * </p>
+   * 
    */
   @Path("/installations")
   @GET
   @Produces("application/json")
-  Response apps_list_installations(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page, @QueryParam("since") String since,
-      @QueryParam("outdated") String outdated);
+  Response apps_list_installations(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page,
+      @QueryParam("since") String since, @QueryParam("outdated") String outdated);
 
   /**
-   * Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.
+   * <p>
+   * Use this endpoint to complete the handshake necessary when implementing the
+   * <a href=
+   * "https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/">GitHub
+   * App Manifest flow</a>. When you create a GitHub App with the manifest flow,
+   * you receive a temporary <code>code</code> used to retrieve the GitHub App's
+   * <code>id</code>, <code>pem</code> (private key), and
+   * <code>webhook_secret</code>.
+   * </p>
+   * 
    */
   @Path("-manifests/{code}/conversions")
   @POST
@@ -76,18 +138,38 @@ public interface AppResource {
   Response apps_create_from_manifest(@PathParam("code") String code);
 
   /**
-   * Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the "[List installations for the authenticated app](https://developer.github.com/v3/apps/#list-installations-for-the-authenticated-app)" endpoint.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Returns the GitHub App associated with the authentication credentials used.
+   * To see how many app installations are associated with this GitHub App, see
+   * the <code>installations_count</code> in the response. For more details about
+   * your app's installations, see the &quot;<a href=
+   * "https://developer.github.com/v3/apps/#list-installations-for-the-authenticated-app">List
+   * installations for the authenticated app</a>&quot; endpoint.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   Response apps_get_authenticated();
 
   /**
-   * Enables an authenticated GitHub App to find an installation's information using the installation id. The installation's account type (`target_type`) will be either an organization or a user account, depending which account the repository belongs to.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Enables an authenticated GitHub App to find an installation's information
+   * using the installation id. The installation's account type
+   * (<code>target_type</code>) will be either an organization or a user account,
+   * depending which account the repository belongs to.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}")
   @GET
@@ -95,9 +177,19 @@ public interface AppResource {
   Response apps_get_installation(@PathParam("installation_id") Integer installationId);
 
   /**
-   * Uninstalls a GitHub App on a user, organization, or business account. If you prefer to temporarily suspend an app's access to your account's resources, then we recommend the "[Suspend an app installation](https://developer.github.com/v3/apps/#suspend-an-app-installation)" endpoint.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Uninstalls a GitHub App on a user, organization, or business account. If you
+   * prefer to temporarily suspend an app's access to your account's resources,
+   * then we recommend the &quot;<a href=
+   * "https://developer.github.com/v3/apps/#suspend-an-app-installation">Suspend
+   * an app installation</a>&quot; endpoint.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}")
   @DELETE

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ApplicationsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ApplicationsResource.java
@@ -13,23 +13,63 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/applications")
 public interface ApplicationsResource {
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
-   *
-   * You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `["repo", "user"]`.
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * You can use this API to list the set of OAuth applications that have been
+   * granted access to your account. Unlike the <a href=
+   * "https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations">list
+   * your authorizations</a> API, this API does not manage individual tokens. This
+   * API will return one entry for each OAuth application that has been granted
+   * access to your account, regardless of the number of tokens an application has
+   * generated for your user. The list of OAuth applications returned matches what
+   * is shown on <a href="https://github.com/settings/applications#authorized">the
+   * application authorizations settings screen within GitHub</a>. The
+   * <code>scopes</code> returned are the union of scopes authorized for the
+   * application. For example, if an application has one token with
+   * <code>repo</code> scope and another token with <code>user</code> scope, the
+   * grant will return <code>[&quot;repo&quot;, &quot;user&quot;]</code>.
+   * </p>
+   * 
    */
   @Path("/grants")
   @GET
   @Produces("application/json")
-  Response oauth_authorizations_list_grants(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response oauth_authorizations_list_grants(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * 
    */
   @Path("/grants/{grant_id}")
   @GET
@@ -37,16 +77,45 @@ public interface ApplicationsResource {
   Response oauth_authorizations_get_grant(@PathParam("grant_id") Integer grantId);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
-   *
-   * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for your user. Once deleted, the application has no access to your account and is no longer listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * Deleting an OAuth application's grant will also delete all OAuth tokens
+   * associated with the application for your user. Once deleted, the application
+   * has no access to your account and is no longer listed on
+   * <a href="https://github.com/settings/applications#authorized">the application
+   * authorizations settings screen within GitHub</a>.
+   * </p>
+   * 
    */
   @Path("/grants/{grant_id}")
   @DELETE
   void oauth_authorizations_delete_grant(@PathParam("grant_id") Integer grantId);
 
   /**
-   * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) to use this endpoint, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.
+   * <p>
+   * OAuth applications can use a special API method for checking OAuth token
+   * validity without exceeding the normal rate limits for failed login attempts.
+   * Authentication works differently with this particular endpoint. You must use
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> to use this endpoint, where the username is the OAuth
+   * application <code>client_id</code> and the password is its
+   * <code>client_secret</code>. Invalid tokens will return
+   * <code>404 NOT FOUND</code>.
+   * </p>
+   * 
    */
   @Path("/{client_id}/token")
   @POST
@@ -55,7 +124,15 @@ public interface ApplicationsResource {
   Response apps_check_token(@PathParam("client_id") String clientId, InputStream data);
 
   /**
-   * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+   * <p>
+   * OAuth application owners can revoke a single token for an OAuth application.
+   * You must use
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password.
+   * </p>
+   * 
    */
   @Path("/{client_id}/token")
   @DELETE
@@ -63,7 +140,16 @@ public interface ApplicationsResource {
   void apps_delete_token(@PathParam("client_id") String clientId, InputStream data);
 
   /**
-   * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+   * <p>
+   * OAuth applications can use this API method to reset a valid OAuth token
+   * without end-user involvement. Applications must save the &quot;token&quot;
+   * property in the response because changes take effect immediately. You must
+   * use <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password. Invalid tokens will return <code>404 NOT FOUND</code>.
+   * </p>
+   * 
    */
   @Path("/{client_id}/token")
   @PATCH
@@ -72,11 +158,35 @@ public interface ApplicationsResource {
   Response apps_reset_token(@PathParam("client_id") String clientId, InputStream data);
 
   /**
-   * **Deprecation Notice:** GitHub will replace and discontinue OAuth endpoints containing `access_token` in the path parameter. We are introducing new endpoints that allow you to securely manage tokens for OAuth Apps by using `access_token` as an input parameter. The OAuth Application API will be removed on May 5, 2021. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/).
-   *
-   * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid token as `:access_token` and the grant for the token's owner will be deleted.
-   *
-   * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the Applications settings page under "Authorized OAuth Apps" on GitHub](https://github.com/settings/applications#authorized).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will replace and discontinue
+   * OAuth endpoints containing <code>access_token</code> in the path parameter.
+   * We are introducing new endpoints that allow you to securely manage tokens for
+   * OAuth Apps by using <code>access_token</code> as an input parameter. The
+   * OAuth Application API will be removed on May 5, 2021. For more information,
+   * including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * OAuth application owners can revoke a grant for their OAuth application and a
+   * specific user. You must use
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password. You must also provide a valid token as
+   * <code>:access_token</code> and the grant for the token's owner will be
+   * deleted.
+   * </p>
+   * <p>
+   * Deleting an OAuth application's grant will also delete all OAuth tokens
+   * associated with the application for the user. Once deleted, the application
+   * will have no access to the user's account and will no longer be listed on
+   * <a href="https://github.com/settings/applications#authorized">the
+   * Applications settings page under &quot;Authorized OAuth Apps&quot; on
+   * GitHub</a>.
+   * </p>
+   * 
    */
   @Path("/{client_id}/grants/{access_token}")
   @DELETE
@@ -84,9 +194,26 @@ public interface ApplicationsResource {
       @PathParam("access_token") String accessToken);
 
   /**
-   * **Deprecation Notice:** GitHub will replace and discontinue OAuth endpoints containing `access_token` in the path parameter. We are introducing new endpoints that allow you to securely manage tokens for OAuth Apps by using `access_token` as an input parameter. The OAuth Application API will be removed on May 5, 2021. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/).
-   *
-   * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will replace and discontinue
+   * OAuth endpoints containing <code>access_token</code> in the path parameter.
+   * We are introducing new endpoints that allow you to securely manage tokens for
+   * OAuth Apps by using <code>access_token</code> as an input parameter. The
+   * OAuth Application API will be removed on May 5, 2021. For more information,
+   * including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * OAuth applications can use a special API method for checking OAuth token
+   * validity without exceeding the normal rate limits for failed login attempts.
+   * Authentication works differently with this particular endpoint. You must use
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password. Invalid tokens will return <code>404 NOT FOUND</code>.
+   * </p>
+   * 
    */
   @Path("/{client_id}/tokens/{access_token}")
   @GET
@@ -95,9 +222,26 @@ public interface ApplicationsResource {
       @PathParam("access_token") String accessToken);
 
   /**
-   * **Deprecation Notice:** GitHub will replace and discontinue OAuth endpoints containing `access_token` in the path parameter. We are introducing new endpoints that allow you to securely manage tokens for OAuth Apps by using `access_token` as an input parameter. The OAuth Application API will be removed on May 5, 2021. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/).
-   *
-   * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will replace and discontinue
+   * OAuth endpoints containing <code>access_token</code> in the path parameter.
+   * We are introducing new endpoints that allow you to securely manage tokens for
+   * OAuth Apps by using <code>access_token</code> as an input parameter. The
+   * OAuth Application API will be removed on May 5, 2021. For more information,
+   * including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * OAuth applications can use this API method to reset a valid OAuth token
+   * without end-user involvement. Applications must save the &quot;token&quot;
+   * property in the response because changes take effect immediately. You must
+   * use <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password. Invalid tokens will return <code>404 NOT FOUND</code>.
+   * </p>
+   * 
    */
   @Path("/{client_id}/tokens/{access_token}")
   @POST
@@ -106,9 +250,25 @@ public interface ApplicationsResource {
       @PathParam("access_token") String accessToken);
 
   /**
-   * **Deprecation Notice:** GitHub will replace and discontinue OAuth endpoints containing `access_token` in the path parameter. We are introducing new endpoints that allow you to securely manage tokens for OAuth Apps by using `access_token` as an input parameter. The OAuth Application API will be removed on May 5, 2021. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/).
-   *
-   * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will replace and discontinue
+   * OAuth endpoints containing <code>access_token</code> in the path parameter.
+   * We are introducing new endpoints that allow you to securely manage tokens for
+   * OAuth Apps by using <code>access_token</code> as an input parameter. The
+   * OAuth Application API will be removed on May 5, 2021. For more information,
+   * including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * OAuth application owners can revoke a single token for an OAuth application.
+   * You must use
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password.
+   * </p>
+   * 
    */
   @Path("/{client_id}/tokens/{access_token}")
   @DELETE
@@ -116,8 +276,22 @@ public interface ApplicationsResource {
       @PathParam("access_token") String accessToken);
 
   /**
-   * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid OAuth `access_token` as an input parameter and the grant for the token's owner will be deleted.
-   * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+   * <p>
+   * OAuth application owners can revoke a grant for their OAuth application and a
+   * specific user. You must use
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a> when accessing this endpoint, using the OAuth
+   * application's <code>client_id</code> and <code>client_secret</code> as the
+   * username and password. You must also provide a valid OAuth
+   * <code>access_token</code> as an input parameter and the grant for the token's
+   * owner will be deleted. Deleting an OAuth application's grant will also delete
+   * all OAuth tokens associated with the application for the user. Once deleted,
+   * the application will have no access to the user's account and will no longer
+   * be listed on
+   * <a href="https://github.com/settings/applications#authorized">the application
+   * authorizations settings screen within GitHub</a>.
+   * </p>
+   * 
    */
   @Path("/{client_id}/grant")
   @DELETE

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/AppsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/AppsResource.java
@@ -7,14 +7,26 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/apps")
 public interface AppsResource {
   /**
-   * **Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).
-   *
-   * If the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+   * <p>
+   * <strong>Note</strong>: The <code>:app_slug</code> is just the URL-friendly
+   * name of your GitHub App. You can find this on the settings page for your
+   * GitHub App (e.g., <code>https://github.com/settings/apps/:app_slug</code>).
+   * </p>
+   * <p>
+   * If the GitHub App you specify is public, you can access this endpoint without
+   * authenticating. If the GitHub App you specify is private, you must
+   * authenticate with a <a href=
+   * "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/">personal
+   * access token</a> or an <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation">installation
+   * access token</a> to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/{app_slug}")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/AuthorizationsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/AuthorizationsResource.java
@@ -14,12 +14,26 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/authorizations")
 public interface AuthorizationsResource {
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
@@ -27,17 +41,61 @@ public interface AuthorizationsResource {
       @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
-   *
-   * **Warning:** Apps must use the [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow) to obtain OAuth tokens that work with GitHub SAML organizations. OAuth tokens created using the Authorizations API will be unable to access GitHub SAML organizations. For more information, see the [blog post](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api).
-   *
-   * Creates OAuth tokens using [Basic Authentication](https://developer.github.com/v3/auth#basic-authentication). If you have two-factor authentication setup, Basic Authentication for this endpoint requires that you use a one-time password (OTP) and your username and password instead of tokens. For more information, see "[Working with two-factor authentication](https://developer.github.com/v3/auth/#working-with-two-factor-authentication)."
-   *
-   * To create tokens for a particular OAuth application using this endpoint, you must authenticate as the user you want to create an authorization for and provide the app's client ID and secret, found on your OAuth application's settings page. If your OAuth application intends to create multiple tokens for one user, use `fingerprint` to differentiate between them.
-   *
-   * You can also create tokens on GitHub from the [personal access tokens settings](https://github.com/settings/tokens) page. Read more about these tokens in [the GitHub Help documentation](https://help.github.com/articles/creating-an-access-token-for-command-line-use).
-   *
-   * Organizations that enforce SAML SSO require personal access tokens to be allowed. Read more about allowing tokens in [the GitHub Help documentation](https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * <strong>Warning:</strong> Apps must use the <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a> to obtain OAuth tokens that work with GitHub SAML
+   * organizations. OAuth tokens created using the Authorizations API will be
+   * unable to access GitHub SAML organizations. For more information, see the
+   * <a href=
+   * "https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * Creates OAuth tokens using
+   * <a href="https://developer.github.com/v3/auth#basic-authentication">Basic
+   * Authentication</a>. If you have two-factor authentication setup, Basic
+   * Authentication for this endpoint requires that you use a one-time password
+   * (OTP) and your username and password instead of tokens. For more information,
+   * see &quot;<a href=
+   * "https://developer.github.com/v3/auth/#working-with-two-factor-authentication">Working
+   * with two-factor authentication</a>.&quot;
+   * </p>
+   * <p>
+   * To create tokens for a particular OAuth application using this endpoint, you
+   * must authenticate as the user you want to create an authorization for and
+   * provide the app's client ID and secret, found on your OAuth application's
+   * settings page. If your OAuth application intends to create multiple tokens
+   * for one user, use <code>fingerprint</code> to differentiate between them.
+   * </p>
+   * <p>
+   * You can also create tokens on GitHub from the
+   * <a href="https://github.com/settings/tokens">personal access tokens
+   * settings</a> page. Read more about these tokens in <a href=
+   * "https://help.github.com/articles/creating-an-access-token-for-command-line-use">the
+   * GitHub Help documentation</a>.
+   * </p>
+   * <p>
+   * Organizations that enforce SAML SSO require personal access tokens to be
+   * allowed. Read more about allowing tokens in <a href=
+   * "https://help.github.com/articles/about-identity-and-access-management-with-saml-single-sign-on">the
+   * GitHub Help documentation</a>.
+   * </p>
+   * 
    */
   @POST
   @Produces("application/json")
@@ -45,68 +103,191 @@ public interface AuthorizationsResource {
   Response oauth_authorizations_create_authorization(InputStream data);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
-   *
-   * **Warning:** Apps must use the [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow) to obtain OAuth tokens that work with GitHub SAML organizations. OAuth tokens created using the Authorizations API will be unable to access GitHub SAML organizations. For more information, see the [blog post](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api).
-   *
-   * This method will create a new authorization for the specified OAuth application, only if an authorization for that application and fingerprint do not already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. `fingerprint` is a unique string to distinguish an authorization from others created for the same client ID and user. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.
-   *
-   * If you have two-factor authentication setup, Basic Authentication for this endpoint requires that you use a one-time password (OTP) and your username and password instead of tokens. For more information, see "[Working with two-factor authentication](https://developer.github.com/v3/auth/#working-with-two-factor-authentication)."
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * <strong>Warning:</strong> Apps must use the <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a> to obtain OAuth tokens that work with GitHub SAML
+   * organizations. OAuth tokens created using the Authorizations API will be
+   * unable to access GitHub SAML organizations. For more information, see the
+   * <a href=
+   * "https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * This method will create a new authorization for the specified OAuth
+   * application, only if an authorization for that application and fingerprint do
+   * not already exist for the user. The URL includes the 20 character client ID
+   * for the OAuth app that is requesting the token. <code>fingerprint</code> is a
+   * unique string to distinguish an authorization from others created for the
+   * same client ID and user. It returns the user's existing authorization for the
+   * application if one is present. Otherwise, it creates and returns a new one.
+   * </p>
+   * <p>
+   * If you have two-factor authentication setup, Basic Authentication for this
+   * endpoint requires that you use a one-time password (OTP) and your username
+   * and password instead of tokens. For more information, see &quot;<a href=
+   * "https://developer.github.com/v3/auth/#working-with-two-factor-authentication">Working
+   * with two-factor authentication</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/clients/{client_id}/{fingerprint}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
   Response oauth_authorizations_get_or_create_authorization_for_app_and_fingerprint(
-      @PathParam("client_id") String clientId, @PathParam("fingerprint") String fingerprint,
-      InputStream data);
+      @PathParam("client_id") String clientId, @PathParam("fingerprint") String fingerprint, InputStream data);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * 
    */
   @Path("/{authorization_id}")
   @GET
   @Produces("application/json")
-  Response oauth_authorizations_get_authorization(
-      @PathParam("authorization_id") Integer authorizationId);
+  Response oauth_authorizations_get_authorization(@PathParam("authorization_id") Integer authorizationId);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * 
    */
   @Path("/{authorization_id}")
   @DELETE
-  void oauth_authorizations_delete_authorization(
-      @PathParam("authorization_id") Integer authorizationId);
+  void oauth_authorizations_delete_authorization(@PathParam("authorization_id") Integer authorizationId);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
-   *
-   * If you have two-factor authentication setup, Basic Authentication for this endpoint requires that you use a one-time password (OTP) and your username and password instead of tokens. For more information, see "[Working with two-factor authentication](https://developer.github.com/v3/auth/#working-with-two-factor-authentication)."
-   *
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * If you have two-factor authentication setup, Basic Authentication for this
+   * endpoint requires that you use a one-time password (OTP) and your username
+   * and password instead of tokens. For more information, see &quot;<a href=
+   * "https://developer.github.com/v3/auth/#working-with-two-factor-authentication">Working
+   * with two-factor authentication</a>.&quot;
+   * </p>
+   * <p>
    * You can only send one of these scope keys at a time.
+   * </p>
+   * 
    */
   @Path("/{authorization_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response oauth_authorizations_update_authorization(
-      @PathParam("authorization_id") Integer authorizationId, InputStream data);
+  Response oauth_authorizations_update_authorization(@PathParam("authorization_id") Integer authorizationId,
+      InputStream data);
 
   /**
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
-   *
-   * **Warning:** Apps must use the [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow) to obtain OAuth tokens that work with GitHub SAML organizations. OAuth tokens created using the Authorizations API will be unable to access GitHub SAML organizations. For more information, see the [blog post](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api).
-   *
-   * Creates a new authorization for the specified OAuth application, only if an authorization for that application doesn't already exist for the user. The URL includes the 20 character client ID for the OAuth app that is requesting the token. It returns the user's existing authorization for the application if one is present. Otherwise, it creates and returns a new one.
-   *
-   * If you have two-factor authentication setup, Basic Authentication for this endpoint requires that you use a one-time password (OTP) and your username and password instead of tokens. For more information, see "[Working with two-factor authentication](https://developer.github.com/v3/auth/#working-with-two-factor-authentication)."
-   *
-   * **Deprecation Notice:** GitHub will discontinue the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * <strong>Warning:</strong> Apps must use the <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a> to obtain OAuth tokens that work with GitHub SAML
+   * organizations. OAuth tokens created using the Authorizations API will be
+   * unable to access GitHub SAML organizations. For more information, see the
+   * <a href=
+   * "https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * Creates a new authorization for the specified OAuth application, only if an
+   * authorization for that application doesn't already exist for the user. The
+   * URL includes the 20 character client ID for the OAuth app that is requesting
+   * the token. It returns the user's existing authorization for the application
+   * if one is present. Otherwise, it creates and returns a new one.
+   * </p>
+   * <p>
+   * If you have two-factor authentication setup, Basic Authentication for this
+   * endpoint requires that you use a one-time password (OTP) and your username
+   * and password instead of tokens. For more information, see &quot;<a href=
+   * "https://developer.github.com/v3/auth/#working-with-two-factor-authentication">Working
+   * with two-factor authentication</a>.&quot;
+   * </p>
+   * <p>
+   * <strong>Deprecation Notice:</strong> GitHub will discontinue the
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a>, which is used by integrations to create personal
+   * access tokens and OAuth tokens, and you must now create these tokens using
+   * our <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow">web
+   * application flow</a>. The
+   * <a href="https://developer.github.com/v3/oauth_authorizations/">OAuth
+   * Authorizations API</a> will be removed on November, 13, 2020. For more
+   * information, including scheduled brownouts, see the <a href=
+   * "https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/">blog
+   * post</a>.
+   * </p>
+   * 
    */
   @Path("/clients/{client_id}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response oauth_authorizations_get_or_create_authorization_for_app(
-      @PathParam("client_id") String clientId, InputStream data);
+  Response oauth_authorizations_get_or_create_authorization_for_app(@PathParam("client_id") String clientId,
+      InputStream data);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/CodesResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/CodesResource.java
@@ -7,12 +7,12 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/codes_of_conduct")
 public interface CodesResource {
   /**
-   *
+   * 
    */
   @Path("/{key}")
   @GET
@@ -20,7 +20,7 @@ public interface CodesResource {
   Response codes_of_conduct_get_conduct_code(@PathParam("key") String key);
 
   /**
-   *
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ContentResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ContentResource.java
@@ -9,21 +9,35 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/content_references")
 public interface ContentResource {
   /**
-   * Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://developer.github.com/webhooks/event-payloads/#content_reference) to create an attachment.
-   *
-   * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://developer.github.com/apps/using-content-attachments/)" for details about content attachments.
-   *
-   * You must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+   * <p>
+   * Creates an attachment under a content reference URL in the body or comment of
+   * an issue or pull request. Use the <code>id</code> of the content reference
+   * from the <a href=
+   * "https://developer.github.com/webhooks/event-payloads/#content_reference"><code>content_reference</code>
+   * event</a> to create an attachment.
+   * </p>
+   * <p>
+   * The app must create a content attachment within six hours of the content
+   * reference URL being posted. See &quot;<a href=
+   * "https://developer.github.com/apps/using-content-attachments/">Using content
+   * attachments</a>&quot; for details about content attachments.
+   * </p>
+   * <p>
+   * You must use an <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation">installation
+   * access token</a> to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/{content_reference_id}/attachments")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response apps_create_content_attachment(
-      @PathParam("content_reference_id") Integer contentReferenceId, InputStream data);
+  Response apps_create_content_attachment(@PathParam("content_reference_id") Integer contentReferenceId,
+      InputStream data);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/EmojisResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/EmojisResource.java
@@ -6,12 +6,15 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/emojis")
 public interface EmojisResource {
   /**
+   * <p>
    * Lists all the emojis available to use on GitHub.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/EnterprisesResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/EnterprisesResource.java
@@ -7,18 +7,32 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/enterprises")
 public interface EnterprisesResource {
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
    * Gets the summary of the free and paid GitHub Actions minutes used.
-   *
-   * Paid minutes only apply to workflows in private repositories that use GitHub-hosted runners. Minutes used is listed for each GitHub-hosted runner operating system. Any job re-runs are also included in the usage. The usage does not include the multiplier for macOS and Windows runners and is not rounded up to the nearest whole minute. For more information, see "[Managing billing for GitHub Actions](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions)".
-   *
+   * </p>
+   * <p>
+   * Paid minutes only apply to workflows in private repositories that use
+   * GitHub-hosted runners. Minutes used is listed for each GitHub-hosted runner
+   * operating system. Any job re-runs are also included in the usage. The usage
+   * does not include the multiplier for macOS and Windows runners and is not
+   * rounded up to the nearest whole minute. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions">Managing
+   * billing for GitHub Actions</a>&quot;.
+   * </p>
+   * <p>
    * The authenticated user must be an enterprise admin.
+   * </p>
+   * 
    */
   @Path("/{enterprise_id}/settings/billing/actions")
   @GET
@@ -26,13 +40,24 @@ public interface EnterprisesResource {
   Response billing_get_github_actions_billing_ghe(@PathParam("enterprise_id") String enterpriseId);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
-   * Gets the estimated paid and estimated total storage used for GitHub Actions and Github Packages.
-   *
-   * Paid minutes only apply to packages stored for private repositories. For more information, see "[Managing billing for GitHub Packages](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages)."
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
+   * Gets the estimated paid and estimated total storage used for GitHub Actions
+   * and Github Packages.
+   * </p>
+   * <p>
+   * Paid minutes only apply to packages stored for private repositories. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages">Managing
+   * billing for GitHub Packages</a>.&quot;
+   * </p>
+   * <p>
    * The authenticated user must be an enterprise admin.
+   * </p>
+   * 
    */
   @Path("/{enterprise_id}/settings/billing/shared-storage")
   @GET
@@ -40,13 +65,23 @@ public interface EnterprisesResource {
   Response billing_get_shared_storage_billing_ghe(@PathParam("enterprise_id") String enterpriseId);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
    * Gets the free and paid storage used for GitHub Packages in gigabytes.
-   *
-   * Paid minutes only apply to packages stored for private repositories. For more information, see "[Managing billing for GitHub Packages](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages)."
-   *
+   * </p>
+   * <p>
+   * Paid minutes only apply to packages stored for private repositories. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages">Managing
+   * billing for GitHub Packages</a>.&quot;
+   * </p>
+   * <p>
    * The authenticated user must be an enterprise admin.
+   * </p>
+   * 
    */
   @Path("/{enterprise_id}/settings/billing/packages")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/EventsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/EventsResource.java
@@ -7,15 +7,19 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/events")
 public interface EventsResource {
   /**
-   * We delay the public events feed by five minutes, which means the most recent event returned by the public events API actually occurred at least five minutes ago.
+   * <p>
+   * We delay the public events feed by five minutes, which means the most recent
+   * event returned by the public events API actually occurred at least five
+   * minutes ago.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
-  Response activity_list_public_events(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response activity_list_public_events(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/FeedsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/FeedsResource.java
@@ -6,22 +6,39 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/feeds")
 public interface FeedsResource {
   /**
-   * GitHub provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:
-   *
-   * *   **Timeline**: The GitHub global public timeline
-   * *   **User**: The public timeline for any user, using [URI template](https://developer.github.com/v3/#hypermedia)
-   * *   **Current user public**: The public timeline for the authenticated user
-   * *   **Current user**: The private timeline for the authenticated user
-   * *   **Current user actor**: The private timeline for activity created by the authenticated user
-   * *   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
-   * *   **Security advisories**: A collection of public announcements that provide information about security-related vulnerabilities in software on GitHub.
-   *
-   * **Note**: Private feeds are only returned when [authenticating via Basic Auth](https://developer.github.com/v3/#basic-authentication) since current feed URIs use the older, non revocable auth tokens.
+   * <p>
+   * GitHub provides several timeline resources in
+   * <a href="http://en.wikipedia.org/wiki/Atom_(standard)">Atom</a> format. The
+   * Feeds API lists all the feeds available to the authenticated user:
+   * </p>
+   * <ul>
+   * <li><strong>Timeline</strong>: The GitHub global public timeline</li>
+   * <li><strong>User</strong>: The public timeline for any user, using
+   * <a href="https://developer.github.com/v3/#hypermedia">URI template</a></li>
+   * <li><strong>Current user public</strong>: The public timeline for the
+   * authenticated user</li>
+   * <li><strong>Current user</strong>: The private timeline for the authenticated
+   * user</li>
+   * <li><strong>Current user actor</strong>: The private timeline for activity
+   * created by the authenticated user</li>
+   * <li><strong>Current user organizations</strong>: The private timeline for the
+   * organizations the authenticated user is a member of.</li>
+   * <li><strong>Security advisories</strong>: A collection of public
+   * announcements that provide information about security-related vulnerabilities
+   * in software on GitHub.</li>
+   * </ul>
+   * <p>
+   * <strong>Note</strong>: Private feeds are only returned when <a href=
+   * "https://developer.github.com/v3/#basic-authentication">authenticating via
+   * Basic Auth</a> since current feed URIs use the older, non revocable auth
+   * tokens.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/GistsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/GistsResource.java
@@ -14,80 +14,94 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/gists")
 public interface GistsResource {
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/star")
   @GET
   void gists_check_is_starred(@PathParam("gist_id") String gistId);
 
   /**
-   * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
+   * <p>
+   * Note that you'll need to set <code>Content-Length</code> to zero when calling
+   * out to this endpoint. For more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{gist_id}/star")
   @PUT
   void gists_star(@PathParam("gist_id") String gistId);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/star")
   @DELETE
   void gists_unstar(@PathParam("gist_id") String gistId);
 
   /**
+   * <p>
    * List the authenticated user's starred gists:
+   * </p>
+   * 
    */
   @Path("/starred")
   @GET
   @Produces("application/json")
-  Response gists_list_starred(@QueryParam("since") String since,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response gists_list_starred(@QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/comments/{comment_id}")
   @GET
   @Produces("application/json")
-  Response gists_get_comment(@PathParam("gist_id") String gistId,
-      @PathParam("comment_id") Integer commentId);
+  Response gists_get_comment(@PathParam("gist_id") String gistId, @PathParam("comment_id") Integer commentId);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/comments/{comment_id}")
   @DELETE
-  void gists_delete_comment(@PathParam("gist_id") String gistId,
-      @PathParam("comment_id") Integer commentId);
+  void gists_delete_comment(@PathParam("gist_id") String gistId, @PathParam("comment_id") Integer commentId);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/comments/{comment_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response gists_update_comment(@PathParam("gist_id") String gistId,
-      @PathParam("comment_id") Integer commentId, InputStream data);
+  Response gists_update_comment(@PathParam("gist_id") String gistId, @PathParam("comment_id") Integer commentId,
+      InputStream data);
 
   /**
+   * <p>
    * List public gists sorted by most recently updated to least recently updated.
-   *
-   * Note: With [pagination](https://developer.github.com/v3/#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.
+   * </p>
+   * <p>
+   * Note: With
+   * <a href="https://developer.github.com/v3/#pagination">pagination</a>, you can
+   * fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists
+   * per page or 30 pages with 100 gists per page.
+   * </p>
+   * 
    */
   @Path("/public")
   @GET
   @Produces("application/json")
-  Response gists_list_public(@QueryParam("since") String since,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response gists_list_public(@QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}")
   @GET
@@ -95,14 +109,19 @@ public interface GistsResource {
   Response gists_get(@PathParam("gist_id") String gistId);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}")
   @DELETE
   void gists_delete(@PathParam("gist_id") String gistId);
 
   /**
-   * Allows you to update or delete a gist file and rename gist files. Files from the previous version of the gist that aren't explicitly changed during an edit are unchanged.
+   * <p>
+   * Allows you to update or delete a gist file and rename gist files. Files from
+   * the previous version of the gist that aren't explicitly changed during an
+   * edit are unchanged.
+   * </p>
+   * 
    */
   @Path("/{gist_id}")
   @PATCH
@@ -111,16 +130,19 @@ public interface GistsResource {
   Response gists_update(@PathParam("gist_id") String gistId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/forks")
   @GET
   @Produces("application/json")
-  Response gists_list_forks(@PathParam("gist_id") String gistId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response gists_list_forks(@PathParam("gist_id") String gistId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Note**: This was previously `/gists/:gist_id/fork`.
+   * <p>
+   * <strong>Note</strong>: This was previously <code>/gists/:gist_id/fork</code>.
+   * </p>
+   * 
    */
   @Path("/{gist_id}/forks")
   @POST
@@ -128,7 +150,11 @@ public interface GistsResource {
   Response gists_fork(@PathParam("gist_id") String gistId);
 
   /**
-   * Lists the authenticated user's gists or if called anonymously, this endpoint returns all public gists:
+   * <p>
+   * Lists the authenticated user's gists or if called anonymously, this endpoint
+   * returns all public gists:
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
@@ -136,9 +162,15 @@ public interface GistsResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Allows you to add a new gist with one or more files.
-   *
-   * **Note:** Don't name your files "gistfile" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> Don't name your files &quot;gistfile&quot; with a
+   * numerical suffix. This is the format of the automatic naming scheme that Gist
+   * uses internally.
+   * </p>
+   * 
    */
   @POST
   @Produces("application/json")
@@ -146,25 +178,25 @@ public interface GistsResource {
   Response gists_create(InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/commits")
   @GET
   @Produces("application/json")
-  Response gists_list_commits(@PathParam("gist_id") String gistId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response gists_list_commits(@PathParam("gist_id") String gistId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/comments")
   @GET
   @Produces("application/json")
-  Response gists_list_comments(@PathParam("gist_id") String gistId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response gists_list_comments(@PathParam("gist_id") String gistId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/comments")
   @POST
@@ -173,7 +205,7 @@ public interface GistsResource {
   Response gists_create_comment(@PathParam("gist_id") String gistId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{gist_id}/{sha}")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/GitignoreResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/GitignoreResource.java
@@ -8,13 +8,17 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/gitignore")
 public interface GitignoreResource {
   /**
-   * The API also allows fetching the source of a single template.
-   * Use the raw [media type](https://developer.github.com/v3/media/) to get the raw contents.
+   * <p>
+   * The API also allows fetching the source of a single template. Use the raw
+   * <a href="https://developer.github.com/v3/media/">media type</a> to get the
+   * raw contents.
+   * </p>
+   * 
    */
   @Path("/templates/{name}")
   @GET
@@ -22,7 +26,12 @@ public interface GitignoreResource {
   Response gitignore_get_template(@PathParam("name") String name);
 
   /**
-   * List all templates available to pass as an option when [creating a repository](https://developer.github.com/v3/repos/#create-a-repository-for-the-authenticated-user).
+   * <p>
+   * List all templates available to pass as an option when <a href=
+   * "https://developer.github.com/v3/repos/#create-a-repository-for-the-authenticated-user">creating
+   * a repository</a>.
+   * </p>
+   * 
    */
   @Path("/templates")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/InstallationResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/InstallationResource.java
@@ -8,14 +8,20 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/installation")
 public interface InstallationResource {
   /**
+   * <p>
    * List repositories that an app installation can access.
-   *
-   * You must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+   * </p>
+   * <p>
+   * You must use an <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation">installation
+   * access token</a> to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/repositories")
   @GET
@@ -24,11 +30,24 @@ public interface InstallationResource {
       @QueryParam("page") Integer page);
 
   /**
-   * Revokes the installation token you're using to authenticate as an installation and access this endpoint.
-   *
-   * Once an installation token is revoked, the token is invalidated and cannot be used. Other endpoints that require the revoked installation token must have a new installation token to work. You can create a new token using the "[Create an installation access token for an app](https://developer.github.com/v3/apps/#create-an-installation-access-token-for-an-app)" endpoint.
-   *
-   * You must use an [installation access token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+   * <p>
+   * Revokes the installation token you're using to authenticate as an
+   * installation and access this endpoint.
+   * </p>
+   * <p>
+   * Once an installation token is revoked, the token is invalidated and cannot be
+   * used. Other endpoints that require the revoked installation token must have a
+   * new installation token to work. You can create a new token using the
+   * &quot;<a href=
+   * "https://developer.github.com/v3/apps/#create-an-installation-access-token-for-an-app">Create
+   * an installation access token for an app</a>&quot; endpoint.
+   * </p>
+   * <p>
+   * You must use an <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation">installation
+   * access token</a> to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/token")
   @DELETE

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/IssuesResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/IssuesResource.java
@@ -7,28 +7,37 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/issues")
 public interface IssuesResource {
   /**
-   * List issues assigned to the authenticated user across all visible repositories including owned repositories, member
-   * repositories, and organization repositories. You can use the `filter` query parameter to fetch issues that are not
-   * necessarily assigned to you. See the [Parameters table](https://developer.github.com/v3/issues/#parameters) for more
-   * information.
-   *
-   *
-   * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
-   * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
-   * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
-   * request id, use the "[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)" endpoint.
+   * <p>
+   * List issues assigned to the authenticated user across all visible
+   * repositories including owned repositories, member repositories, and
+   * organization repositories. You can use the <code>filter</code> query
+   * parameter to fetch issues that are not necessarily assigned to you. See the
+   * <a href="https://developer.github.com/v3/issues/#parameters">Parameters
+   * table</a> for more information.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: GitHub's REST API v3 considers every pull request an
+   * issue, but not every issue is a pull request. For this reason,
+   * &quot;Issues&quot; endpoints may return both issues and pull requests in the
+   * response. You can identify pull requests by the <code>pull_request</code>
+   * key. Be aware that the <code>id</code> of a pull request returned from
+   * &quot;Issues&quot; endpoints will be an <em>issue id</em>. To find out the
+   * pull request id, use the &quot;<a href=
+   * "https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a>&quot; endpoint.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   Response issues_list(@QueryParam("filter") String filter, @QueryParam("state") String state,
-      @QueryParam("labels") String labels, @QueryParam("sort") String sort,
-      @QueryParam("direction") String direction, @QueryParam("since") String since,
-      @QueryParam("collab") Boolean collab, @QueryParam("orgs") Boolean orgs,
-      @QueryParam("owned") Boolean owned, @QueryParam("pulls") Boolean pulls,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+      @QueryParam("labels") String labels, @QueryParam("sort") String sort, @QueryParam("direction") String direction,
+      @QueryParam("since") String since, @QueryParam("collab") Boolean collab, @QueryParam("orgs") Boolean orgs,
+      @QueryParam("owned") Boolean owned, @QueryParam("pulls") Boolean pulls, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/LicensesResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/LicensesResource.java
@@ -8,12 +8,12 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/licenses")
 public interface LicensesResource {
   /**
-   *
+   * 
    */
   @Path("/{license}")
   @GET
@@ -21,7 +21,7 @@ public interface LicensesResource {
   Response licenses_get(@PathParam("license") String license);
 
   /**
-   *
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/MarkdownResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/MarkdownResource.java
@@ -7,19 +7,27 @@ import jakarta.ws.rs.Produces;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/markdown")
 public interface MarkdownResource {
   /**
-   *
+   * 
    */
   @POST
   @Consumes("application/json")
   void markdown_render(InputStream data);
 
   /**
-   * You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.
+   * <p>
+   * You must send Markdown as plain text (using a <code>Content-Type</code>
+   * header of <code>text/plain</code> or <code>text/x-markdown</code>) to this
+   * endpoint, rather than using JSON format. In raw mode,
+   * <a href="https://github.github.com/gfm/">GitHub Flavored Markdown</a> is not
+   * supported and Markdown will be rendered in plain format like a README.md
+   * file. Markdown content must be 400 KB or less.
+   * </p>
+   * 
    */
   @Path("/raw")
   @POST

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/MarketplaceResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/MarketplaceResource.java
@@ -8,49 +8,99 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/marketplace_listing")
 public interface MarketplaceResource {
   /**
-   * Returns user and organization accounts associated with the specified plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.
-   *
-   * GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.
+   * <p>
+   * Returns user and organization accounts associated with the specified plan,
+   * including free plans. For per-seat pricing, you see the list of accounts that
+   * have purchased the plan, including the number of seats purchased. When
+   * someone submits a plan change that won't be processed until the end of their
+   * billing cycle, you will also see the upcoming pending change.
+   * </p>
+   * <p>
+   * GitHub Apps must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint. OAuth Apps must use
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">basic
+   * authentication</a> with their client ID and client secret to access this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/plans/{plan_id}/accounts")
   @GET
   @Produces("application/json")
-  Response apps_list_accounts_for_plan(@PathParam("plan_id") Integer planId,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response apps_list_accounts_for_plan(@PathParam("plan_id") Integer planId, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.
-   *
-   * GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.
+   * <p>
+   * Shows whether the user or organization account actively subscribes to a plan
+   * listed by the authenticated GitHub App. When someone submits a plan change
+   * that won't be processed until the end of their billing cycle, you will also
+   * see the upcoming pending change.
+   * </p>
+   * <p>
+   * GitHub Apps must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint. OAuth Apps must use
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">basic
+   * authentication</a> with their client ID and client secret to access this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/stubbed/accounts/{account_id}")
   @GET
   @Produces("application/json")
-  Response apps_get_subscription_plan_for_account_stubbed(
-      @PathParam("account_id") Integer accountId);
+  Response apps_get_subscription_plan_for_account_stubbed(@PathParam("account_id") Integer accountId);
 
   /**
-   * Returns repository and organization accounts associated with the specified plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.
-   *
-   * GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.
+   * <p>
+   * Returns repository and organization accounts associated with the specified
+   * plan, including free plans. For per-seat pricing, you see the list of
+   * accounts that have purchased the plan, including the number of seats
+   * purchased. When someone submits a plan change that won't be processed until
+   * the end of their billing cycle, you will also see the upcoming pending
+   * change.
+   * </p>
+   * <p>
+   * GitHub Apps must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint. OAuth Apps must use
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">basic
+   * authentication</a> with their client ID and client secret to access this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/stubbed/plans/{plan_id}/accounts")
   @GET
   @Produces("application/json")
-  Response apps_list_accounts_for_plan_stubbed(@PathParam("plan_id") Integer planId,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response apps_list_accounts_for_plan_stubbed(@PathParam("plan_id") Integer planId, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.
-   *
-   * GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.
+   * <p>
+   * Shows whether the user or organization account actively subscribes to a plan
+   * listed by the authenticated GitHub App. When someone submits a plan change
+   * that won't be processed until the end of their billing cycle, you will also
+   * see the upcoming pending change.
+   * </p>
+   * <p>
+   * GitHub Apps must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint. OAuth Apps must use
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">basic
+   * authentication</a> with their client ID and client secret to access this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/accounts/{account_id}")
   @GET
@@ -58,24 +108,40 @@ public interface MarketplaceResource {
   Response apps_get_subscription_plan_for_account(@PathParam("account_id") Integer accountId);
 
   /**
+   * <p>
    * Lists all plans that are part of your GitHub Marketplace listing.
-   *
-   * GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.
+   * </p>
+   * <p>
+   * GitHub Apps must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint. OAuth Apps must use
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">basic
+   * authentication</a> with their client ID and client secret to access this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/stubbed/plans")
   @GET
   @Produces("application/json")
-  Response apps_list_plans_stubbed(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response apps_list_plans_stubbed(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists all plans that are part of your GitHub Marketplace listing.
-   *
-   * GitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.
+   * </p>
+   * <p>
+   * GitHub Apps must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint. OAuth Apps must use
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">basic
+   * authentication</a> with their client ID and client secret to access this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/plans")
   @GET
   @Produces("application/json")
-  Response apps_list_plans(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response apps_list_plans(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/MetaResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/MetaResource.java
@@ -6,12 +6,18 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/meta")
 public interface MetaResource {
   /**
-   * This endpoint provides a list of GitHub's IP addresses. For more information, see "[About GitHub's IP addresses](https://help.github.com/articles/about-github-s-ip-addresses/)."
+   * <p>
+   * This endpoint provides a list of GitHub's IP addresses. For more information,
+   * see &quot;<a href=
+   * "https://help.github.com/articles/about-github-s-ip-addresses/">About
+   * GitHub's IP addresses</a>.&quot;
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/NetworksResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/NetworksResource.java
@@ -8,17 +8,16 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/networks")
 public interface NetworksResource {
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/events")
   @GET
   @Produces("application/json")
   Response activity_list_public_events_for_repo_network(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/NotificationsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/NotificationsResource.java
@@ -13,12 +13,12 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/notifications")
 public interface NotificationsResource {
   /**
-   *
+   * 
    */
   @Path("/threads/{thread_id}")
   @GET
@@ -26,56 +26,97 @@ public interface NotificationsResource {
   Response activity_get_thread(@PathParam("thread_id") Integer threadId);
 
   /**
-   *
+   * 
    */
   @Path("/threads/{thread_id}")
   @PATCH
   void activity_mark_thread_as_read(@PathParam("thread_id") Integer threadId);
 
   /**
-   * This checks to see if the current user is subscribed to a thread. You can also [get a repository subscription](https://developer.github.com/v3/activity/watching/#get-a-repository-subscription).
-   *
-   * Note that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mentioned**, or manually subscribe to a thread.
+   * <p>
+   * This checks to see if the current user is subscribed to a thread. You can
+   * also <a href=
+   * "https://developer.github.com/v3/activity/watching/#get-a-repository-subscription">get
+   * a repository subscription</a>.
+   * </p>
+   * <p>
+   * Note that subscriptions are only generated if a user is participating in a
+   * conversation--for example, they've replied to the thread, were
+   * <strong>@mentioned</strong>, or manually subscribe to a thread.
+   * </p>
+   * 
    */
   @Path("/threads/{thread_id}/subscription")
   @GET
   @Produces("application/json")
-  Response activity_get_thread_subscription_for_authenticated_user(
-      @PathParam("thread_id") Integer threadId);
+  Response activity_get_thread_subscription_for_authenticated_user(@PathParam("thread_id") Integer threadId);
 
   /**
-   * If you are watching a repository, you receive notifications for all threads by default. Use this endpoint to ignore future notifications for threads until you comment on the thread or get an **@mention**.
-   *
-   * You can also use this endpoint to subscribe to threads that you are currently not receiving notifications for or to subscribed to threads that you have previously ignored.
-   *
-   * Unsubscribing from a conversation in a repository that you are not watching is functionally equivalent to the [Delete a thread subscription](https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription) endpoint.
+   * <p>
+   * If you are watching a repository, you receive notifications for all threads
+   * by default. Use this endpoint to ignore future notifications for threads
+   * until you comment on the thread or get an <strong>@mention</strong>.
+   * </p>
+   * <p>
+   * You can also use this endpoint to subscribe to threads that you are currently
+   * not receiving notifications for or to subscribed to threads that you have
+   * previously ignored.
+   * </p>
+   * <p>
+   * Unsubscribing from a conversation in a repository that you are not watching
+   * is functionally equivalent to the <a href=
+   * "https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription">Delete
+   * a thread subscription</a> endpoint.
+   * </p>
+   * 
    */
   @Path("/threads/{thread_id}/subscription")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response activity_set_thread_subscription(@PathParam("thread_id") Integer threadId,
-      InputStream data);
+  Response activity_set_thread_subscription(@PathParam("thread_id") Integer threadId, InputStream data);
 
   /**
-   * Mutes all future notifications for a conversation until you comment on the thread or get an **@mention**. If you are watching the repository of the thread, you will still receive notifications. To ignore future notifications for a repository you are watching, use the [Set a thread subscription](https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription) endpoint and set `ignore` to `true`.
+   * <p>
+   * Mutes all future notifications for a conversation until you comment on the
+   * thread or get an <strong>@mention</strong>. If you are watching the
+   * repository of the thread, you will still receive notifications. To ignore
+   * future notifications for a repository you are watching, use the <a href=
+   * "https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription">Set
+   * a thread subscription</a> endpoint and set <code>ignore</code> to
+   * <code>true</code>.
+   * </p>
+   * 
    */
   @Path("/threads/{thread_id}/subscription")
   @DELETE
   void activity_delete_thread_subscription(@PathParam("thread_id") Integer threadId);
 
   /**
+   * <p>
    * List all notifications for the current user, sorted by most recently updated.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   Response activity_list_notifications_for_authenticated_user(@QueryParam("all") Boolean all,
       @QueryParam("participating") Boolean participating, @QueryParam("since") String since,
-      @QueryParam("before") String before, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("before") String before, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Marks all notifications as "read" removes it from the [default view on GitHub](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List notifications for the authenticated user](https://developer.github.com/v3/activity/notifications/#list-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+   * <p>
+   * Marks all notifications as &quot;read&quot; removes it from the
+   * <a href="https://github.com/notifications">default view on GitHub</a>. If the
+   * number of notifications is too large to complete in one request, you will
+   * receive a <code>202 Accepted</code> status and GitHub will run an
+   * asynchronous process to mark notifications as &quot;read.&quot; To check
+   * whether any &quot;unread&quot; notifications remain, you can use the <a href=
+   * "https://developer.github.com/v3/activity/notifications/#list-notifications-for-the-authenticated-user">List
+   * notifications for the authenticated user</a> endpoint and pass the query
+   * parameter <code>all=false</code>.
+   * </p>
+   * 
    */
   @PUT
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/OctocatResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/OctocatResource.java
@@ -6,12 +6,15 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/octocat")
 public interface OctocatResource {
   /**
+   * <p>
    * Get the octocat as ASCII art
+   * </p>
+   * 
    */
   @GET
   @Produces("application/octocat-stream")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/OrganizationsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/OrganizationsResource.java
@@ -7,14 +7,21 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/organizations")
 public interface OrganizationsResource {
   /**
+   * <p>
    * Lists all organizations, in the order that they were created on GitHub.
-   *
-   * **Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of organizations.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> Pagination is powered exclusively by the
+   * <code>since</code> parameter. Use the
+   * <a href="https://developer.github.com/v3/#link-header">Link header</a> to get
+   * the URL for the next page of organizations.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/OrgsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/OrgsResource.java
@@ -14,12 +14,15 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/orgs")
 public interface OrgsResource {
   /**
+   * <p>
    * Lists repositories for the specified organization.
+   * </p>
+   * 
    */
   @Path("/{org}/repos")
   @GET
@@ -29,14 +32,24 @@ public interface OrgsResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Creates a new repository in the specified organization. The authenticated user must be a member of the organization.
-   *
-   * **OAuth scope requirements**
-   *
-   * When using [OAuth](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
-   *
-   * *   `public_repo` scope or `repo` scope to create a public repository
-   * *   `repo` scope to create a private repository
+   * <p>
+   * Creates a new repository in the specified organization. The authenticated
+   * user must be a member of the organization.
+   * </p>
+   * <p>
+   * <strong>OAuth scope requirements</strong>
+   * </p>
+   * <p>
+   * When using <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">OAuth</a>,
+   * authorizations must include:
+   * </p>
+   * <ul>
+   * <li><code>public_repo</code> scope or <code>repo</code> scope to create a
+   * public repository</li>
+   * <li><code>repo</code> scope to create a private repository</li>
+   * </ul>
+   * 
    */
   @Path("/{org}/repos")
   @POST
@@ -45,16 +58,22 @@ public interface OrgsResource {
   Response repos_create_in_org(@PathParam("org") String org, InputStream data);
 
   /**
+   * <p>
    * Lists the most recent migrations.
+   * </p>
+   * 
    */
   @Path("/{org}/migrations")
   @GET
   @Produces("application/json")
-  Response migrations_list_for_org(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response migrations_list_for_org(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Initiates the generation of a migration archive.
+   * </p>
+   * 
    */
   @Path("/{org}/migrations")
   @POST
@@ -63,25 +82,37 @@ public interface OrgsResource {
   Response migrations_start_for_org(@PathParam("org") String org, InputStream data);
 
   /**
-   * Unlocks a repository that was locked for migration. You should unlock each migrated repository and [delete them](https://developer.github.com/v3/repos/#delete-a-repository) when the migration is complete and you no longer need the source data.
+   * <p>
+   * Unlocks a repository that was locked for migration. You should unlock each
+   * migrated repository and
+   * <a href="https://developer.github.com/v3/repos/#delete-a-repository">delete
+   * them</a> when the migration is complete and you no longer need the source
+   * data.
+   * </p>
+   * 
    */
   @Path("/{org}/migrations/{migration_id}/repos/{repo_name}/lock")
   @DELETE
-  void migrations_unlock_repo_for_org(@PathParam("org") String org,
-      @PathParam("migration_id") Integer migrationId, @PathParam("repo_name") String repoName);
+  void migrations_unlock_repo_for_org(@PathParam("org") String org, @PathParam("migration_id") Integer migrationId,
+      @PathParam("repo_name") String repoName);
 
   /**
+   * <p>
    * List all the repositories for this organization migration.
+   * </p>
+   * 
    */
   @Path("/{org}/migrations/{migration_id}/repositories")
   @GET
   @Produces("application/json")
-  Response migrations_list_repos_for_org(@PathParam("org") String org,
-      @PathParam("migration_id") Integer migrationId, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response migrations_list_repos_for_org(@PathParam("org") String org, @PathParam("migration_id") Integer migrationId,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Fetches the URL to a migration archive.
+   * </p>
+   * 
    */
   @Path("/{org}/migrations/{migration_id}/archive")
   @GET
@@ -89,31 +120,44 @@ public interface OrgsResource {
       @PathParam("migration_id") Integer migrationId);
 
   /**
-   * Deletes a previous migration archive. Migration archives are automatically deleted after seven days.
+   * <p>
+   * Deletes a previous migration archive. Migration archives are automatically
+   * deleted after seven days.
+   * </p>
+   * 
    */
   @Path("/{org}/migrations/{migration_id}/archive")
   @DELETE
-  void migrations_delete_archive_for_org(@PathParam("org") String org,
-      @PathParam("migration_id") Integer migrationId);
+  void migrations_delete_archive_for_org(@PathParam("org") String org, @PathParam("migration_id") Integer migrationId);
 
   /**
+   * <p>
    * Fetches the status of a migration.
-   *
-   * The `state` of a migration can be one of the following values:
-   *
-   * *   `pending`, which means the migration hasn't started yet.
-   * *   `exporting`, which means the migration is in progress.
-   * *   `exported`, which means the migration finished successfully.
-   * *   `failed`, which means the migration failed.
+   * </p>
+   * <p>
+   * The <code>state</code> of a migration can be one of the following values:
+   * </p>
+   * <ul>
+   * <li><code>pending</code>, which means the migration hasn't started yet.</li>
+   * <li><code>exporting</code>, which means the migration is in progress.</li>
+   * <li><code>exported</code>, which means the migration finished
+   * successfully.</li>
+   * <li><code>failed</code>, which means the migration failed.</li>
+   * </ul>
+   * 
    */
   @Path("/{org}/migrations/{migration_id}")
   @GET
   @Produces("application/json")
-  Response migrations_get_status_for_org(@PathParam("org") String org,
-      @PathParam("migration_id") Integer migrationId);
+  Response migrations_get_status_for_org(@PathParam("org") String org, @PathParam("migration_id") Integer migrationId);
 
   /**
-   * Shows which group of GitHub users can interact with this organization and when the restriction expires. If there are no restrictions, you will see an empty response.
+   * <p>
+   * Shows which group of GitHub users can interact with this organization and
+   * when the restriction expires. If there are no restrictions, you will see an
+   * empty response.
+   * </p>
+   * 
    */
   @Path("/{org}/interaction-limits")
   @GET
@@ -121,7 +165,12 @@ public interface OrgsResource {
   Response interactions_get_restrictions_for_org(@PathParam("org") String org);
 
   /**
-   * Temporarily restricts interactions to certain GitHub users in any public repository in the given organization. You must be an organization owner to set these restrictions.
+   * <p>
+   * Temporarily restricts interactions to certain GitHub users in any public
+   * repository in the given organization. You must be an organization owner to
+   * set these restrictions.
+   * </p>
+   * 
    */
   @Path("/{org}/interaction-limits")
   @PUT
@@ -130,23 +179,33 @@ public interface OrgsResource {
   Response interactions_set_restrictions_for_org(@PathParam("org") String org, InputStream data);
 
   /**
-   * Removes all interaction restrictions from public repositories in the given organization. You must be an organization owner to remove restrictions.
+   * <p>
+   * Removes all interaction restrictions from public repositories in the given
+   * organization. You must be an organization owner to remove restrictions.
+   * </p>
+   * 
    */
   @Path("/{org}/interaction-limits")
   @DELETE
   void interactions_remove_restrictions_for_org(@PathParam("org") String org);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/events")
   @GET
   @Produces("application/json")
-  Response activity_list_public_org_events(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response activity_list_public_org_events(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+   * <p>
+   * Lists the projects in an organization. Returns a <code>404 Not Found</code>
+   * status if projects are disabled in the organization. If you do not have
+   * sufficient privileges to perform this action, a <code>401 Unauthorized</code>
+   * or <code>410 Gone</code> status is returned.
+   * </p>
+   * 
    */
   @Path("/{org}/projects")
   @GET
@@ -155,7 +214,13 @@ public interface OrgsResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Creates an organization project board. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+   * <p>
+   * Creates an organization project board. Returns a <code>404 Not Found</code>
+   * status if projects are disabled in the organization. If you do not have
+   * sufficient privileges to perform this action, a <code>401 Unauthorized</code>
+   * or <code>410 Gone</code> status is returned.
+   * </p>
+   * 
    */
   @Path("/{org}/projects")
   @POST
@@ -164,89 +229,158 @@ public interface OrgsResource {
   Response projects_create_for_org(@PathParam("org") String org, InputStream data);
 
   /**
-   * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions/:reaction_id`.
-   *
-   * Delete a reaction to a [team discussion](https://developer.github.com/v3/teams/discussions/). OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Note:</strong> You can also specify a team or organization with
+   * <code>team_id</code> and <code>org_id</code> using the route
+   * <code>DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions/:reaction_id</code>.
+   * </p>
+   * <p>
+   * Delete a reaction to a
+   * <a href="https://developer.github.com/v3/teams/discussions/">team
+   * discussion</a>. OAuth access tokens require the <code>write:discussion</code>
+   * <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}")
   @DELETE
-  void reactions_delete_for_team_discussion(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("reaction_id") Integer reactionId);
+  void reactions_delete_for_team_discussion(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("reaction_id") Integer reactionId);
 
   /**
-   * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions/:reaction_id`.
-   *
-   * Delete a reaction to a [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/). OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Note:</strong> You can also specify a team or organization with
+   * <code>team_id</code> and <code>org_id</code> using the route
+   * <code>DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions/:reaction_id</code>.
+   * </p>
+   * <p>
+   * Delete a reaction to a
+   * <a href="https://developer.github.com/v3/teams/discussion_comments/">team
+   * discussion comment</a>. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}")
   @DELETE
   void reactions_delete_for_team_discussion_comment(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber,
-      @PathParam("reaction_id") Integer reactionId);
+      @PathParam("team_slug") String teamSlug, @PathParam("discussion_number") Integer discussionNumber,
+      @PathParam("comment_number") Integer commentNumber, @PathParam("reaction_id") Integer reactionId);
 
   /**
-   * List the reactions to a [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/). OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+   * <p>
+   * List the reactions to a
+   * <a href="https://developer.github.com/v3/teams/discussion_comments/">team
+   * discussion comment</a>. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions")
   @GET
   @Produces("application/json")
   Response reactions_list_for_team_discussion_comment_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
+      @PathParam("team_slug") String teamSlug, @PathParam("discussion_number") Integer discussionNumber,
       @PathParam("comment_number") Integer commentNumber, @QueryParam("content") String content,
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Create a reaction to a [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/). OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with a `Status: 200 OK` means that you already added the reaction type to this team discussion comment.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+   * <p>
+   * Create a reaction to a
+   * <a href="https://developer.github.com/v3/teams/discussion_comments/">team
+   * discussion comment</a>. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * A response with a <code>Status: 200 OK</code> means that you already added
+   * the reaction type to this team discussion comment.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
   Response reactions_create_for_team_discussion_comment_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
+      @PathParam("team_slug") String teamSlug, @PathParam("discussion_number") Integer discussionNumber,
       @PathParam("comment_number") Integer commentNumber, InputStream data);
 
   /**
-   * List the reactions to a [team discussion](https://developer.github.com/v3/teams/discussions/). OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+   * <p>
+   * List the reactions to a
+   * <a href="https://developer.github.com/v3/teams/discussions/">team
+   * discussion</a>. OAuth access tokens require the <code>read:discussion</code>
+   * <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions")
   @GET
   @Produces("application/json")
   Response reactions_list_for_team_discussion_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("team_slug") String teamSlug, @PathParam("discussion_number") Integer discussionNumber,
+      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Create a reaction to a [team discussion](https://developer.github.com/v3/teams/discussions/). OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with a `Status: 200 OK` means that you already added the reaction type to this team discussion.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+   * <p>
+   * Create a reaction to a
+   * <a href="https://developer.github.com/v3/teams/discussions/">team
+   * discussion</a>. OAuth access tokens require the <code>write:discussion</code>
+   * <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * A response with a <code>Status: 200 OK</code> means that you already added
+   * the reaction type to this team discussion.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
   Response reactions_create_for_team_discussion_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber, InputStream data);
+      @PathParam("team_slug") String teamSlug, @PathParam("discussion_number") Integer discussionNumber,
+      InputStream data);
 
   /**
-   * Listing and deleting credential authorizations is available to organizations with GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products).
-   *
-   * An authenticated organization owner with the `read:org` scope can list all credential authorizations for an organization that uses SAML single sign-on (SSO). The credentials are either personal access tokens or SSH keys that organization members have authorized for the organization. For more information, see [About authentication with SAML single sign-on](https://help.github.com/en/articles/about-authentication-with-saml-single-sign-on).
+   * <p>
+   * Listing and deleting credential authorizations is available to organizations
+   * with GitHub Enterprise Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a>.
+   * </p>
+   * <p>
+   * An authenticated organization owner with the <code>read:org</code> scope can
+   * list all credential authorizations for an organization that uses SAML single
+   * sign-on (SSO). The credentials are either personal access tokens or SSH keys
+   * that organization members have authorized for the organization. For more
+   * information, see <a href=
+   * "https://help.github.com/en/articles/about-authentication-with-saml-single-sign-on">About
+   * authentication with SAML single sign-on</a>.
+   * </p>
+   * 
    */
   @Path("/{org}/credential-authorizations")
   @GET
@@ -254,17 +388,28 @@ public interface OrgsResource {
   Response orgs_list_saml_sso_authorizations(@PathParam("org") String org);
 
   /**
-   * List all teams associated with an invitation. In order to see invitations in an organization, the authenticated user must be an organization owner.
+   * <p>
+   * List all teams associated with an invitation. In order to see invitations in
+   * an organization, the authenticated user must be an organization owner.
+   * </p>
+   * 
    */
   @Path("/{org}/invitations/{invitation_id}/teams")
   @GET
   @Produces("application/json")
-  Response orgs_list_invitation_teams(@PathParam("org") String org,
-      @PathParam("invitation_id") Integer invitationId, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response orgs_list_invitation_teams(@PathParam("org") String org, @PathParam("invitation_id") Integer invitationId,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see "[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)".
+   * <p>
+   * When an organization member is converted to an outside collaborator, they'll
+   * only have access to the repositories that their current team membership
+   * allows. The user will no longer be a member of the organization. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/">Converting
+   * an organization member to an outside collaborator</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{org}/outside_collaborators/{username}")
   @PUT
@@ -272,52 +417,89 @@ public interface OrgsResource {
       @PathParam("username") String username);
 
   /**
-   * Removing a user from this list will remove them from all the organization's repositories.
+   * <p>
+   * Removing a user from this list will remove them from all the organization's
+   * repositories.
+   * </p>
+   * 
    */
   @Path("/{org}/outside_collaborators/{username}")
   @DELETE
-  void orgs_remove_outside_collaborator(@PathParam("org") String org,
-      @PathParam("username") String username);
+  void orgs_remove_outside_collaborator(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   * In order to get a user's membership with an organization, the authenticated user must be an organization member.
+   * <p>
+   * In order to get a user's membership with an organization, the authenticated
+   * user must be an organization member.
+   * </p>
+   * 
    */
   @Path("/{org}/memberships/{username}")
   @GET
   @Produces("application/json")
-  Response orgs_get_membership_for_user(@PathParam("org") String org,
-      @PathParam("username") String username);
+  Response orgs_get_membership_for_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   * Only authenticated organization owners can add a member to the organization or update the member's role.
-   *
-   * *   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](https://developer.github.com/v3/orgs/members/#get-organization-membership-for-a-user) will be `pending` until they accept the invitation.
-   *     
-   * *   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.
-   *
-   * **Rate limits**
-   *
-   * To prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.
+   * <p>
+   * Only authenticated organization owners can add a member to the organization
+   * or update the member's role.
+   * </p>
+   * <ul>
+   * <li>
+   * <p>
+   * If the authenticated user is <em>adding</em> a member to the organization,
+   * the invited user will receive an email inviting them to the organization. The
+   * user's <a href=
+   * "https://developer.github.com/v3/orgs/members/#get-organization-membership-for-a-user">membership
+   * status</a> will be <code>pending</code> until they accept the invitation.
+   * </p>
+   * </li>
+   * <li>
+   * <p>
+   * Authenticated users can <em>update</em> a user's membership by passing the
+   * <code>role</code> parameter. If the authenticated user changes a member's
+   * role to <code>admin</code>, the affected user will receive an email notifying
+   * them that they've been made an organization owner. If the authenticated user
+   * changes an owner's role to <code>member</code>, no email will be sent.
+   * </p>
+   * </li>
+   * </ul>
+   * <p>
+   * <strong>Rate limits</strong>
+   * </p>
+   * <p>
+   * To prevent abuse, the authenticated user is limited to 50 organization
+   * invitations per 24 hour period. If the organization is more than one month
+   * old or on a paid plan, the limit is 500 invitations per 24 hour period.
+   * </p>
+   * 
    */
   @Path("/{org}/memberships/{username}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response orgs_set_membership_for_user(@PathParam("org") String org,
-      @PathParam("username") String username, InputStream data);
+  Response orgs_set_membership_for_user(@PathParam("org") String org, @PathParam("username") String username,
+      InputStream data);
 
   /**
-   * In order to remove a user's membership with an organization, the authenticated user must be an organization owner.
-   *
-   * If the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.
+   * <p>
+   * In order to remove a user's membership with an organization, the
+   * authenticated user must be an organization owner.
+   * </p>
+   * <p>
+   * If the specified user is an active member of the organization, this will
+   * remove them from the organization. If the specified user has been invited to
+   * the organization, this will cancel their invitation. The specified user will
+   * receive an email notification in both cases.
+   * </p>
+   * 
    */
   @Path("/{org}/memberships/{username}")
   @DELETE
-  void orgs_remove_membership_for_user(@PathParam("org") String org,
-      @PathParam("username") String username);
+  void orgs_remove_membership_for_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/hooks/{hook_id}")
   @GET
@@ -325,26 +507,42 @@ public interface OrgsResource {
   Response orgs_get_webhook(@PathParam("org") String org, @PathParam("hook_id") Integer hookId);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/hooks/{hook_id}")
   @DELETE
   void orgs_delete_webhook(@PathParam("org") String org, @PathParam("hook_id") Integer hookId);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/hooks/{hook_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response orgs_update_webhook(@PathParam("org") String org, @PathParam("hook_id") Integer hookId,
-      InputStream data);
+  Response orgs_update_webhook(@PathParam("org") String org, @PathParam("hook_id") Integer hookId, InputStream data);
 
   /**
-   * To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
-   *
-   * GitHub Apps with the `Organization plan` permission can use this endpoint to retrieve information about an organization's GitHub plan. See "[Authenticating with GitHub Apps](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/)" for details. For an example response, see "[Response with GitHub plan information](https://developer.github.com/v3/orgs/#response-with-github-plan-information)."
+   * <p>
+   * To see many of the organization response values, you need to be an
+   * authenticated organization owner with the <code>admin:org</code> scope. When
+   * the value of <code>two_factor_requirement_enabled</code> is
+   * <code>true</code>, the organization requires all members, billing managers,
+   * and outside collaborators to enable <a href=
+   * "https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/">two-factor
+   * authentication</a>.
+   * </p>
+   * <p>
+   * GitHub Apps with the <code>Organization plan</code> permission can use this
+   * endpoint to retrieve information about an organization's GitHub plan. See
+   * &quot;<a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/">Authenticating
+   * with GitHub Apps</a>&quot; for details. For an example response, see
+   * &quot;<a href=
+   * "https://developer.github.com/v3/orgs/#response-with-github-plan-information">Response
+   * with GitHub plan information</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{org}")
   @GET
@@ -352,9 +550,23 @@ public interface OrgsResource {
   Response orgs_get(@PathParam("org") String org);
 
   /**
-   * **Parameter Deprecation Notice:** GitHub will replace and discontinue `members_allowed_repository_creation_type` in favor of more granular permissions. The new input parameters are `members_can_create_public_repositories`, `members_can_create_private_repositories` for all organizations and `members_can_create_internal_repositories` for organizations associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. For more information, see the [blog post](https://developer.github.com/changes/2019-12-03-internal-visibility-changes).
-   *
-   * Enables an authenticated organization owner with the `admin:org` scope to update the organization's profile and member privileges.
+   * <p>
+   * <strong>Parameter Deprecation Notice:</strong> GitHub will replace and
+   * discontinue <code>members_allowed_repository_creation_type</code> in favor of
+   * more granular permissions. The new input parameters are
+   * <code>members_can_create_public_repositories</code>,
+   * <code>members_can_create_private_repositories</code> for all organizations
+   * and <code>members_can_create_internal_repositories</code> for organizations
+   * associated with an enterprise account using GitHub Enterprise Cloud or GitHub
+   * Enterprise Server 2.20+. For more information, see the <a href=
+   * "https://developer.github.com/changes/2019-12-03-internal-visibility-changes">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * Enables an authenticated organization owner with the <code>admin:org</code>
+   * scope to update the organization's profile and member privileges.
+   * </p>
+   * 
    */
   @Path("/{org}")
   @PATCH
@@ -363,48 +575,71 @@ public interface OrgsResource {
   Response orgs_update(@PathParam("org") String org, InputStream data);
 
   /**
-   * This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.
+   * <p>
+   * This will trigger a
+   * <a href="https://developer.github.com/webhooks/#ping-event">ping event</a> to
+   * be sent to the hook.
+   * </p>
+   * 
    */
   @Path("/{org}/hooks/{hook_id}/pings")
   @POST
   void orgs_ping_webhook(@PathParam("org") String org, @PathParam("hook_id") Integer hookId);
 
   /**
+   * <p>
    * Check if a user is, publicly or privately, a member of the organization.
+   * </p>
+   * 
    */
   @Path("/{org}/members/{username}")
   @GET
-  void orgs_check_membership_for_user(@PathParam("org") String org,
-      @PathParam("username") String username);
+  void orgs_check_membership_for_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   * Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+   * <p>
+   * Removing a user from this list will remove them from all teams and they will
+   * no longer have any access to the organization's repositories.
+   * </p>
+   * 
    */
   @Path("/{org}/members/{username}")
   @DELETE
   void orgs_remove_member(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   * Lists all GitHub Apps in an organization. The installation count includes all GitHub Apps installed on repositories in the organization. You must be an organization owner with `admin:read` scope to use this endpoint.
+   * <p>
+   * Lists all GitHub Apps in an organization. The installation count includes all
+   * GitHub Apps installed on repositories in the organization. You must be an
+   * organization owner with <code>admin:read</code> scope to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/installations")
   @GET
   @Produces("application/json")
-  Response orgs_list_app_installations(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response orgs_list_app_installations(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/public_members/{username}")
   @GET
-  void orgs_check_public_membership_for_user(@PathParam("org") String org,
-      @PathParam("username") String username);
+  void orgs_check_public_membership_for_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   * The user can publicize their own membership. (A user cannot publicize the membership for another user.)
-   *
-   * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
+   * <p>
+   * The user can publicize their own membership. (A user cannot publicize the
+   * membership for another user.)
+   * </p>
+   * <p>
+   * Note that you'll need to set <code>Content-Length</code> to zero when calling
+   * out to this endpoint. For more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{org}/public_members/{username}")
   @PUT
@@ -412,7 +647,7 @@ public interface OrgsResource {
       @PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/public_members/{username}")
   @DELETE
@@ -420,28 +655,51 @@ public interface OrgsResource {
       @PathParam("username") String username);
 
   /**
+   * <p>
    * List all users who are outside collaborators of an organization.
+   * </p>
+   * 
    */
   @Path("/{org}/outside_collaborators")
   @GET
   @Produces("application/json")
-  Response orgs_list_outside_collaborators(@PathParam("org") String org,
-      @QueryParam("filter") String filter, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response orgs_list_outside_collaborators(@PathParam("org") String org, @QueryParam("filter") String filter,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.
+   * <p>
+   * The return hash contains a <code>role</code> field which refers to the
+   * Organization Invitation role and will be one of the following values:
+   * <code>direct_member</code>, <code>admin</code>, <code>billing_manager</code>,
+   * <code>hiring_manager</code>, or <code>reinstate</code>. If the invitee is not
+   * a GitHub member, the <code>login</code> field in the return hash will be
+   * <code>null</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/invitations")
   @GET
   @Produces("application/json")
-  Response orgs_list_pending_invitations(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response orgs_list_pending_invitations(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Invite people to an organization by using their GitHub user ID or their email address. In order to create invitations in an organization, the authenticated user must be an organization owner.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * Invite people to an organization by using their GitHub user ID or their email
+   * address. In order to create invitations in an organization, the authenticated
+   * user must be an organization owner.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{org}/invitations")
   @POST
@@ -450,7 +708,7 @@ public interface OrgsResource {
   Response orgs_create_invitation(@PathParam("org") String org, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/hooks")
   @GET
@@ -459,7 +717,10 @@ public interface OrgsResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Here's how you can create a hook that posts payloads in JSON format:
+   * </p>
+   * 
    */
   @Path("/{org}/hooks")
   @POST
@@ -468,7 +729,10 @@ public interface OrgsResource {
   Response orgs_create_webhook(@PathParam("org") String org, InputStream data);
 
   /**
+   * <p>
    * List the users blocked by an organization.
+   * </p>
+   * 
    */
   @Path("/{org}/blocks")
   @GET
@@ -476,41 +740,55 @@ public interface OrgsResource {
   Response orgs_list_blocked_users(@PathParam("org") String org);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/blocks/{username}")
   @GET
-  void orgs_check_blocked_user(@PathParam("org") String org,
-      @PathParam("username") String username);
+  void orgs_check_blocked_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/blocks/{username}")
   @PUT
   void orgs_block_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/{org}/blocks/{username}")
   @DELETE
   void orgs_unblock_user(@PathParam("org") String org, @PathParam("username") String username);
 
   /**
-   * List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
+   * <p>
+   * List all users who are members of an organization. If the authenticated user
+   * is also a member of this organization then both concealed and public members
+   * will be returned.
+   * </p>
+   * 
    */
   @Path("/{org}/members")
   @GET
   @Produces("application/json")
   Response orgs_list_members(@PathParam("org") String org, @QueryParam("filter") String filter,
-      @QueryParam("role") String role, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("role") String role, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Listing and deleting credential authorizations is available to organizations with GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products).
-   *
-   * An authenticated organization owner with the `admin:org` scope can remove a credential authorization for an organization that uses SAML SSO. Once you remove someone's credential authorization, they will need to create a new personal access token or SSH key and authorize it for the organization they want to access.
+   * <p>
+   * Listing and deleting credential authorizations is available to organizations
+   * with GitHub Enterprise Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a>.
+   * </p>
+   * <p>
+   * An authenticated organization owner with the <code>admin:org</code> scope can
+   * remove a credential authorization for an organization that uses SAML SSO.
+   * Once you remove someone's credential authorization, they will need to create
+   * a new personal access token or SSH key and authorize it for the organization
+   * they want to access.
+   * </p>
+   * 
    */
   @Path("/{org}/credential-authorizations/{credential_id}")
   @DELETE
@@ -518,18 +796,29 @@ public interface OrgsResource {
       @PathParam("credential_id") Integer credentialId);
 
   /**
-   * Members of an organization can choose to have their membership publicized or not.
+   * <p>
+   * Members of an organization can choose to have their membership publicized or
+   * not.
+   * </p>
+   * 
    */
   @Path("/{org}/public_members")
   @GET
   @Produces("application/json")
-  Response orgs_list_public_members(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response orgs_list_public_members(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Warning:** The self-hosted runners API for organizations is currently in public beta and subject to change.
-   *
-   * Gets a specific self-hosted runner for an organization. You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+   * <p>
+   * <strong>Warning:</strong> The self-hosted runners API for organizations is
+   * currently in public beta and subject to change.
+   * </p>
+   * <p>
+   * Gets a specific self-hosted runner for an organization. You must authenticate
+   * using an access token with the <code>admin:org</code> scope to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/runners/{runner_id}")
   @GET
@@ -538,9 +827,17 @@ public interface OrgsResource {
       @PathParam("runner_id") Integer runnerId);
 
   /**
-   * **Warning:** The self-hosted runners API for organizations is currently in public beta and subject to change.
-   *
-   * Forces the removal of a self-hosted runner from an organization. You can use this endpoint to completely remove the runner when the machine you were using no longer exists. You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+   * <p>
+   * <strong>Warning:</strong> The self-hosted runners API for organizations is
+   * currently in public beta and subject to change.
+   * </p>
+   * <p>
+   * Forces the removal of a self-hosted runner from an organization. You can use
+   * this endpoint to completely remove the runner when the machine you were using
+   * no longer exists. You must authenticate using an access token with the
+   * <code>admin:org</code> scope to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/runners/{runner_id}")
   @DELETE
@@ -548,9 +845,16 @@ public interface OrgsResource {
       @PathParam("runner_id") Integer runnerId);
 
   /**
-   * **Warning:** The self-hosted runners API for organizations is currently in public beta and subject to change.
-   *
-   * Lists all self-hosted runners for an organization. You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+   * <p>
+   * <strong>Warning:</strong> The self-hosted runners API for organizations is
+   * currently in public beta and subject to change.
+   * </p>
+   * <p>
+   * Lists all self-hosted runners for an organization. You must authenticate
+   * using an access token with the <code>admin:org</code> scope to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/runners")
   @GET
@@ -559,128 +863,168 @@ public interface OrgsResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Gets a single organization secret without revealing its encrypted value. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Gets a single organization secret without revealing its encrypted value. You
+   * must authenticate using an access token with the <code>admin:org</code> scope
+   * to use this endpoint. GitHub Apps must have the <code>secrets</code>
+   * organization permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}")
   @GET
   @Produces("application/json")
-  Response actions_get_org_secret(@PathParam("org") String org,
-      @PathParam("secret_name") String secretName);
+  Response actions_get_org_secret(@PathParam("org") String org, @PathParam("secret_name") String secretName);
 
   /**
-   * Creates or updates an organization secret with an encrypted value. Encrypt your secret using
-   * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
-   * token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to
-   * use this endpoint.
-   *
-   * #### Example encrypting a secret using Node.js
-   *
-   * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
-   *
-   * ```
-   * const sodium = require('tweetsodium');
-   *
-   * const key = "base64-encoded-public-key";
-   * const value = "plain-text-secret";
-   *
-   * // Convert the message and key to Uint8Array's (Buffer implements that interface)
-   * const messageBytes = Buffer.from(value);
-   * const keyBytes = Buffer.from(key, 'base64');
-   *
-   * // Encrypt using LibSodium.
-   * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
-   *
-   * // Base64 the encrypted secret
-   * const encrypted = Buffer.from(encryptedBytes).toString('base64');
-   *
-   * console.log(encrypted);
-   * ```
-   *
-   *
-   * #### Example encrypting a secret using Python
-   *
-   * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
-   *
-   * ```
-   * from base64 import b64encode
-   * from nacl import encoding, public
-   *
-   * def encrypt(public_key: str, secret_value: str) -> str:
-   *   """Encrypt a Unicode string using the public key."""
-   *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
-   *   sealed_box = public.SealedBox(public_key)
-   *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
-   *   return b64encode(encrypted).decode("utf-8")
-   * ```
-   *
-   * #### Example encrypting a secret using C#
-   *
-   * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
-   *
-   * ```
-   * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
-   * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
-   *
-   * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
-   *
-   * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
-   * ```
-   *
-   * #### Example encrypting a secret using Ruby
-   *
-   * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
-   *
-   * ```ruby
-   * require "rbnacl"
-   * require "base64"
-   *
-   * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
-   * public_key = RbNaCl::PublicKey.new(key)
-   *
-   * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
-   * encrypted_secret = box.encrypt("my_secret")
-   *
-   * # Print the base64 encoded secret
-   * puts Base64.strict_encode64(encrypted_secret)
-   * ```
+   * <p>
+   * Creates or updates an organization secret with an encrypted value. Encrypt
+   * your secret using <a href=
+   * "https://libsodium.gitbook.io/doc/bindings_for_other_languages">LibSodium</a>.
+   * You must authenticate using an access token with the <code>admin:org</code>
+   * scope to use this endpoint. GitHub Apps must have the <code>secrets</code>
+   * organization permission to use this endpoint.
+   * </p>
+   * <h4>Example encrypting a secret using Node.js</h4>
+   * <p>
+   * Encrypt your secret using the
+   * <a href="https://github.com/github/tweetsodium">tweetsodium</a> library.
+   * </p>
+   * 
+   * <pre>
+   * <code>const sodium = require('tweetsodium');
+  
+  const key = &quot;base64-encoded-public-key&quot;;
+  const value = &quot;plain-text-secret&quot;;
+  
+  // Convert the message and key to Uint8Array's (Buffer implements that interface)
+  const messageBytes = Buffer.from(value);
+  const keyBytes = Buffer.from(key, 'base64');
+  
+  // Encrypt using LibSodium.
+  const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+  
+  // Base64 the encrypted secret
+  const encrypted = Buffer.from(encryptedBytes).toString('base64');
+  
+  console.log(encrypted);
+  </code>
+   * </pre>
+   * 
+   * <h4>Example encrypting a secret using Python</h4>
+   * <p>
+   * Encrypt your secret using <a href=
+   * "https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox">pynacl</a>
+   * with Python 3.
+   * </p>
+   * 
+   * <pre>
+   * <code>from base64 import b64encode
+  from nacl import encoding, public
+  
+  def encrypt(public_key: str, secret_value: str) -&gt; str:
+    &quot;&quot;&quot;Encrypt a Unicode string using the public key.&quot;&quot;&quot;
+    public_key = public.PublicKey(public_key.encode(&quot;utf-8&quot;), encoding.Base64Encoder())
+    sealed_box = public.SealedBox(public_key)
+    encrypted = sealed_box.encrypt(secret_value.encode(&quot;utf-8&quot;))
+    return b64encode(encrypted).decode(&quot;utf-8&quot;)
+  </code>
+   * </pre>
+   * 
+   * <h4>Example encrypting a secret using C#</h4>
+   * <p>
+   * Encrypt your secret using the
+   * <a href="https://www.nuget.org/packages/Sodium.Core/">Sodium.Core</a>
+   * package.
+   * </p>
+   * 
+   * <pre>
+   * <code>var secretValue = System.Text.Encoding.UTF8.GetBytes(&quot;mySecret&quot;);
+  var publicKey = Convert.FromBase64String(&quot;2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=&quot;);
+  
+  var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+  
+  Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+  </code>
+   * </pre>
+   * 
+   * <h4>Example encrypting a secret using Ruby</h4>
+   * <p>
+   * Encrypt your secret using the
+   * <a href="https://github.com/RubyCrypto/rbnacl">rbnacl</a> gem.
+   * </p>
+   * 
+   * <pre>
+   * <code class="language-ruby">require &quot;rbnacl&quot;
+  require &quot;base64&quot;
+  
+  key = Base64.decode64(&quot;+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=&quot;)
+  public_key = RbNaCl::PublicKey.new(key)
+  
+  box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+  encrypted_secret = box.encrypt(&quot;my_secret&quot;)
+  
+  # Print the base64 encoded secret
+  puts Base64.strict_encode64(encrypted_secret)
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}")
   @PUT
   @Consumes("application/json")
-  void actions_create_or_update_org_secret(@PathParam("org") String org,
-      @PathParam("secret_name") String secretName, InputStream data);
+  void actions_create_or_update_org_secret(@PathParam("org") String org, @PathParam("secret_name") String secretName,
+      InputStream data);
 
   /**
-   * Deletes a secret in an organization using the secret name. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Deletes a secret in an organization using the secret name. You must
+   * authenticate using an access token with the <code>admin:org</code> scope to
+   * use this endpoint. GitHub Apps must have the <code>secrets</code>
+   * organization permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}")
   @DELETE
-  void actions_delete_org_secret(@PathParam("org") String org,
-      @PathParam("secret_name") String secretName);
+  void actions_delete_org_secret(@PathParam("org") String org, @PathParam("secret_name") String secretName);
 
   /**
-   * Lists all secrets available in an organization without revealing their encrypted values. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Lists all secrets available in an organization without revealing their
+   * encrypted values. You must authenticate using an access token with the
+   * <code>admin:org</code> scope to use this endpoint. GitHub Apps must have the
+   * <code>secrets</code> organization permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets")
   @GET
   @Produces("application/json")
-  Response actions_list_org_secrets(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response actions_list_org_secrets(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Warning:** The self-hosted runners API for organizations is currently in public beta and subject to change.
-   *
-   *
-   * Returns a token that you can pass to the `config` script. The token expires after one hour. You must authenticate
-   * using an access token with the `admin:org` scope to use this endpoint.
-   *
-   * #### Example using registration token
-   *
-   * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
-   *
-   * ```
-   * ./config.sh --url https://github.com/octo-org --token TOKEN
-   * ```
+   * <p>
+   * <strong>Warning:</strong> The self-hosted runners API for organizations is
+   * currently in public beta and subject to change.
+   * </p>
+   * <p>
+   * Returns a token that you can pass to the <code>config</code> script. The
+   * token expires after one hour. You must authenticate using an access token
+   * with the <code>admin:org</code> scope to use this endpoint.
+   * </p>
+   * <h4>Example using registration token</h4>
+   * <p>
+   * Configure your self-hosted runner, replacing <code>TOKEN</code> with the
+   * registration token provided by this endpoint.
+   * </p>
+   * 
+   * <pre>
+   * <code>./config.sh --url https://github.com/octo-org --token TOKEN
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{org}/actions/runners/registration-token")
   @POST
@@ -688,27 +1032,52 @@ public interface OrgsResource {
   Response actions_create_registration_token_for_org(@PathParam("org") String org);
 
   /**
-   * Adds a repository to an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Adds a repository to an organization secret when the <code>visibility</code>
+   * for repository access is set to <code>selected</code>. The visibility is set
+   * when you <a href=
+   * "https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret">Create
+   * or update an organization secret</a>. You must authenticate using an access
+   * token with the <code>admin:org</code> scope to use this endpoint. GitHub Apps
+   * must have the <code>secrets</code> organization permission to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}/repositories/{repository_id}")
   @PUT
   void actions_add_selected_repo_to_org_secret(@PathParam("org") String org,
-      @PathParam("secret_name") String secretName,
-      @PathParam("repository_id") Integer repositoryId);
+      @PathParam("secret_name") String secretName, @PathParam("repository_id") Integer repositoryId);
 
   /**
-   * Removes a repository from an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Removes a repository from an organization secret when the
+   * <code>visibility</code> for repository access is set to
+   * <code>selected</code>. The visibility is set when you <a href=
+   * "https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret">Create
+   * or update an organization secret</a>. You must authenticate using an access
+   * token with the <code>admin:org</code> scope to use this endpoint. GitHub Apps
+   * must have the <code>secrets</code> organization permission to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}/repositories/{repository_id}")
   @DELETE
   void actions_remove_selected_repo_from_org_secret(@PathParam("org") String org,
-      @PathParam("secret_name") String secretName,
-      @PathParam("repository_id") Integer repositoryId);
+      @PathParam("secret_name") String secretName, @PathParam("repository_id") Integer repositoryId);
 
   /**
-   * **Warning:** The self-hosted runners API for organizations is currently in public beta and subject to change.
-   *
-   * Lists binaries for the runner application that you can download and run. You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+   * <p>
+   * <strong>Warning:</strong> The self-hosted runners API for organizations is
+   * currently in public beta and subject to change.
+   * </p>
+   * <p>
+   * Lists binaries for the runner application that you can download and run. You
+   * must authenticate using an access token with the <code>admin:org</code> scope
+   * to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/runners/downloads")
   @GET
@@ -716,21 +1085,27 @@ public interface OrgsResource {
   Response actions_list_runner_applications_for_org(@PathParam("org") String org);
 
   /**
-   * **Warning:** The self-hosted runners API for organizations is currently in public beta and subject to change.
-   *
-   *
-   * Returns a token that you can pass to the `config` script to remove a self-hosted runner from an organization. The
-   * token expires after one hour. You must authenticate using an access token with the `admin:org` scope to use this
-   * endpoint.
-   *
-   * #### Example using remove token
-   *
-   * To remove your self-hosted runner from an organization, replace `TOKEN` with the remove token provided by this
-   * endpoint.
-   *
-   * ```
-   * ./config.sh remove --token TOKEN
-   * ```
+   * <p>
+   * <strong>Warning:</strong> The self-hosted runners API for organizations is
+   * currently in public beta and subject to change.
+   * </p>
+   * <p>
+   * Returns a token that you can pass to the <code>config</code> script to remove
+   * a self-hosted runner from an organization. The token expires after one hour.
+   * You must authenticate using an access token with the <code>admin:org</code>
+   * scope to use this endpoint.
+   * </p>
+   * <h4>Example using remove token</h4>
+   * <p>
+   * To remove your self-hosted runner from an organization, replace
+   * <code>TOKEN</code> with the remove token provided by this endpoint.
+   * </p>
+   * 
+   * <pre>
+   * <code>./config.sh remove --token TOKEN
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{org}/actions/runners/remove-token")
   @POST
@@ -738,7 +1113,14 @@ public interface OrgsResource {
   Response actions_create_remove_token_for_org(@PathParam("org") String org);
 
   /**
-   * Lists all repositories that have been selected when the `visibility` for repository access to a secret is set to `selected`. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Lists all repositories that have been selected when the
+   * <code>visibility</code> for repository access to a secret is set to
+   * <code>selected</code>. You must authenticate using an access token with the
+   * <code>admin:org</code> scope to use this endpoint. GitHub Apps must have the
+   * <code>secrets</code> organization permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}/repositories")
   @GET
@@ -747,7 +1129,17 @@ public interface OrgsResource {
       @PathParam("secret_name") String secretName);
 
   /**
-   * Replaces all repositories for an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Replaces all repositories for an organization secret when the
+   * <code>visibility</code> for repository access is set to
+   * <code>selected</code>. The visibility is set when you <a href=
+   * "https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret">Create
+   * or update an organization secret</a>. You must authenticate using an access
+   * token with the <code>admin:org</code> scope to use this endpoint. GitHub Apps
+   * must have the <code>secrets</code> organization permission to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/{secret_name}/repositories")
   @PUT
@@ -756,7 +1148,14 @@ public interface OrgsResource {
       @PathParam("secret_name") String secretName, InputStream data);
 
   /**
-   * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+   * <p>
+   * Gets your public key, which you need to encrypt secrets. You need to encrypt
+   * a secret before you can create or update secrets. You must authenticate using
+   * an access token with the <code>admin:org</code> scope to use this endpoint.
+   * GitHub Apps must have the <code>secrets</code> organization permission to use
+   * this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/actions/secrets/public-key")
   @GET
@@ -764,165 +1163,291 @@ public interface OrgsResource {
   Response actions_get_org_public_key(@PathParam("org") String org);
 
   /**
-   * Checks whether a team has `admin`, `push`, `maintain`, `triage`, or `pull` permission for a repository. Repositories inherited through a parent team will also be checked.
-   *
-   * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://developer.github.com/v3/media/) via the `application/vnd.github.v3.repository+json` accept header.
-   *
-   * If a team doesn't have permission for the repository, you will receive a `404 Not Found` response status.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+   * <p>
+   * Checks whether a team has <code>admin</code>, <code>push</code>,
+   * <code>maintain</code>, <code>triage</code>, or <code>pull</code> permission
+   * for a repository. Repositories inherited through a parent team will also be
+   * checked.
+   * </p>
+   * <p>
+   * You can also get information about the specified repository, including what
+   * permissions the team grants on it, by passing the following custom
+   * <a href="https://developer.github.com/v3/media/">media type</a> via the
+   * <code>application/vnd.github.v3.repository+json</code> accept header.
+   * </p>
+   * <p>
+   * If a team doesn't have permission for the repository, you will receive a
+   * <code>404 Not Found</code> response status.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/repos/{owner}/{repo}")
   @GET
   @Produces("application/vnd.github.v3.repository+json")
   Response teams_check_permissions_for_repo_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+      @PathParam("team_slug") String teamSlug, @PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
-   *
-   * For more information about the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+   * <p>
+   * To add a repository to a team or update the team's permission on a
+   * repository, the authenticated user must have admin access to the repository,
+   * and must be able to see the team. The repository must be owned by the
+   * organization, or a direct fork of a repository owned by the organization. You
+   * will get a <code>422 Unprocessable Entity</code> status if you attempt to add
+   * a repository to a team that is not owned by the organization. Note that, if
+   * you choose not to pass any parameters, you'll need to set
+   * <code>Content-Length</code> to zero when calling out to this endpoint. For
+   * more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PUT /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}</code>.
+   * </p>
+   * <p>
+   * For more information about the permission levels, see &quot;<a href=
+   * "https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization">Repository
+   * permission levels for an organization</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/repos/{owner}/{repo}")
   @PUT
   @Consumes("application/json")
   void teams_add_or_update_repo_permissions_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+      @PathParam("team_slug") String teamSlug, @PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
-   * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. This does not delete the repository, it just removes it from the team.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+   * <p>
+   * If the authenticated user is an organization owner or a team maintainer, they
+   * can remove any repositories from the team. To remove a repository from a team
+   * as an organization member, the authenticated user must have admin access to
+   * the repository and must be able to see the team. This does not delete the
+   * repository, it just removes it from the team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>DELETE /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/repos/{owner}/{repo}")
   @DELETE
-  void teams_remove_repo_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void teams_remove_repo_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * Team members will include the members of child teams.
-   *
-   * To list members in a team, the team must be visible to the authenticated user.
+   * </p>
+   * <p>
+   * To list members in a team, the team must be visible to the authenticated
+   * user.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/members")
   @GET
   @Produces("application/json")
-  Response teams_list_members_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @QueryParam("role") String role,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response teams_list_members_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @QueryParam("role") String role, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+   * <p>
+   * List all comments on a team discussion. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments")
   @GET
   @Produces("application/json")
-  Response teams_list_discussion_comments_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
+  Response teams_list_discussion_comments_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("discussion_number") Integer discussionNumber, @QueryParam("direction") String direction,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+
+  /**
+   * <p>
+   * Creates a new comment on a team discussion. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>POST /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments</code>.
+   * </p>
+   * 
+   */
+  @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments")
+  @POST
+  @Produces("application/json")
+  @Consumes("application/json")
+  Response teams_create_discussion_comment_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("discussion_number") Integer discussionNumber, InputStream data);
+
+  /**
+   * <p>
+   * List all discussions on a team's page. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/discussions</code>.
+   * </p>
+   * 
+   */
+  @Path("/{org}/teams/{team_slug}/discussions")
+  @GET
+  @Produces("application/json")
+  Response teams_list_discussions_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
       @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
       @QueryParam("page") Integer page);
 
   /**
-   * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
-   */
-  @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments")
-  @POST
-  @Produces("application/json")
-  @Consumes("application/json")
-  Response teams_create_discussion_comment_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber, InputStream data);
-
-  /**
-   * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions`.
-   */
-  @Path("/{org}/teams/{team_slug}/discussions")
-  @GET
-  @Produces("application/json")
-  Response teams_list_discussions_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @QueryParam("direction") String direction,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
-
-  /**
-   * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions`.
+   * <p>
+   * Creates a new discussion post on a team's page. OAuth access tokens require
+   * the <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>POST /organizations/{org_id}/team/{team_id}/discussions</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response teams_create_discussion_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, InputStream data);
+  Response teams_create_discussion_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      InputStream data);
 
   /**
-   * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+   * <p>
+   * Get a specific discussion on a team's page. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}")
   @GET
   @Produces("application/json")
-  Response teams_get_discussion_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
+  Response teams_get_discussion_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
       @PathParam("discussion_number") Integer discussionNumber);
 
   /**
-   * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+   * <p>
+   * Delete a discussion from a team's page. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}")
   @DELETE
-  void teams_delete_discussion_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
+  void teams_delete_discussion_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
       @PathParam("discussion_number") Integer discussionNumber);
 
   /**
-   * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+   * <p>
+   * Edits the title and body text of a discussion post. Only the parameters you
+   * provide are updated. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response teams_update_discussion_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
+  Response teams_update_discussion_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
       @PathParam("discussion_number") Integer discussionNumber, InputStream data);
 
   /**
+   * <p>
    * Lists the organization projects for a team.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects`.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/projects</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/projects")
   @GET
   @Produces("application/json")
-  Response teams_list_projects_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response teams_list_projects_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+   * <p>
+   * Checks whether a team has <code>read</code>, <code>write</code>, or
+   * <code>admin</code> permissions for an organization project. The response
+   * includes projects inherited from a parent team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/projects/{project_id}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/projects/{project_id}")
   @GET
@@ -931,157 +1456,297 @@ public interface OrgsResource {
       @PathParam("team_slug") String teamSlug, @PathParam("project_id") Integer projectId);
 
   /**
-   * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+   * <p>
+   * Adds an organization project to a team. To add a project to a team or update
+   * the team's permission on a project, the authenticated user must have
+   * <code>admin</code> permissions for the project. The project and team must be
+   * part of the same organization.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PUT /organizations/{org_id}/team/{team_id}/projects/{project_id}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/projects/{project_id}")
   @PUT
   @Consumes("application/json")
   void teams_add_or_update_project_permissions_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("project_id") Integer projectId,
-      InputStream data);
+      @PathParam("team_slug") String teamSlug, @PathParam("project_id") Integer projectId, InputStream data);
 
   /**
-   * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. This endpoint removes the project from the team, but does not delete the project.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+   * <p>
+   * Removes an organization project from a team. An organization owner or a team
+   * maintainer can remove any project from the team. To remove a project from a
+   * team as an organization member, the authenticated user must have
+   * <code>read</code> access to both the team and project, or <code>admin</code>
+   * access to the team or project. This endpoint removes the project from the
+   * team, but does not delete the project.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>DELETE /organizations/{org_id}/team/{team_id}/projects/{project_id}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/projects/{project_id}")
   @DELETE
-  void teams_remove_project_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("project_id") Integer projectId);
+  void teams_remove_project_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("project_id") Integer projectId);
 
   /**
-   * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+   * <p>
+   * Get a specific comment on a team discussion. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}")
   @GET
   @Produces("application/json")
-  Response teams_get_discussion_comment_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber);
+  Response teams_get_discussion_comment_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber);
 
   /**
-   * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+   * <p>
+   * Deletes a comment on a team discussion. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}")
   @DELETE
-  void teams_delete_discussion_comment_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber);
+  void teams_delete_discussion_comment_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber);
 
   /**
-   * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+   * <p>
+   * Edits the body text of a discussion comment. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response teams_update_discussion_comment_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber, InputStream data);
+  Response teams_update_discussion_comment_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber,
+      InputStream data);
 
   /**
+   * <p>
    * Lists a team's repositories visible to the authenticated user.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos`.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/repos</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/repos")
   @GET
   @Produces("application/json")
-  Response teams_list_repos_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response teams_list_repos_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * List IdP groups available in an organization. You can limit your page results using the `per_page` parameter. GitHub generates a url-encoded `page` token using a cursor value for where the next page begins. For more information on cursor pagination, see "[Offset and Cursor Pagination explained](https://dev.to/jackmarchant/offset-and-cursor-pagination-explained-b89)."
-   *
-   * The `per_page` parameter provides pagination for a list of IdP groups the authenticated user can access in an organization. For example, if the user `octocat` wants to see two groups per page in `octo-org` via cURL, it would look like this:
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * List IdP groups available in an organization. You can limit your page results
+   * using the <code>per_page</code> parameter. GitHub generates a url-encoded
+   * <code>page</code> token using a cursor value for where the next page begins.
+   * For more information on cursor pagination, see &quot;<a href=
+   * "https://dev.to/jackmarchant/offset-and-cursor-pagination-explained-b89">Offset
+   * and Cursor Pagination explained</a>.&quot;
+   * </p>
+   * <p>
+   * The <code>per_page</code> parameter provides pagination for a list of IdP
+   * groups the authenticated user can access in an organization. For example, if
+   * the user <code>octocat</code> wants to see two groups per page in
+   * <code>octo-org</code> via cURL, it would look like this:
+   * </p>
+   * 
    */
   @Path("/{org}/team-sync/groups")
   @GET
   @Produces("application/json")
-  Response teams_list_idp_groups_for_org(@PathParam("org") String org,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response teams_list_idp_groups_for_org(@PathParam("org") String org, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Team members will include the members of child teams.
-   *
-   * To get a user's membership with a team, the team must be visible to the authenticated user.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/memberships/{username}`.
-   *
-   * **Note:** The `role` for organization owners returns as `maintainer`. For more information about `maintainer` roles, see [Create a team](https://developer.github.com/v3/teams/#create-a-team).
+   * </p>
+   * <p>
+   * To get a user's membership with a team, the team must be visible to the
+   * authenticated user.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/memberships/{username}</code>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> The <code>role</code> for organization owners returns
+   * as <code>maintainer</code>. For more information about
+   * <code>maintainer</code> roles, see
+   * <a href="https://developer.github.com/v3/teams/#create-a-team">Create a
+   * team</a>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/memberships/{username}")
   @GET
   @Produces("application/json")
-  Response teams_get_membership_for_user_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("username") String username);
+  Response teams_get_membership_for_user_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("username") String username);
 
   /**
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Adds an organization member to a team. An authenticated organization owner or team maintainer can add organization members to a team.
-   *
-   * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
-   *
-   * An organization owner can add someone who is not part of the team's organization to a team. When an organization owner adds someone to a team who is not an organization member, this endpoint will send an invitation to the person via email. This newly-created membership will be in the "pending" state until the person accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team.
-   *
-   * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Adds an organization member to a team. An authenticated organization owner or
+   * team maintainer can add organization members to a team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> When you have team synchronization set up for a team
+   * with your organization's identity provider (IdP), you will see an error if
+   * you attempt to use the API for making changes to the team's membership. If
+   * you have access to manage group membership in your IdP, you can manage GitHub
+   * team membership through your identity provider, which automatically adds and
+   * removes team members in an organization. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/">Synchronizing
+   * teams between your identity provider and GitHub</a>.&quot;
+   * </p>
+   * <p>
+   * An organization owner can add someone who is not part of the team's
+   * organization to a team. When an organization owner adds someone to a team who
+   * is not an organization member, this endpoint will send an invitation to the
+   * person via email. This newly-created membership will be in the
+   * &quot;pending&quot; state until the person accepts the invitation, at which
+   * point the membership will transition to the &quot;active&quot; state and the
+   * user will be added as a member of the team.
+   * </p>
+   * <p>
+   * If the user is already a member of the team, this endpoint will update the
+   * role of the team member's role. To update the membership of a team member,
+   * the authenticated user must be an organization owner or a team maintainer.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PUT /organizations/{org_id}/team/{team_id}/memberships/{username}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/memberships/{username}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
   Response teams_add_or_update_membership_for_user_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("username") String username,
-      InputStream data);
+      @PathParam("team_slug") String teamSlug, @PathParam("username") String username, InputStream data);
 
   /**
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
-   *
-   * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * To remove a membership between a user and a team, the authenticated user must
+   * have 'admin' permissions to the team or be an owner of the organization that
+   * the team is associated with. Removing team membership does not delete the
+   * user, it just removes their membership from the team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> When you have team synchronization set up for a team
+   * with your organization's identity provider (IdP), you will see an error if
+   * you attempt to use the API for making changes to the team's membership. If
+   * you have access to manage group membership in your IdP, you can manage GitHub
+   * team membership through your identity provider, which automatically adds and
+   * removes team members in an organization. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/">Synchronizing
+   * teams between your identity provider and GitHub</a>.&quot;
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>DELETE /organizations/{org_id}/team/{team_id}/memberships/{username}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/memberships/{username}")
   @DELETE
-  void teams_remove_membership_for_user_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @PathParam("username") String username);
+  void teams_remove_membership_for_user_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @PathParam("username") String username);
 
   /**
-   * The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/invitations`.
+   * <p>
+   * The return hash contains a <code>role</code> field which refers to the
+   * Organization Invitation role and will be one of the following values:
+   * <code>direct_member</code>, <code>admin</code>, <code>billing_manager</code>,
+   * <code>hiring_manager</code>, or <code>reinstate</code>. If the invitee is not
+   * a GitHub member, the <code>login</code> field in the return hash will be
+   * <code>null</code>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/invitations</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/invitations")
   @GET
   @Produces("application/json")
-  Response teams_list_pending_invitations_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response teams_list_pending_invitations_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Gets a team using the team's `slug`. GitHub generates the `slug` from the team `name`.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}`.
+   * <p>
+   * Gets a team using the team's <code>slug</code>. GitHub generates the
+   * <code>slug</code> from the team <code>name</code>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}")
   @GET
@@ -1089,30 +1754,49 @@ public interface OrgsResource {
   Response teams_get_by_name(@PathParam("org") String org, @PathParam("team_slug") String teamSlug);
 
   /**
-   * To delete a team, the authenticated user must be an organization owner or team maintainer.
-   *
-   * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}`.
+   * <p>
+   * To delete a team, the authenticated user must be an organization owner or
+   * team maintainer.
+   * </p>
+   * <p>
+   * If you are an organization owner, deleting a parent team will delete all of
+   * its child teams as well.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>DELETE /organizations/{org_id}/team/{team_id}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}")
   @DELETE
   void teams_delete_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug);
 
   /**
-   * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}`.
+   * <p>
+   * To edit a team, the authenticated user must either be an organization owner
+   * or a team maintainer.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PATCH /organizations/{org_id}/team/{team_id}</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response teams_update_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, InputStream data);
+  Response teams_update_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug, InputStream data);
 
   /**
-   * Lists all teams in an organization that are visible to the authenticated user.
+   * <p>
+   * Lists all teams in an organization that are visible to the authenticated
+   * user.
+   * </p>
+   * 
    */
   @Path("/{org}/teams")
   @GET
@@ -1121,9 +1805,22 @@ public interface OrgsResource {
       @QueryParam("page") Integer page);
 
   /**
-   * To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams. Organization owners can limit team creation to organization owners. For more information, see "[Setting team creation permissions](https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization)."
-   *
-   * When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of `maintainers`. For more information, see "[About teams](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+   * <p>
+   * To create a team, the authenticated user must be a member or owner of
+   * <code>{org}</code>. By default, organization members can create teams.
+   * Organization owners can limit team creation to organization owners. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization">Setting
+   * team creation permissions</a>.&quot;
+   * </p>
+   * <p>
+   * When you create a new team, you automatically become a team maintainer
+   * without explicitly adding yourself to the optional array of
+   * <code>maintainers</code>. For more information, see &quot;<a href=
+   * "https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams">About
+   * teams</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{org}/teams")
   @POST
@@ -1132,36 +1829,63 @@ public interface OrgsResource {
   Response teams_create(@PathParam("org") String org, InputStream data);
 
   /**
-   * Lists the child teams of the team specified by `{team_slug}`.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/teams`.
+   * <p>
+   * Lists the child teams of the team specified by <code>{team_slug}</code>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/teams</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/teams")
   @GET
   @Produces("application/json")
-  Response teams_list_child_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response teams_list_child_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * List IdP groups connected to a team on GitHub.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/team-sync/group-mappings`.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>GET /organizations/{org_id}/team/{team_id}/team-sync/group-mappings</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/team-sync/group-mappings")
   @GET
   @Produces("application/json")
-  Response teams_list_idp_groups_in_org(@PathParam("org") String org,
-      @PathParam("team_slug") String teamSlug);
+  Response teams_list_idp_groups_in_org(@PathParam("org") String org, @PathParam("team_slug") String teamSlug);
 
   /**
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Creates, updates, or removes a connection between a team and an IdP group. When adding groups to a team, you must include all new and existing groups to avoid replacing existing groups with the new ones. Specifying an empty `groups` array will remove all connections for a team.
-   *
-   * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/team-sync/group-mappings`.
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Creates, updates, or removes a connection between a team and an IdP group.
+   * When adding groups to a team, you must include all new and existing groups to
+   * avoid replacing existing groups with the new ones. Specifying an empty
+   * <code>groups</code> array will remove all connections for a team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You can also specify a team by <code>org_id</code> and
+   * <code>team_id</code> using the route
+   * <code>PATCH /organizations/{org_id}/team/{team_id}/team-sync/group-mappings</code>.
+   * </p>
+   * 
    */
   @Path("/{org}/teams/{team_slug}/team-sync/group-mappings")
   @PATCH
@@ -1171,26 +1895,41 @@ public interface OrgsResource {
       @PathParam("team_slug") String teamSlug, InputStream data);
 
   /**
+   * <p>
    * List issues in an organization assigned to the authenticated user.
-   *
-   * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
-   * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
-   * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
-   * request id, use the "[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)" endpoint.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: GitHub's REST API v3 considers every pull request an
+   * issue, but not every issue is a pull request. For this reason,
+   * &quot;Issues&quot; endpoints may return both issues and pull requests in the
+   * response. You can identify pull requests by the <code>pull_request</code>
+   * key. Be aware that the <code>id</code> of a pull request returned from
+   * &quot;Issues&quot; endpoints will be an <em>issue id</em>. To find out the
+   * pull request id, use the &quot;<a href=
+   * "https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a>&quot; endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/issues")
   @GET
   @Produces("application/json")
   Response issues_list_for_org(@PathParam("org") String org, @QueryParam("filter") String filter,
-      @QueryParam("state") String state, @QueryParam("labels") String labels,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("state") String state, @QueryParam("labels") String labels, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("since") String since,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Enables an authenticated GitHub App to find the organization's installation information.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Enables an authenticated GitHub App to find the organization's installation
+   * information.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/{org}/installation")
   @GET
@@ -1198,13 +1937,23 @@ public interface OrgsResource {
   Response apps_get_org_installation(@PathParam("org") String org);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
    * Gets the free and paid storage usued for GitHub Packages in gigabytes.
-   *
-   * Paid minutes only apply to packages stored for private repositories. For more information, see "[Managing billing for GitHub Packages](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages)."
-   *
-   * Access tokens must have the `read:org` scope.
+   * </p>
+   * <p>
+   * Paid minutes only apply to packages stored for private repositories. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages">Managing
+   * billing for GitHub Packages</a>.&quot;
+   * </p>
+   * <p>
+   * Access tokens must have the <code>read:org</code> scope.
+   * </p>
+   * 
    */
   @Path("/{org}/settings/billing/packages")
   @GET
@@ -1212,13 +1961,24 @@ public interface OrgsResource {
   Response billing_get_github_packages_billing_org(@PathParam("org") String org);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
-   * Gets the estimated paid and estimated total storage used for GitHub Actions and Github Packages.
-   *
-   * Paid minutes only apply to packages stored for private repositories. For more information, see "[Managing billing for GitHub Packages](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages)."
-   *
-   * Access tokens must have the `read:org` scope.
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
+   * Gets the estimated paid and estimated total storage used for GitHub Actions
+   * and Github Packages.
+   * </p>
+   * <p>
+   * Paid minutes only apply to packages stored for private repositories. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages">Managing
+   * billing for GitHub Packages</a>.&quot;
+   * </p>
+   * <p>
+   * Access tokens must have the <code>read:org</code> scope.
+   * </p>
+   * 
    */
   @Path("/{org}/settings/billing/shared-storage")
   @GET
@@ -1226,13 +1986,27 @@ public interface OrgsResource {
   Response billing_get_shared_storage_billing_org(@PathParam("org") String org);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
    * Gets the summary of the free and paid GitHub Actions minutes used.
-   *
-   * Paid minutes only apply to workflows in private repositories that use GitHub-hosted runners. Minutes used is listed for each GitHub-hosted runner operating system. Any job re-runs are also included in the usage. The usage does not include the multiplier for macOS and Windows runners and is not rounded up to the nearest whole minute. For more information, see "[Managing billing for GitHub Actions](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions)".
-   *
-   * Access tokens must have the `read:org` scope.
+   * </p>
+   * <p>
+   * Paid minutes only apply to workflows in private repositories that use
+   * GitHub-hosted runners. Minutes used is listed for each GitHub-hosted runner
+   * operating system. Any job re-runs are also included in the usage. The usage
+   * does not include the multiplier for macOS and Windows runners and is not
+   * rounded up to the nearest whole minute. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions">Managing
+   * billing for GitHub Actions</a>&quot;.
+   * </p>
+   * <p>
+   * Access tokens must have the <code>read:org</code> scope.
+   * </p>
+   * 
    */
   @Path("/{org}/settings/billing/actions")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ProjectsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ProjectsResource.java
@@ -14,12 +14,12 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/projects")
 public interface ProjectsResource {
   /**
-   *
+   * 
    */
   @Path("/columns/{column_id}/moves")
   @POST
@@ -28,7 +28,7 @@ public interface ProjectsResource {
   Response projects_move_column(@PathParam("column_id") Integer columnId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/columns/cards/{card_id}")
   @GET
@@ -36,14 +36,14 @@ public interface ProjectsResource {
   Response projects_get_card(@PathParam("card_id") Integer cardId);
 
   /**
-   *
+   * 
    */
   @Path("/columns/cards/{card_id}")
   @DELETE
   void projects_delete_card(@PathParam("card_id") Integer cardId);
 
   /**
-   *
+   * 
    */
   @Path("/columns/cards/{card_id}")
   @PATCH
@@ -52,7 +52,7 @@ public interface ProjectsResource {
   Response projects_update_card(@PathParam("card_id") Integer cardId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/columns/{column_id}")
   @GET
@@ -60,14 +60,14 @@ public interface ProjectsResource {
   Response projects_get_column(@PathParam("column_id") Integer columnId);
 
   /**
-   *
+   * 
    */
   @Path("/columns/{column_id}")
   @DELETE
   void projects_delete_column(@PathParam("column_id") Integer columnId);
 
   /**
-   *
+   * 
    */
   @Path("/columns/{column_id}")
   @PATCH
@@ -76,7 +76,13 @@ public interface ProjectsResource {
   Response projects_update_column(@PathParam("column_id") Integer columnId, InputStream data);
 
   /**
-   * Gets a project by its `id`. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+   * <p>
+   * Gets a project by its <code>id</code>. Returns a <code>404 Not Found</code>
+   * status if projects are disabled. If you do not have sufficient privileges to
+   * perform this action, a <code>401 Unauthorized</code> or <code>410 Gone</code>
+   * status is returned.
+   * </p>
+   * 
    */
   @Path("/{project_id}")
   @GET
@@ -84,14 +90,24 @@ public interface ProjectsResource {
   Response projects_get(@PathParam("project_id") Integer projectId);
 
   /**
-   * Deletes a project board. Returns a `404 Not Found` status if projects are disabled.
+   * <p>
+   * Deletes a project board. Returns a <code>404 Not Found</code> status if
+   * projects are disabled.
+   * </p>
+   * 
    */
   @Path("/{project_id}")
   @DELETE
   void projects_delete(@PathParam("project_id") Integer projectId);
 
   /**
-   * Updates a project board's information. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+   * <p>
+   * Updates a project board's information. Returns a <code>404 Not Found</code>
+   * status if projects are disabled. If you do not have sufficient privileges to
+   * perform this action, a <code>401 Unauthorized</code> or <code>410 Gone</code>
+   * status is returned.
+   * </p>
+   * 
    */
   @Path("/{project_id}")
   @PATCH
@@ -100,16 +116,16 @@ public interface ProjectsResource {
   Response projects_update(@PathParam("project_id") Integer projectId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{project_id}/columns")
   @GET
   @Produces("application/json")
-  Response projects_list_columns(@PathParam("project_id") Integer projectId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response projects_list_columns(@PathParam("project_id") Integer projectId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{project_id}/columns")
   @POST
@@ -118,7 +134,7 @@ public interface ProjectsResource {
   Response projects_create_column(@PathParam("project_id") Integer projectId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/columns/{column_id}/cards")
   @GET
@@ -128,9 +144,21 @@ public interface ProjectsResource {
       @QueryParam("page") Integer page);
 
   /**
-   * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.
-   *
-   * Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull request id, use the "[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)" endpoint.
+   * <p>
+   * <strong>Note</strong>: GitHub's REST API v3 considers every pull request an
+   * issue, but not every issue is a pull request. For this reason,
+   * &quot;Issues&quot; endpoints may return both issues and pull requests in the
+   * response. You can identify pull requests by the <code>pull_request</code>
+   * key.
+   * </p>
+   * <p>
+   * Be aware that the <code>id</code> of a pull request returned from
+   * &quot;Issues&quot; endpoints will be an <em>issue id</em>. To find out the
+   * pull request id, use the &quot;<a href=
+   * "https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a>&quot; endpoint.
+   * </p>
+   * 
    */
   @Path("/columns/{column_id}/cards")
   @POST
@@ -139,24 +167,39 @@ public interface ProjectsResource {
   Response projects_create_card(@PathParam("column_id") Integer columnId, InputStream data);
 
   /**
-   * Adds a collaborator to an organization project and sets their permission level. You must be an organization owner or a project `admin` to add a collaborator.
+   * <p>
+   * Adds a collaborator to an organization project and sets their permission
+   * level. You must be an organization owner or a project <code>admin</code> to
+   * add a collaborator.
+   * </p>
+   * 
    */
   @Path("/{project_id}/collaborators/{username}")
   @PUT
   @Consumes("application/json")
-  void projects_add_collaborator(@PathParam("project_id") Integer projectId,
-      @PathParam("username") String username, InputStream data);
+  void projects_add_collaborator(@PathParam("project_id") Integer projectId, @PathParam("username") String username,
+      InputStream data);
 
   /**
-   * Removes a collaborator from an organization project. You must be an organization owner or a project `admin` to remove a collaborator.
+   * <p>
+   * Removes a collaborator from an organization project. You must be an
+   * organization owner or a project <code>admin</code> to remove a collaborator.
+   * </p>
+   * 
    */
   @Path("/{project_id}/collaborators/{username}")
   @DELETE
-  void projects_remove_collaborator(@PathParam("project_id") Integer projectId,
-      @PathParam("username") String username);
+  void projects_remove_collaborator(@PathParam("project_id") Integer projectId, @PathParam("username") String username);
 
   /**
-   * Returns the collaborator's permission level for an organization project. Possible values for the `permission` key: `admin`, `write`, `read`, `none`. You must be an organization owner or a project `admin` to review a user's permission level.
+   * <p>
+   * Returns the collaborator's permission level for an organization project.
+   * Possible values for the <code>permission</code> key: <code>admin</code>,
+   * <code>write</code>, <code>read</code>, <code>none</code>. You must be an
+   * organization owner or a project <code>admin</code> to review a user's
+   * permission level.
+   * </p>
+   * 
    */
   @Path("/{project_id}/collaborators/{username}/permission")
   @GET
@@ -165,7 +208,7 @@ public interface ProjectsResource {
       @PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/columns/cards/{card_id}/moves")
   @POST
@@ -174,7 +217,15 @@ public interface ProjectsResource {
   Response projects_move_card(@PathParam("card_id") Integer cardId, InputStream data);
 
   /**
-   * Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
+   * <p>
+   * Lists the collaborators for an organization project. For a project, the list
+   * of collaborators includes outside collaborators, organization members that
+   * are direct collaborators, organization members with access through team
+   * memberships, organization members with access through default organization
+   * permissions, and organization owners. You must be an organization owner or a
+   * project <code>admin</code> to list collaborators.
+   * </p>
+   * 
    */
   @Path("/{project_id}/collaborators")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/RateResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/RateResource.java
@@ -6,14 +6,23 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/rate_limit")
 public interface RateResource {
   /**
-   * **Note:** Accessing this endpoint does not count against your REST API rate limit.
-   *
-   * **Note:** The `rate` object is deprecated. If you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.
+   * <p>
+   * <strong>Note:</strong> Accessing this endpoint does not count against your
+   * REST API rate limit.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> The <code>rate</code> object is deprecated. If you're
+   * writing new API client code or updating existing code, you should use the
+   * <code>core</code> object instead of the <code>rate</code> object. The
+   * <code>core</code> object contains the same information that is present in the
+   * <code>rate</code> object.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ReactionsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ReactionsResource.java
@@ -5,14 +5,29 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/reactions")
 public interface ReactionsResource {
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Reactions API. We recommend migrating your existing code to use the new delete reactions endpoints. For more information, see this [blog post](https://developer.github.com/changes/2020-02-26-new-delete-reactions-endpoints/).
-   *
-   * OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), when deleting a [team discussion](https://developer.github.com/v3/teams/discussions/) or [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Reactions API. We recommend migrating your existing
+   * code to use the new delete reactions endpoints. For more information, see
+   * this <a href=
+   * "https://developer.github.com/changes/2020-02-26-new-delete-reactions-endpoints/">blog
+   * post</a>.
+   * </p>
+   * <p>
+   * OAuth access tokens require the <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>,
+   * when deleting a
+   * <a href="https://developer.github.com/v3/teams/discussions/">team
+   * discussion</a> or
+   * <a href="https://developer.github.com/v3/teams/discussion_comments/">team
+   * discussion comment</a>.
+   * </p>
+   * 
    */
   @Path("/{reaction_id}")
   @DELETE

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ReposResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ReposResource.java
@@ -15,14 +15,24 @@ import java.io.InputStream;
 import java.util.List;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/repos")
 public interface ReposResource {
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Lists the teams who have push access to this branch. The list includes child teams.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Lists the teams who have push access to this branch. The list includes child
+   * teams.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")
   @GET
@@ -31,66 +41,119 @@ public interface ReposResource {
       @PathParam("repo") String repo, @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. Team restrictions include child teams.
-   *
-   * | Type    | Description                                                                                                                                |
-   * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-   * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Replaces the list of teams that have push access to this branch. This removes
+   * all teams that previously had push access and grants push access to the new
+   * list of teams. Team restrictions include child teams.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | The teams that can have push access. Use the team's
+   * <code>slug</code>. <strong>Note</strong>: The list of users, apps, and teams
+   * in total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_set_team_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_set_team_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Grants the specified teams push access for this branch. You can also give push access to child teams.
-   *
-   * | Type    | Description                                                                                                                                |
-   * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-   * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Grants the specified teams push access for this branch. You can also give
+   * push access to child teams.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | The teams that can have push access. Use the team's
+   * <code>slug</code>. <strong>Note</strong>: The list of users, apps, and teams
+   * in total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_add_team_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_add_team_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Removes the ability of a team to push to this branch. You can also remove push access for child teams.
-   *
-   * | Type    | Description                                                                                                                                         |
-   * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Removes the ability of a team to push to this branch. You can also remove
+   * push access for child teams.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ---------------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | Teams that should no longer have push access. Use
+   * the team's <code>slug</code>. <strong>Note</strong>: The list of users, apps,
+   * and teams in total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")
   @DELETE
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_remove_team_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_remove_team_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Returns all branches where the given commit SHA is the HEAD, or latest commit for the branch.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Returns all branches where the given commit SHA is the HEAD, or latest commit
+   * for the branch.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{commit_sha}/branches-where-head")
   @GET
   @Produces("application/json")
-  Response repos_list_branches_for_head_commit(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("commit_sha") String commitSha);
+  Response repos_list_branches_for_head_commit(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("commit_sha") String commitSha);
 
   /**
+   * <p>
    * Get the top 10 popular contents over the last 14 days.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/traffic/popular/paths")
   @GET
@@ -98,7 +161,7 @@ public interface ReposResource {
   Response repos_get_top_paths(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/deployments/{deployment_id}")
   @GET
@@ -107,14 +170,28 @@ public interface ReposResource {
       @PathParam("deployment_id") Integer deploymentId);
 
   /**
-   * To ensure there can always be an active deployment, you can only delete an _inactive_ deployment. Anyone with `repo` or `repo_deployment` scopes can delete an inactive deployment.
-   *
+   * <p>
+   * To ensure there can always be an active deployment, you can only delete an
+   * <em>inactive</em> deployment. Anyone with <code>repo</code> or
+   * <code>repo_deployment</code> scopes can delete an inactive deployment.
+   * </p>
+   * <p>
    * To set a deployment as inactive, you must:
-   *
-   * *   Create a new deployment that is active so that the system has a record of the current state, then delete the previously active deployment.
-   * *   Mark the active deployment as inactive by adding any non-successful deployment status.
-   *
-   * For more information, see "[Create a deployment](https://developer.github.com/v3/repos/deployments/#create-a-deployment)" and "[Create a deployment status](https://developer.github.com/v3/repos/deployments/#create-a-deployment-status)."
+   * </p>
+   * <ul>
+   * <li>Create a new deployment that is active so that the system has a record of
+   * the current state, then delete the previously active deployment.</li>
+   * <li>Mark the active deployment as inactive by adding any non-successful
+   * deployment status.</li>
+   * </ul>
+   * <p>
+   * For more information, see &quot;<a href=
+   * "https://developer.github.com/v3/repos/deployments/#create-a-deployment">Create
+   * a deployment</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/repos/deployments/#create-a-deployment-status">Create
+   * a deployment status</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/deployments/{deployment_id}")
   @DELETE
@@ -122,7 +199,15 @@ public interface ReposResource {
       @PathParam("deployment_id") Integer deploymentId);
 
   /**
-   * To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://developer.github.com/v3/media/#media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.
+   * <p>
+   * To download the asset's binary content, set the <code>Accept</code> header of
+   * the request to <a href=
+   * "https://developer.github.com/v3/media/#media-types"><code>application/octet-stream</code></a>.
+   * The API will either redirect the client to the location, or stream it
+   * directly if possible. API clients should handle both a <code>200</code> or
+   * <code>302</code> response.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/assets/{asset_id}")
   @GET
@@ -131,7 +216,7 @@ public interface ReposResource {
       @PathParam("asset_id") Integer assetId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/releases/assets/{asset_id}")
   @DELETE
@@ -139,87 +224,148 @@ public interface ReposResource {
       @PathParam("asset_id") Integer assetId);
 
   /**
+   * <p>
    * Users with push access to the repository can edit a release asset.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/assets/{asset_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_update_release_asset(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("asset_id") Integer assetId, InputStream data);
+  Response repos_update_release_asset(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("asset_id") Integer assetId, InputStream data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")
   @GET
   @Produces("application/json")
-  List<String> repos_get_all_status_check_contexts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  List<String> repos_get_all_status_check_contexts(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  List<String> repos_set_status_check_contexts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  List<String> repos_set_status_check_contexts(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  List<String> repos_add_status_check_contexts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  List<String> repos_add_status_check_contexts(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")
   @DELETE
   @Produces("application/json")
   @Consumes("application/json")
-  List<String> repos_remove_status_check_contexts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  List<String> repos_remove_status_check_contexts(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Gets the contents of a file or directory in a repository. Specify the file path or directory in `:path`. If you omit
-   * `:path`, you will receive the contents of all files in the repository.
-   *
-   * Files and symlinks support [a custom media type](https://developer.github.com/v3/repos/contents/#custom-media-types) for
-   * retrieving the raw content or rendered HTML (when supported). All content types support [a custom media
-   * type](https://developer.github.com/v3/repos/contents/#custom-media-types) to ensure the content is returned in a consistent
-   * object format.
-   *
-   * **Note**:
-   * *   To get a repository's contents recursively, you can [recursively get the tree](https://developer.github.com/v3/git/trees/).
-   * *   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees
-   * API](https://developer.github.com/v3/git/trees/#get-a-tree).
-   * *   This API supports files up to 1 megabyte in size.
-   *
-   * #### If the content is a directory
-   * The response will be an array of objects, one object for each item in the directory.
-   * When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value
-   * _should_ be "submodule". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW).
-   * In the next major version of the API, the type will be returned as "submodule".
-   *
-   * #### If the content is a symlink 
-   * If the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the
-   * API responds with the content of the file (in the format shown in the example. Otherwise, the API responds with an object 
-   * describing the symlink itself.
-   *
-   * #### If the content is a submodule
-   * The `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific
-   * commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out
-   * the submodule at that specific commit.
-   *
-   * If the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links["git"]`) and the
-   * github.com URLs (`html_url` and `_links["html"]`) will have null values.
+   * <p>
+   * Gets the contents of a file or directory in a repository. Specify the file
+   * path or directory in <code>:path</code>. If you omit <code>:path</code>, you
+   * will receive the contents of all files in the repository.
+   * </p>
+   * <p>
+   * Files and symlinks support <a href=
+   * "https://developer.github.com/v3/repos/contents/#custom-media-types">a custom
+   * media type</a> for retrieving the raw content or rendered HTML (when
+   * supported). All content types support <a href=
+   * "https://developer.github.com/v3/repos/contents/#custom-media-types">a custom
+   * media type</a> to ensure the content is returned in a consistent object
+   * format.
+   * </p>
+   * <p>
+   * <strong>Note</strong>:
+   * </p>
+   * <ul>
+   * <li>To get a repository's contents recursively, you can
+   * <a href="https://developer.github.com/v3/git/trees/">recursively get the
+   * tree</a>.</li>
+   * <li>This API has an upper limit of 1,000 files for a directory. If you need
+   * to retrieve more files, use the
+   * <a href="https://developer.github.com/v3/git/trees/#get-a-tree">Git Trees
+   * API</a>.</li>
+   * <li>This API supports files up to 1 megabyte in size.</li>
+   * </ul>
+   * <h4>If the content is a directory</h4>
+   * <p>
+   * The response will be an array of objects, one object for each item in the
+   * directory. When listing the contents of a directory, submodules have their
+   * &quot;type&quot; specified as &quot;file&quot;. Logically, the value
+   * <em>should</em> be &quot;submodule&quot;. This behavior exists in API v3
+   * <a href="https://git.io/v1YCW">for backwards compatibility purposes</a>. In
+   * the next major version of the API, the type will be returned as
+   * &quot;submodule&quot;.
+   * </p>
+   * <h4>If the content is a symlink</h4>
+   * <p>
+   * If the requested <code>:path</code> points to a symlink, and the symlink's
+   * target is a normal file in the repository, then the API responds with the
+   * content of the file (in the format shown in the example. Otherwise, the API
+   * responds with an object describing the symlink itself.
+   * </p>
+   * <h4>If the content is a submodule</h4>
+   * <p>
+   * The <code>submodule_git_url</code> identifies the location of the submodule
+   * repository, and the <code>sha</code> identifies a specific commit within the
+   * submodule repository. Git uses the given URL when cloning the submodule
+   * repository, and checks out the submodule at that specific commit.
+   * </p>
+   * <p>
+   * If the submodule repository is not hosted on github.com, the Git URLs
+   * (<code>git_url</code> and <code>_links[&quot;git&quot;]</code>) and the
+   * github.com URLs (<code>html_url</code> and
+   * <code>_links[&quot;html&quot;]</code>) will have null values.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/contents/{path}")
   @GET
@@ -228,23 +374,39 @@ public interface ReposResource {
       @PathParam("path") String path, @QueryParam("ref") String ref);
 
   /**
+   * <p>
    * Creates a new file or replaces an existing file in a repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/contents/{path}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_or_update_file_contents(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("path") String path, InputStream data);
+  Response repos_create_or_update_file_contents(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("path") String path, InputStream data);
 
   /**
+   * <p>
    * Deletes a file in a repository.
-   *
-   * You can provide an additional `committer` parameter, which is an object containing information about the committer. Or, you can provide an `author` parameter, which is an object containing information about the author.
-   *
-   * The `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.
-   *
-   * You must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.
+   * </p>
+   * <p>
+   * You can provide an additional <code>committer</code> parameter, which is an
+   * object containing information about the committer. Or, you can provide an
+   * <code>author</code> parameter, which is an object containing information
+   * about the author.
+   * </p>
+   * <p>
+   * The <code>author</code> section is optional and is filled in with the
+   * <code>committer</code> information if omitted. If the <code>committer</code>
+   * information is omitted, the authenticated user's information is used.
+   * </p>
+   * <p>
+   * You must provide values for both <code>name</code> and <code>email</code>,
+   * whether you choose to use <code>author</code> or <code>committer</code>.
+   * Otherwise, you'll receive a <code>422</code> status code.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/contents/{path}")
   @DELETE
@@ -254,7 +416,7 @@ public interface ReposResource {
       @PathParam("path") String path, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/topics")
   @GET
@@ -262,41 +424,61 @@ public interface ReposResource {
   Response repos_get_all_topics(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/topics")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_replace_all_topics(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response repos_replace_all_topics(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Shows whether dependency alerts are enabled or disabled for a repository. The authenticated user must have admin access to the repository. For more information, see "[About security alerts for vulnerable dependencies](https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies)".
+   * <p>
+   * Shows whether dependency alerts are enabled or disabled for a repository. The
+   * authenticated user must have admin access to the repository. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies">About
+   * security alerts for vulnerable dependencies</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/vulnerability-alerts")
   @GET
-  void repos_check_vulnerability_alerts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void repos_check_vulnerability_alerts(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Enables dependency alerts and the dependency graph for a repository. The authenticated user must have admin access to the repository. For more information, see "[About security alerts for vulnerable dependencies](https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies)".
+   * <p>
+   * Enables dependency alerts and the dependency graph for a repository. The
+   * authenticated user must have admin access to the repository. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies">About
+   * security alerts for vulnerable dependencies</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/vulnerability-alerts")
   @PUT
-  void repos_enable_vulnerability_alerts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void repos_enable_vulnerability_alerts(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Disables dependency alerts and the dependency graph for a repository. The authenticated user must have admin access to the repository. For more information, see "[About security alerts for vulnerable dependencies](https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies)".
+   * <p>
+   * Disables dependency alerts and the dependency graph for a repository. The
+   * authenticated user must have admin access to the repository. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies">About
+   * security alerts for vulnerable dependencies</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/vulnerability-alerts")
   @DELETE
-  void repos_disable_vulnerability_alerts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void repos_disable_vulnerability_alerts(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * Simple filtering of deployments is available via query parameters:
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/deployments")
   @GET
@@ -307,70 +489,109 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Deployments offer a few configurable parameters with certain defaults.
-   *
-   * The `ref` parameter can be any named branch, tag, or SHA. At GitHub we often deploy branches and verify them
-   * before we merge a pull request.
-   *
-   * The `environment` parameter allows deployments to be issued to different runtime environments. Teams often have
-   * multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This parameter
-   * makes it easier to track which environments have requested deployments. The default environment is `production`.
-   *
-   * The `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If
-   * the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds,
-   * the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will
-   * return a failure response.
-   *
-   * By default, [commit statuses](https://developer.github.com/v3/repos/statuses) for every submitted context must be in a `success`
-   * state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to
-   * specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do
-   * not require any contexts or create any commit statuses, the deployment will always succeed.
-   *
-   * The `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text
-   * field that will be passed on when a deployment event is dispatched.
-   *
-   * The `task` parameter is used by the deployment system to allow different execution paths. In the web world this might
-   * be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an
-   * application with debugging enabled.
-   *
-   * Users with `repo` or `repo_deployment` scopes can create a deployment for a given ref.
-   *
-   * #### Merged branch response
-   * You will see this response when GitHub automatically merges the base branch into the topic branch instead of creating
-   * a deployment. This auto-merge happens when:
-   * *   Auto-merge option is enabled in the repository
-   * *   Topic branch does not include the latest changes on the base branch, which is `master` in the response example
-   * *   There are no merge conflicts
-   *
-   * If there are no new commits in the base branch, a new request to create a deployment should give a successful
-   * response.
-   *
-   * #### Merge conflict response
-   * This error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't
-   * be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.
-   *
-   * #### Failed commit status checks
-   * This error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success`
-   * status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.
+   * </p>
+   * <p>
+   * The <code>ref</code> parameter can be any named branch, tag, or SHA. At
+   * GitHub we often deploy branches and verify them before we merge a pull
+   * request.
+   * </p>
+   * <p>
+   * The <code>environment</code> parameter allows deployments to be issued to
+   * different runtime environments. Teams often have multiple environments for
+   * verifying their applications, such as <code>production</code>,
+   * <code>staging</code>, and <code>qa</code>. This parameter makes it easier to
+   * track which environments have requested deployments. The default environment
+   * is <code>production</code>.
+   * </p>
+   * <p>
+   * The <code>auto_merge</code> parameter is used to ensure that the requested
+   * ref is not behind the repository's default branch. If the ref <em>is</em>
+   * behind the default branch for the repository, we will attempt to merge it for
+   * you. If the merge succeeds, the API will return a successful merge commit. If
+   * merge conflicts prevent the merge from succeeding, the API will return a
+   * failure response.
+   * </p>
+   * <p>
+   * By default, <a href="https://developer.github.com/v3/repos/statuses">commit
+   * statuses</a> for every submitted context must be in a <code>success</code>
+   * state. The <code>required_contexts</code> parameter allows you to specify a
+   * subset of contexts that must be <code>success</code>, or to specify contexts
+   * that have not yet been submitted. You are not required to use commit statuses
+   * to deploy. If you do not require any contexts or create any commit statuses,
+   * the deployment will always succeed.
+   * </p>
+   * <p>
+   * The <code>payload</code> parameter is available for any extra information
+   * that a deployment system might need. It is a JSON text field that will be
+   * passed on when a deployment event is dispatched.
+   * </p>
+   * <p>
+   * The <code>task</code> parameter is used by the deployment system to allow
+   * different execution paths. In the web world this might be
+   * <code>deploy:migrations</code> to run schema changes on the system. In the
+   * compiled world this could be a flag to compile an application with debugging
+   * enabled.
+   * </p>
+   * <p>
+   * Users with <code>repo</code> or <code>repo_deployment</code> scopes can
+   * create a deployment for a given ref.
+   * </p>
+   * <h4>Merged branch response</h4>
+   * <p>
+   * You will see this response when GitHub automatically merges the base branch
+   * into the topic branch instead of creating a deployment. This auto-merge
+   * happens when:
+   * </p>
+   * <ul>
+   * <li>Auto-merge option is enabled in the repository</li>
+   * <li>Topic branch does not include the latest changes on the base branch,
+   * which is <code>master</code> in the response example</li>
+   * <li>There are no merge conflicts</li>
+   * </ul>
+   * <p>
+   * If there are no new commits in the base branch, a new request to create a
+   * deployment should give a successful response.
+   * </p>
+   * <h4>Merge conflict response</h4>
+   * <p>
+   * This error happens when the <code>auto_merge</code> option is enabled and
+   * when the default branch (in this case <code>master</code>), can't be merged
+   * into the branch that's being deployed (in this case
+   * <code>topic-branch</code>), due to merge conflicts.
+   * </p>
+   * <h4>Failed commit status checks</h4>
+   * <p>
+   * This error happens when the <code>required_contexts</code> parameter
+   * indicates that one or more contexts need to have a <code>success</code>
+   * status for the commit to be deployed, but one or more of the required
+   * contexts do not have a state of <code>success</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/deployments")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_deployment(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_create_deployment(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * This endpoint will return all community profile metrics, including an overall health score, repository description, the presence of documentation, detected code of conduct, detected license, and the presence of ISSUE\_TEMPLATE, PULL\_REQUEST\_TEMPLATE, README, and CONTRIBUTING files.
+   * <p>
+   * This endpoint will return all community profile metrics, including an overall
+   * health score, repository description, the presence of documentation, detected
+   * code of conduct, detected license, and the presence of ISSUE_TEMPLATE,
+   * PULL_REQUEST_TEMPLATE, README, and CONTRIBUTING files.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/community/profile")
   @GET
   @Produces("application/json")
-  Response repos_get_community_profile_metrics(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_community_profile_metrics(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages")
   @GET
@@ -378,117 +599,194 @@ public interface ReposResource {
   Response repos_get_pages(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages")
   @PUT
   @Consumes("application/json")
-  void repos_update_information_about_pages_site(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  void repos_update_information_about_pages_site(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_pages_site(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_create_pages_site(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages")
   @DELETE
   void repos_delete_pages_site(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews")
   @GET
   @Produces("application/vnd.github.luke-cage-preview+json")
-  Response repos_get_pull_request_review_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_get_pull_request_review_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews")
   @DELETE
-  void repos_delete_pull_request_review_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  void repos_delete_pull_request_review_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
-   *
-   * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Updating pull request review enforcement requires admin or owner permissions
+   * to the repository and branch protection to be enabled.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: Passing new arrays of <code>users</code> and
+   * <code>teams</code> replaces their previous values.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_update_pull_request_review_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, InputStream data);
+  Response repos_update_pull_request_review_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, InputStream data);
 
   /**
+   * <p>
    * Get the top 10 referrers over the last 14 days.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/traffic/popular/referrers")
   @GET
   @Produces("application/json")
-  Response repos_get_top_referrers(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_top_referrers(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.
-   *
-   * This resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.
+   * <p>
+   * Users with pull access in a repository can view commit statuses for a given
+   * ref. The ref can be a SHA, a branch name, or a tag name. Statuses are
+   * returned in reverse chronological order. The first status in the list will be
+   * the latest one.
+   * </p>
+   * <p>
+   * This resource is also available via a legacy route:
+   * <code>GET /repos/:owner/:repo/statuses/:ref</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{ref}/statuses")
   @GET
   @Produces("application/json")
-  Response repos_list_commit_statuses_for_ref(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("ref") String ref,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response repos_list_commit_statuses_for_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("ref") String ref, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`.
-   *
-   * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
-   *
-   * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
-   *
-   * **Working with large comparisons**
-   *
-   * The response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [List commits](https://developer.github.com/v3/repos/commits/#list-commits) to enumerate all commits in the range.
-   *
-   * For comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long to generate. You can typically resolve this error by using a smaller commit range.
-   *
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * <p>
+   * Both <code>:base</code> and <code>:head</code> must be branch names in
+   * <code>:repo</code>. To compare branches across other repositories in the same
+   * network as <code>:repo</code>, use the format
+   * <code>&lt;USERNAME&gt;:branch</code>.
+   * </p>
+   * <p>
+   * The response from the API is equivalent to running the
+   * <code>git log base..head</code> command; however, commits are returned in
+   * chronological order. Pass the appropriate <a href=
+   * "https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests">media
+   * type</a> to fetch diff and patch formats.
+   * </p>
+   * <p>
+   * The response also includes details on the files that were changed between the
+   * two commits. This includes the status of the change (for example, if a file
+   * was added, removed, modified, or renamed), and details of the change itself.
+   * For example, files with a <code>renamed</code> status have a
+   * <code>previous_filename</code> field showing the previous filename of the
+   * file, and files with a <code>modified</code> status have a <code>patch</code>
+   * field showing the changes made to the file.
+   * </p>
+   * <p>
+   * <strong>Working with large comparisons</strong>
+   * </p>
+   * <p>
+   * The response will include a comparison of up to 250 commits. If you are
+   * working with a larger commit range, you can use the
+   * <a href="https://developer.github.com/v3/repos/commits/#list-commits">List
+   * commits</a> to enumerate all commits in the range.
+   * </p>
+   * <p>
+   * For comparisons with extremely large diffs, you may receive an error response
+   * indicating that the diff took too long to generate. You can typically resolve
+   * this error by using a smaller commit range.
+   * </p>
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/compare/{base}...{head}")
   @GET
@@ -497,7 +795,17 @@ public interface ReposResource {
       @PathParam("base") String base, @PathParam("head") String head);
 
   /**
-   * Lists all pull requests containing the provided commit SHA, which can be from any point in the commit history. The results will include open and closed pull requests. Additional preview headers may be required to see certain details for associated pull requests, such as whether a pull request is in a draft state. For more information about previews that might affect this endpoint, see the [List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests) endpoint.
+   * <p>
+   * Lists all pull requests containing the provided commit SHA, which can be from
+   * any point in the commit history. The results will include open and closed
+   * pull requests. Additional preview headers may be required to see certain
+   * details for associated pull requests, such as whether a pull request is in a
+   * draft state. For more information about previews that might affect this
+   * endpoint, see the
+   * <a href="https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a> endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{commit_sha}/pulls")
   @GET
@@ -507,99 +815,188 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/enforce_admins")
   @GET
   @Produces("application/json")
-  Response repos_get_admin_branch_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_get_admin_branch_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Adding admin enforcement requires admin or owner permissions to the
+   * repository and branch protection to be enabled.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/enforce_admins")
   @POST
   @Produces("application/json")
-  Response repos_set_admin_branch_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_set_admin_branch_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Removing admin enforcement requires admin or owner permissions to the
+   * repository and branch protection to be enabled.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/enforce_admins")
   @DELETE
-  void repos_delete_admin_branch_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  void repos_delete_admin_branch_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
+   * <p>
    * Users with pull access can view a deployment status for a deployment:
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}")
   @GET
   @Produces("application/json")
-  Response repos_get_deployment_status(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("deployment_id") Integer deploymentId,
-      @PathParam("status_id") Integer statusId);
+  Response repos_get_deployment_status(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("deployment_id") Integer deploymentId, @PathParam("status_id") Integer statusId);
 
   /**
-   * Enables automated security fixes for a repository. The authenticated user must have admin access to the repository. For more information, see "[Configuring automated security fixes](https://help.github.com/en/articles/configuring-automated-security-fixes)".
+   * <p>
+   * Enables automated security fixes for a repository. The authenticated user
+   * must have admin access to the repository. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/en/articles/configuring-automated-security-fixes">Configuring
+   * automated security fixes</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/automated-security-fixes")
   @PUT
-  void repos_enable_automated_security_fixes(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void repos_enable_automated_security_fixes(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Disables automated security fixes for a repository. The authenticated user must have admin access to the repository. For more information, see "[Configuring automated security fixes](https://help.github.com/en/articles/configuring-automated-security-fixes)".
+   * <p>
+   * Disables automated security fixes for a repository. The authenticated user
+   * must have admin access to the repository. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/en/articles/configuring-automated-security-fixes">Configuring
+   * automated security fixes</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/automated-security-fixes")
   @DELETE
-  void repos_disable_automated_security_fixes(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void repos_disable_automated_security_fixes(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * When authenticated with admin or owner permissions to the repository, you can use this endpoint to check whether a branch requires signed commits. An enabled status of `true` indicates you must sign commits on this branch. For more information, see [Signing commits with GPG](https://help.github.com/articles/signing-commits-with-gpg) in GitHub Help.
-   *
-   * **Note**: You must enable branch protection to require signed commits.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * When authenticated with admin or owner permissions to the repository, you can
+   * use this endpoint to check whether a branch requires signed commits. An
+   * enabled status of <code>true</code> indicates you must sign commits on this
+   * branch. For more information, see
+   * <a href="https://help.github.com/articles/signing-commits-with-gpg">Signing
+   * commits with GPG</a> in GitHub Help.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: You must enable branch protection to require signed
+   * commits.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_signatures")
   @GET
   @Produces("application/json")
-  Response repos_get_commit_signature_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_get_commit_signature_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * When authenticated with admin or owner permissions to the repository, you can use this endpoint to require signed commits on a branch. You must enable branch protection to require signed commits.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * When authenticated with admin or owner permissions to the repository, you can
+   * use this endpoint to require signed commits on a branch. You must enable
+   * branch protection to require signed commits.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_signatures")
   @POST
   @Produces("application/json")
-  Response repos_create_commit_signature_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_create_commit_signature_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * When authenticated with admin or owner permissions to the repository, you can use this endpoint to disable required signed commits on a branch. You must enable branch protection to require signed commits.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * When authenticated with admin or owner permissions to the repository, you can
+   * use this endpoint to disable required signed commits on a branch. You must
+   * enable branch protection to require signed commits.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_signatures")
   @DELETE
-  void repos_delete_commit_signature_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  void repos_delete_commit_signature_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Lists the people who have push access to this branch.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/users")
   @GET
@@ -608,55 +1005,93 @@ public interface ReposResource {
       @PathParam("repo") String repo, @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.
-   *
-   * | Type    | Description                                                                                                                   |
-   * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Replaces the list of people that have push access to this branch. This
+   * removes all people that previously had push access and grants push access to
+   * the new list of people.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * -----------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | Usernames for people who can have push access.
+   * <strong>Note</strong>: The list of users, apps, and teams in total is limited
+   * to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/users")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_set_user_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_set_user_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Grants the specified people push access for this branch.
-   *
-   * | Type    | Description                                                                                                                   |
-   * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * -----------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | Usernames for people who can have push access.
+   * <strong>Note</strong>: The list of users, apps, and teams in total is limited
+   * to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/users")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_add_user_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_add_user_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Removes the ability of a user to push to this branch.
-   *
-   * | Type    | Description                                                                                                                                   |
-   * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | Usernames of the people who should no longer have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ---------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | Usernames of the people who should no longer have
+   * push access. <strong>Note</strong>: The list of users, apps, and teams in
+   * total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/users")
   @DELETE
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_remove_user_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_remove_user_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/branches")
   @GET
@@ -666,7 +1101,7 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}")
   @GET
@@ -675,7 +1110,7 @@ public interface ReposResource {
       @PathParam("branch") String branch);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/keys")
   @GET
@@ -684,17 +1119,19 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * You can create a read-only deploy key.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/keys")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_deploy_key(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_create_deploy_key(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages/builds/{build_id}")
   @GET
@@ -703,7 +1140,12 @@ public interface ReposResource {
       @PathParam("build_id") Integer buildId);
 
   /**
-   * Get the total number of clones and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.
+   * <p>
+   * Get the total number of clones and breakdown per day or week for the last 14
+   * days. Timestamps are aligned to UTC midnight of the beginning of the day or
+   * week. Week begins on Monday.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/traffic/clones")
   @GET
@@ -712,7 +1154,7 @@ public interface ReposResource {
       @QueryParam("per") String per);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/hooks/{hook_id}")
   @GET
@@ -721,7 +1163,7 @@ public interface ReposResource {
       @PathParam("hook_id") Integer hookId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/hooks/{hook_id}")
   @DELETE
@@ -729,7 +1171,7 @@ public interface ReposResource {
       @PathParam("hook_id") Integer hookId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/hooks/{hook_id}")
   @PATCH
@@ -739,9 +1181,18 @@ public interface ReposResource {
       @PathParam("hook_id") Integer hookId, InputStream data);
 
   /**
-   * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://developer.github.com/v3/repos/#list-repository-tags).
-   *
-   * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+   * <p>
+   * This returns a list of releases, which does not include regular Git tags that
+   * have not been associated with a release. To get a list of Git tags, use the
+   * <a href=
+   * "https://developer.github.com/v3/repos/#list-repository-tags">Repository Tags
+   * API</a>.
+   * </p>
+   * <p>
+   * Information about published releases are available to everyone. Only users
+   * with push access will receive listings for draft releases.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases")
   @GET
@@ -750,26 +1201,53 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Users with push access to the repository can create a release.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_release(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_create_release(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Creates a new repository using a repository template. Use the `template_owner` and `template_repo` route parameters to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the [Get a repository](https://developer.github.com/v3/repos/#get-a-repository) endpoint and check that the `is_template` key is `true`.
-   *
-   * **OAuth scope requirements**
-   *
-   * When using [OAuth](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
-   *
-   * *   `public_repo` scope or `repo` scope to create a public repository
-   * *   `repo` scope to create a private repository
+   * <p>
+   * Creates a new repository using a repository template. Use the
+   * <code>template_owner</code> and <code>template_repo</code> route parameters
+   * to specify the repository to use as the template. The authenticated user must
+   * own or be a member of an organization that owns the repository. To check if a
+   * repository is available to use as a template, get the repository's
+   * information using the
+   * <a href="https://developer.github.com/v3/repos/#get-a-repository">Get a
+   * repository</a> endpoint and check that the <code>is_template</code> key is
+   * <code>true</code>.
+   * </p>
+   * <p>
+   * <strong>OAuth scope requirements</strong>
+   * </p>
+   * <p>
+   * When using <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">OAuth</a>,
+   * authorizations must include:
+   * </p>
+   * <ul>
+   * <li><code>public_repo</code> scope or <code>repo</code> scope to create a
+   * public repository</li>
+   * <li><code>repo</code> scope to create a private repository</li>
+   * </ul>
+   * 
    */
   @Path("/{template_owner}/{template_repo}/generate")
   @POST
@@ -779,38 +1257,72 @@ public interface ReposResource {
       @PathParam("template_repo") String templateRepo, InputStream data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks")
   @GET
   @Produces("application/json")
-  Response repos_get_status_checks_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_get_status_checks_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks")
   @DELETE
-  void repos_remove_status_check_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  void repos_remove_status_check_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Updating required status checks requires admin or owner permissions to the
+   * repository and branch protection to be enabled.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/required_status_checks")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_update_status_check_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, InputStream data);
+  Response repos_update_status_check_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, InputStream data);
 
   /**
-   * When you pass the `scarlet-witch-preview` media type, requests to get a repository will also return the repository's code of conduct if it can be detected from the repository's code of conduct file.
-   *
-   * The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.
+   * <p>
+   * When you pass the <code>scarlet-witch-preview</code> media type, requests to
+   * get a repository will also return the repository's code of conduct if it can
+   * be detected from the repository's code of conduct file.
+   * </p>
+   * <p>
+   * The <code>parent</code> and <code>source</code> objects are present when the
+   * repository is a fork. <code>parent</code> is the repository this repository
+   * was forked from, <code>source</code> is the ultimate source for the network.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}")
   @GET
@@ -818,50 +1330,80 @@ public interface ReposResource {
   Response repos_get(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
-   *
-   * If an organization owner has configured the organization to prevent members from deleting organization-owned
-   * repositories, you will get a `403 Forbidden` response.
+   * <p>
+   * Deleting a repository requires admin access. If OAuth is used, the
+   * <code>delete_repo</code> scope is required.
+   * </p>
+   * <p>
+   * If an organization owner has configured the organization to prevent members
+   * from deleting organization-owned repositories, you will get a
+   * <code>403 Forbidden</code> response.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}")
   @DELETE
   void repos_delete(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * **Note**: To edit a repository's topics, use the [Replace all repository topics](https://developer.github.com/v3/repos/#replace-all-repository-topics) endpoint.
+   * <p>
+   * <strong>Note</strong>: To edit a repository's topics, use the <a href=
+   * "https://developer.github.com/v3/repos/#replace-all-repository-topics">Replace
+   * all repository topics</a> endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_update(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_update(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Lists who has access to this protected branch.
-   *
-   * **Note**: Users, apps, and teams `restrictions` are only available for organization-owned repositories.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: Users, apps, and teams <code>restrictions</code> are
+   * only available for organization-owned repositories.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions")
   @GET
   @Produces("application/json")
-  Response repos_get_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_get_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Disables the ability to restrict who can push to this branch.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions")
   @DELETE
-  void repos_delete_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  void repos_delete_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/keys/{key_id}")
   @GET
@@ -870,7 +1412,11 @@ public interface ReposResource {
       @PathParam("key_id") Integer keyId);
 
   /**
-   * Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
+   * <p>
+   * Deploy keys are immutable. If you need to update a key, remove the key and
+   * create a new one instead.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/keys/{key_id}")
   @DELETE
@@ -878,7 +1424,13 @@ public interface ReposResource {
       @PathParam("key_id") Integer keyId);
 
   /**
-   * **Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://developer.github.com/v3/#hypermedia).
+   * <p>
+   * <strong>Note:</strong> This returns an <code>upload_url</code> key
+   * corresponding to the endpoint for uploading release assets. This key is a
+   * <a href="https://developer.github.com/v3/#hypermedia">hypermedia
+   * resource</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/{release_id}")
   @GET
@@ -887,7 +1439,10 @@ public interface ReposResource {
       @PathParam("release_id") Integer releaseId);
 
   /**
+   * <p>
    * Users with push access to the repository can delete a release.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/{release_id}")
   @DELETE
@@ -895,7 +1450,10 @@ public interface ReposResource {
       @PathParam("release_id") Integer releaseId);
 
   /**
+   * <p>
    * Users with push access to the repository can edit a release.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/{release_id}")
   @PATCH
@@ -905,40 +1463,73 @@ public interface ReposResource {
       @PathParam("release_id") Integer releaseId, InputStream data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection")
   @GET
   @Produces("application/json")
-  Response repos_get_branch_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  Response repos_get_branch_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Protecting a branch requires admin or owner permissions to the repository.
-   *
-   * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
-   *
-   * **Note**: The list of users, apps, and teams in total is limited to 100 items.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: Passing new arrays of <code>users</code> and
+   * <code>teams</code> replaces their previous values.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: The list of users, apps, and teams in total is limited
+   * to 100 items.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_update_branch_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, InputStream data);
+  Response repos_update_branch_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, InputStream data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection")
   @DELETE
-  void repos_delete_branch_protection(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch);
+  void repos_delete_branch_protection(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
 
   /**
-   * When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.
+   * <p>
+   * When authenticating as a user with admin rights to a repository, this
+   * endpoint will list all currently open repository invitations.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/invitations")
   @GET
@@ -947,7 +1538,12 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * This will trigger a [ping event](https://developer.github.com/webhooks/#ping-event) to be sent to the hook.
+   * <p>
+   * This will trigger a
+   * <a href="https://developer.github.com/webhooks/#ping-event">ping event</a> to
+   * be sent to the hook.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/hooks/{hook_id}/pings")
   @POST
@@ -955,7 +1551,7 @@ public interface ReposResource {
       @PathParam("hook_id") Integer hookId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/tags")
   @GET
@@ -964,7 +1560,7 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/teams")
   @GET
@@ -973,16 +1569,24 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.
+   * <p>
+   * Returns the last year of commit activity grouped by week. The
+   * <code>days</code> array is a group of commits per day, starting on
+   * <code>Sunday</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/stats/commit_activity")
   @GET
   @Produces("application/json")
-  Response repos_get_commit_activity_stats(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_commit_activity_stats(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.
+   * <p>
+   * Lists languages for the specified repository. The value shown for each
+   * language is the number of bytes of code written in that language.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/languages")
   @GET
@@ -990,47 +1594,84 @@ public interface ReposResource {
   Response repos_list_languages(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * You can use this endpoint to trigger a webhook event called `repository_dispatch` when you want activity that happens outside of GitHub to trigger a GitHub Actions workflow or GitHub App webhook. You must configure your GitHub Actions workflow or GitHub App to run when the `repository_dispatch` event occurs. For an example `repository_dispatch` webhook payload, see "[RepositoryDispatchEvent](https://developer.github.com/webhooks/event-payloads/#repository_dispatch)."
-   *
-   * The `client_payload` parameter is available for any extra information that your workflow might need. This parameter is a JSON payload that will be passed on when the webhook event is dispatched. For example, the `client_payload` can include a message that a user would like to send using a GitHub Actions workflow. Or the `client_payload` can be used as a test to debug your workflow. For a test example, see the [input example](https://developer.github.com/v3/repos/#example-4).
-   *
-   * To give you write access to the repository, you must use a personal access token with the `repo` scope. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)" in the GitHub Help documentation.
-   *
-   * This input example shows how you can use the `client_payload` as a test to debug your workflow.
+   * <p>
+   * You can use this endpoint to trigger a webhook event called
+   * <code>repository_dispatch</code> when you want activity that happens outside
+   * of GitHub to trigger a GitHub Actions workflow or GitHub App webhook. You
+   * must configure your GitHub Actions workflow or GitHub App to run when the
+   * <code>repository_dispatch</code> event occurs. For an example
+   * <code>repository_dispatch</code> webhook payload, see &quot;<a href=
+   * "https://developer.github.com/webhooks/event-payloads/#repository_dispatch">RepositoryDispatchEvent</a>.&quot;
+   * </p>
+   * <p>
+   * The <code>client_payload</code> parameter is available for any extra
+   * information that your workflow might need. This parameter is a JSON payload
+   * that will be passed on when the webhook event is dispatched. For example, the
+   * <code>client_payload</code> can include a message that a user would like to
+   * send using a GitHub Actions workflow. Or the <code>client_payload</code> can
+   * be used as a test to debug your workflow. For a test example, see the
+   * <a href="https://developer.github.com/v3/repos/#example-4">input example</a>.
+   * </p>
+   * <p>
+   * To give you write access to the repository, you must use a personal access
+   * token with the <code>repo</code> scope. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line">Creating
+   * a personal access token for the command line</a>&quot; in the GitHub Help
+   * documentation.
+   * </p>
+   * <p>
+   * This input example shows how you can use the <code>client_payload</code> as a
+   * test to debug your workflow.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/dispatches")
   @POST
   @Consumes("application/json")
-  void repos_create_dispatch_event(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  void repos_create_dispatch_event(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
+   * <p>
    * Each array contains the day number, hour number, and number of commits:
-   *
-   * *   `0-6`: Sunday - Saturday
-   * *   `0-23`: Hour of day
-   * *   Number of commits
-   *
-   * For example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+   * </p>
+   * <ul>
+   * <li><code>0-6</code>: Sunday - Saturday</li>
+   * <li><code>0-23</code>: Hour of day</li>
+   * <li>Number of commits</li>
+   * </ul>
+   * <p>
+   * For example, <code>[2, 14, 25]</code> indicates that there were 25 total
+   * commits, during the 2:00pm hour on Tuesdays. All times are based on the time
+   * zone of individual commits.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/stats/punch_card")
   @GET
   @Produces("application/json")
-  List<Integer> repos_get_punch_card_stats(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  List<Integer> repos_get_punch_card_stats(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * A transfer request will need to be accepted by the new owner when transferring a personal repository to another user. The response will contain the original `owner`, and the transfer will continue asynchronously. For more details on the requirements to transfer personal and organization-owned repositories, see [about repository transfers](https://help.github.com/articles/about-repository-transfers/).
+   * <p>
+   * A transfer request will need to be accepted by the new owner when
+   * transferring a personal repository to another user. The response will contain
+   * the original <code>owner</code>, and the transfer will continue
+   * asynchronously. For more details on the requirements to transfer personal and
+   * organization-owned repositories, see
+   * <a href="https://help.github.com/articles/about-repository-transfers/">about
+   * repository transfers</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/transfer")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_transfer(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_transfer(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages/builds")
   @GET
@@ -1039,20 +1680,36 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.
-   *
-   * Build requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.
+   * <p>
+   * You can request that your site be built from the latest revision on the
+   * default branch. This has the same effect as pushing a commit to your default
+   * branch, but does not require an additional commit. Manually triggering page
+   * builds can be helpful when diagnosing build warnings and failures.
+   * </p>
+   * <p>
+   * Build requests are limited to one concurrent build per repository and one
+   * concurrent build per requester. If you request a build while another is still
+   * in progress, the second request will be queued until the first completes.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pages/builds")
   @POST
   @Produces("application/json")
-  Response repos_request_pages_build(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_request_pages_build(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
-   *
+   * <p>
+   * For organization-owned repositories, the list of collaborators includes
+   * outside collaborators, organization members that are direct collaborators,
+   * organization members with access through team memberships, organization
+   * members with access through default organization permissions, and
+   * organization owners.
+   * </p>
+   * <p>
    * Team members will include the members of child teams.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/collaborators/{username}")
   @GET
@@ -1060,17 +1717,44 @@ public interface ReposResource {
       @PathParam("username") String username);
 
   /**
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
-   *
-   * For more information the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
-   *
-   * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
-   *
-   * The invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://developer.github.com/v3/repos/invitations/).
-   *
-   * **Rate limits**
-   *
-   * To prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * <p>
+   * For more information the permission levels, see &quot;<a href=
+   * "https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization">Repository
+   * permission levels for an organization</a>&quot;.
+   * </p>
+   * <p>
+   * Note that, if you choose not to pass any parameters, you'll need to set
+   * <code>Content-Length</code> to zero when calling out to this endpoint. For
+   * more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * <p>
+   * The invitee will receive a notification that they have been invited to the
+   * repository, which they must accept or decline. They may do this via the
+   * notifications page, the email they receive, or by using the
+   * <a href="https://developer.github.com/v3/repos/invitations/">repository
+   * invitations API endpoints</a>.
+   * </p>
+   * <p>
+   * <strong>Rate limits</strong>
+   * </p>
+   * <p>
+   * To prevent abuse, you are limited to sending 50 invitations to a repository
+   * per 24 hour period. Note there is no limit if you are inviting organization
+   * members to an organization repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/collaborators/{username}")
   @PUT
@@ -1080,7 +1764,7 @@ public interface ReposResource {
       @PathParam("username") String username, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/collaborators/{username}")
   @DELETE
@@ -1088,29 +1772,40 @@ public interface ReposResource {
       @PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/forks")
   @GET
   @Produces("application/json")
   Response repos_list_forks(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @QueryParam("sort") String sort, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("sort") String sort, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Create a fork for the authenticated user.
-   *
-   * **Note**: Forking a Repository happens asynchronously. You may have to wait a short period of time before you can access the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub Support](https://github.com/contact) or [GitHub Premium Support](https://premium.githubsupport.com).
+   * </p>
+   * <p>
+   * <strong>Note</strong>: Forking a Repository happens asynchronously. You may
+   * have to wait a short period of time before you can access the git objects. If
+   * this takes longer than 5 minutes, be sure to contact
+   * <a href="https://github.com/contact">GitHub Support</a> or
+   * <a href="https://premium.githubsupport.com">GitHub Premium Support</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/forks")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_fork(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_create_fork(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Get the total number of views and breakdown per day or week for the last 14 days. Timestamps are aligned to UTC midnight of the beginning of the day or week. Week begins on Monday.
+   * <p>
+   * Get the total number of views and breakdown per day or week for the last 14
+   * days. Timestamps are aligned to UTC midnight of the beginning of the day or
+   * week. Week begins on Monday.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/traffic/views")
   @GET
@@ -1119,54 +1814,87 @@ public interface ReposResource {
       @QueryParam("per") String per);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/releases/{release_id}/assets")
   @GET
   @Produces("application/json")
-  Response repos_list_release_assets(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("release_id") Integer releaseId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response repos_list_release_assets(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("release_id") Integer releaseId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * This endpoint makes use of [a Hypermedia relation](https://developer.github.com/v3/#hypermedia) to determine which URL to access. The endpoint you call to upload release assets is specific to your release. Use the `upload_url` returned in
-   * the response of the [Create a release endpoint](https://developer.github.com/v3/repos/releases/#create-a-release) to upload a release asset.
-   *
-   * You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.
-   *
-   * Most libraries will set the required `Content-Length` header automatically. Use the required `Content-Type` header to provide the media type of the asset. For a list of media types, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). For example: 
-   *
-   * `application/zip`
-   *
-   * GitHub expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body. Everything else about the endpoint is the same as the rest of the API. For example,
+   * <p>
+   * This endpoint makes use of
+   * <a href="https://developer.github.com/v3/#hypermedia">a Hypermedia
+   * relation</a> to determine which URL to access. The endpoint you call to
+   * upload release assets is specific to your release. Use the
+   * <code>upload_url</code> returned in the response of the <a href=
+   * "https://developer.github.com/v3/repos/releases/#create-a-release">Create a
+   * release endpoint</a> to upload a release asset.
+   * </p>
+   * <p>
+   * You need to use an HTTP client which supports
+   * <a href="http://en.wikipedia.org/wiki/Server_Name_Indication">SNI</a> to make
+   * calls to this endpoint.
+   * </p>
+   * <p>
+   * Most libraries will set the required <code>Content-Length</code> header
+   * automatically. Use the required <code>Content-Type</code> header to provide
+   * the media type of the asset. For a list of media types, see <a href=
+   * "https://www.iana.org/assignments/media-types/media-types.xhtml">Media
+   * Types</a>. For example:
+   * </p>
+   * <p>
+   * <code>application/zip</code>
+   * </p>
+   * <p>
+   * GitHub expects the asset data in its raw binary form, rather than JSON. You
+   * will send the raw binary content of the asset as the request body. Everything
+   * else about the endpoint is the same as the rest of the API. For example,
    * you'll still need to pass your authentication to be able to upload an asset.
-   *
-   * When an upstream failure occurs, you will receive a `502 Bad Gateway` status. This may leave an empty asset with a state of `starter`. It can be safely deleted.
-   *
-   * **Notes:**
-   * *   GitHub renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "[List assets for a release](https://developer.github.com/v3/repos/releases/#list-assets-for-a-release)"
-   * endpoint lists the renamed filenames. For more information and help, contact [GitHub Support](https://github.com/contact).
-   * *   If you upload an asset with the same filename as another uploaded asset, you'll receive an error and must delete the old file before you can re-upload the new asset.
+   * </p>
+   * <p>
+   * When an upstream failure occurs, you will receive a
+   * <code>502 Bad Gateway</code> status. This may leave an empty asset with a
+   * state of <code>starter</code>. It can be safely deleted.
+   * </p>
+   * <p>
+   * <strong>Notes:</strong>
+   * </p>
+   * <ul>
+   * <li>GitHub renames asset filenames that have special characters,
+   * non-alphanumeric characters, and leading or trailing periods. The
+   * &quot;<a href=
+   * "https://developer.github.com/v3/repos/releases/#list-assets-for-a-release">List
+   * assets for a release</a>&quot; endpoint lists the renamed filenames. For more
+   * information and help, contact <a href="https://github.com/contact">GitHub
+   * Support</a>.</li>
+   * <li>If you upload an asset with the same filename as another uploaded asset,
+   * you'll receive an error and must delete the old file before you can re-upload
+   * the new asset.</li>
+   * </ul>
+   * 
    */
   @Path("/{owner}/{repo}/releases/{release_id}/assets")
   @POST
   @Produces("application/json")
   @Consumes("*/*")
-  Response repos_upload_release_asset(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("release_id") Integer releaseId,
-      @QueryParam("name") String name, @QueryParam("label") String label, String data);
+  Response repos_upload_release_asset(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("release_id") Integer releaseId, @QueryParam("name") String name, @QueryParam("label") String label,
+      String data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/comments/{comment_id}")
   @GET
   @Produces("application/json")
-  Response repos_get_commit_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId);
+  Response repos_get_commit_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/comments/{comment_id}")
   @DELETE
@@ -1174,19 +1902,27 @@ public interface ReposResource {
       @PathParam("comment_id") Integer commentId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/comments/{comment_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_update_commit_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId, InputStream data);
+  Response repos_update_commit_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.
-   *
-   * **Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`
+   * <p>
+   * This will trigger the hook with the latest push to the current repository if
+   * the hook is subscribed to <code>push</code> events. If the hook is not
+   * subscribed to <code>push</code> events, the server will respond with 204 but
+   * no test POST will be generated.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: Previously
+   * <code>/repos/:owner/:repo/hooks/:hook_id/test</code>
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/hooks/{hook_id}/tests")
   @POST
@@ -1194,7 +1930,7 @@ public interface ReposResource {
       @PathParam("hook_id") Integer hookId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/hooks")
   @GET
@@ -1203,94 +1939,146 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can
-   * share the same `config` as long as those webhooks do not have any `events` that overlap.
+   * <p>
+   * Repositories can have multiple webhooks installed. Each webhook should have a
+   * unique <code>config</code>. Multiple webhooks can share the same
+   * <code>config</code> as long as those webhooks do not have any
+   * <code>events</code> that overlap.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/hooks")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_webhook(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_create_webhook(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pages/builds/latest")
   @GET
   @Produces("application/json")
-  Response repos_get_latest_pages_build(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_latest_pages_build(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Use the `:commit_sha` to specify the commit that will have its comments listed.
+   * <p>
+   * Use the <code>:commit_sha</code> to specify the commit that will have its
+   * comments listed.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{commit_sha}/comments")
   @GET
   @Produces("application/json")
-  Response repos_list_comments_for_commit(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("commit_sha") String commitSha,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response repos_list_comments_for_commit(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("commit_sha") String commitSha, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Create a comment for a commit using its `:commit_sha`.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * Create a comment for a commit using its <code>:commit_sha</code>.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{commit_sha}/comments")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_commit_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("commit_sha") String commitSha, InputStream data);
+  Response repos_create_commit_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("commit_sha") String commitSha, InputStream data);
 
   /**
-   * Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.
-   *
+   * <p>
+   * Returns the total commit counts for the <code>owner</code> and total commit
+   * counts in <code>all</code>. <code>all</code> is everyone combined, including
+   * the <code>owner</code> in the last 52 weeks. If you'd like to get the commit
+   * counts for non-owners, you can subtract <code>owner</code> from
+   * <code>all</code>.
+   * </p>
+   * <p>
    * The array order is oldest week (index 0) to most recent week.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/stats/participation")
   @GET
   @Produces("application/json")
-  Response repos_get_participation_stats(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_participation_stats(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits")
   @GET
   @Produces("application/json")
   Response repos_list_commits(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @QueryParam("sha") String sha, @QueryParam("path") String path,
-      @QueryParam("author") String author, @QueryParam("since") String since,
-      @QueryParam("until") String until, @QueryParam("per_page") Integer perPage,
+      @QueryParam("sha") String sha, @QueryParam("path") String path, @QueryParam("author") String author,
+      @QueryParam("since") String since, @QueryParam("until") String until, @QueryParam("per_page") Integer perPage,
       @QueryParam("page") Integer page);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Lists the GitHub Apps that have push access to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Lists the GitHub Apps that have push access to this branch. Only installed
+   * GitHub Apps with <code>write</code> access to the <code>contents</code>
+   * permission can be added as authorized actors on a protected branch.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/apps")
   @GET
@@ -1299,75 +2087,128 @@ public interface ReposResource {
       @PathParam("repo") String repo, @PathParam("branch") String branch);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Replaces the list of apps that have push access to this branch. This removes all apps that previously had push access and grants push access to the new list of apps. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
-   *
-   * | Type    | Description                                                                                                                                                |
-   * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Replaces the list of apps that have push access to this branch. This removes
+   * all apps that previously had push access and grants push access to the new
+   * list of apps. Only installed GitHub Apps with <code>write</code> access to
+   * the <code>contents</code> permission can be added as authorized actors on a
+   * protected branch.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ----------------------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | The GitHub Apps that have push access to this
+   * branch. Use the app's <code>slug</code>. <strong>Note</strong>: The list of
+   * users, apps, and teams in total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/apps")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_set_app_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_set_app_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Grants the specified apps push access for this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
-   *
-   * | Type    | Description                                                                                                                                                |
-   * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Grants the specified apps push access for this branch. Only installed GitHub
+   * Apps with <code>write</code> access to the <code>contents</code> permission
+   * can be added as authorized actors on a protected branch.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ----------------------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | The GitHub Apps that have push access to this
+   * branch. Use the app's <code>slug</code>. <strong>Note</strong>: The list of
+   * users, apps, and teams in total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/apps")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_add_app_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_add_app_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
-   * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Removes the ability of an app to push to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
-   *
-   * | Type    | Description                                                                                                                                                |
-   * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+   * <p>
+   * Protected branches are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, and in public and private repositories with
+   * GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
+   * Server. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Removes the ability of an app to push to this branch. Only installed GitHub
+   * Apps with <code>write</code> access to the <code>contents</code> permission
+   * can be added as authorized actors on a protected branch.
+   * </p>
+   * <p>
+   * | Type | Description | | ------- |
+   * ----------------------------------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>array</code> | The GitHub Apps that have push access to this
+   * branch. Use the app's <code>slug</code>. <strong>Note</strong>: The list of
+   * users, apps, and teams in total is limited to 100 items. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/branches/{branch}/protection/restrictions/apps")
   @DELETE
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_remove_app_access_restrictions(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("branch") String branch, List<String> data);
+  Response repos_remove_app_access_restrictions(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("branch") String branch, List<String> data);
 
   /**
+   * <p>
    * Get a published release with the specified tag.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/tags/{tag}")
   @GET
   @Produces("application/json")
-  Response repos_get_release_by_tag(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("tag") String tag);
+  Response repos_get_release_by_tag(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("tag") String tag);
 
   /**
-   * Gets a redirect URL to download a zip archive for a repository. If you omit `:ref`, the repository’s default branch (usually
-   * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
-   * the `Location` header to make a second `GET` request.
-   * **Note**: For private repositories, these links are temporary and expire after five minutes.
+   * <p>
+   * Gets a redirect URL to download a zip archive for a repository. If you omit
+   * <code>:ref</code>, the repository’s default branch (usually
+   * <code>master</code>) will be used. Please make sure your HTTP framework is
+   * configured to follow redirects or you will need to use the
+   * <code>Location</code> header to make a second <code>GET</code> request.
+   * <strong>Note</strong>: For private repositories, these links are temporary
+   * and expire after five minutes.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/zipball/{ref}")
   @GET
-  void repos_download_zipball_archive(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("ref") String ref);
+  void repos_download_zipball_archive(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("ref") String ref);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/invitations/{invitation_id}")
   @DELETE
@@ -1375,7 +2216,7 @@ public interface ReposResource {
       @PathParam("invitation_id") Integer invitationId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/invitations/{invitation_id}")
   @PATCH
@@ -1385,87 +2226,134 @@ public interface ReposResource {
       @PathParam("invitation_id") Integer invitationId, InputStream data);
 
   /**
-   * Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
-   *
-   * The most recent status for each context is returned, up to 100. This field [paginates](https://developer.github.com/v3/#pagination) if there are over 100 contexts.
-   *
-   * Additionally, a combined `state` is returned. The `state` is one of:
-   *
-   * *   **failure** if any of the contexts report as `error` or `failure`
-   * *   **pending** if there are no statuses or a context is `pending`
-   * *   **success** if the latest status for all contexts is `success`
+   * <p>
+   * Users with pull access in a repository can access a combined view of commit
+   * statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
+   * </p>
+   * <p>
+   * The most recent status for each context is returned, up to 100. This field
+   * <a href="https://developer.github.com/v3/#pagination">paginates</a> if there
+   * are over 100 contexts.
+   * </p>
+   * <p>
+   * Additionally, a combined <code>state</code> is returned. The
+   * <code>state</code> is one of:
+   * </p>
+   * <ul>
+   * <li><strong>failure</strong> if any of the contexts report as
+   * <code>error</code> or <code>failure</code></li>
+   * <li><strong>pending</strong> if there are no statuses or a context is
+   * <code>pending</code></li>
+   * <li><strong>success</strong> if the latest status for all contexts is
+   * <code>success</code></li>
+   * </ul>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{ref}/status")
   @GET
   @Produces("application/json")
-  Response repos_get_combined_status_for_ref(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("ref") String ref);
+  Response repos_get_combined_status_for_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("ref") String ref);
 
   /**
-   * Users with push access in a repository can create commit statuses for a given SHA.
-   *
-   * Note: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.
+   * <p>
+   * Users with push access in a repository can create commit statuses for a given
+   * SHA.
+   * </p>
+   * <p>
+   * Note: there is a limit of 1000 statuses per <code>sha</code> and
+   * <code>context</code> within a repository. Attempts to create more than 1000
+   * statuses will result in a validation error.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/statuses/{sha}")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_commit_status(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("sha") String sha, InputStream data);
+  Response repos_create_commit_status(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("sha") String sha, InputStream data);
 
   /**
+   * <p>
    * Users with pull access can view deployment statuses for a deployment:
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/deployments/{deployment_id}/statuses")
   @GET
   @Produces("application/json")
-  Response repos_list_deployment_statuses(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("deployment_id") Integer deploymentId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response repos_list_deployment_statuses(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("deployment_id") Integer deploymentId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Users with `push` access can create deployment statuses for a given deployment.
-   *
-   * GitHub Apps require `read & write` access to "Deployments" and `read-only` access to "Repo contents" (for private repos). OAuth Apps require the `repo_deployment` scope.
+   * <p>
+   * Users with <code>push</code> access can create deployment statuses for a
+   * given deployment.
+   * </p>
+   * <p>
+   * GitHub Apps require <code>read &amp; write</code> access to
+   * &quot;Deployments&quot; and <code>read-only</code> access to &quot;Repo
+   * contents&quot; (for private repos). OAuth Apps require the
+   * <code>repo_deployment</code> scope.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/deployments/{deployment_id}/statuses")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_create_deployment_status(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("deployment_id") Integer deploymentId,
-      InputStream data);
+  Response repos_create_deployment_status(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("deployment_id") Integer deploymentId, InputStream data);
 
   /**
-   * Gets a redirect URL to download a tar archive for a repository. If you omit `:ref`, the repository’s default branch (usually
-   * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
-   * the `Location` header to make a second `GET` request.
-   * **Note**: For private repositories, these links are temporary and expire after five minutes.
+   * <p>
+   * Gets a redirect URL to download a tar archive for a repository. If you omit
+   * <code>:ref</code>, the repository’s default branch (usually
+   * <code>master</code>) will be used. Please make sure your HTTP framework is
+   * configured to follow redirects or you will need to use the
+   * <code>Location</code> header to make a second <code>GET</code> request.
+   * <strong>Note</strong>: For private repositories, these links are temporary
+   * and expire after five minutes.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/tarball/{ref}")
   @GET
-  void repos_download_tarball_archive(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("ref") String ref);
+  void repos_download_tarball_archive(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("ref") String ref);
 
   /**
-   *
-   * Returns the `total` number of commits authored by the contributor. In addition, the response includes a Weekly Hash (`weeks` array) with the following information:
-   *
-   * *   `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
-   * *   `a` - Number of additions
-   * *   `d` - Number of deletions
-   * *   `c` - Number of commits
+   * <p>
+   * Returns the <code>total</code> number of commits authored by the contributor.
+   * In addition, the response includes a Weekly Hash (<code>weeks</code> array)
+   * with the following information:
+   * </p>
+   * <ul>
+   * <li><code>w</code> - Start of the week, given as a
+   * <a href="http://en.wikipedia.org/wiki/Unix_time">Unix timestamp</a>.</li>
+   * <li><code>a</code> - Number of additions</li>
+   * <li><code>d</code> - Number of deletions</li>
+   * <li><code>c</code> - Number of commits</li>
+   * </ul>
+   * 
    */
   @Path("/{owner}/{repo}/stats/contributors")
   @GET
   @Produces("application/json")
-  Response repos_get_contributors_stats(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_contributors_stats(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * Gets the preferred README for a repository.
-   *
-   * READMEs support [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw content or rendered HTML.
+   * </p>
+   * <p>
+   * READMEs support <a href=
+   * "https://developer.github.com/v3/repos/contents/#custom-media-types">custom
+   * media types</a> for retrieving the raw content or rendered HTML.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/readme")
   @GET
@@ -1474,45 +2362,80 @@ public interface ReposResource {
       @QueryParam("ref") String ref);
 
   /**
-   * Commit Comments use [these custom media types](https://developer.github.com/v3/repos/comments/#custom-media-types). You can read more about the use of media types in the API [here](https://developer.github.com/v3/media/).
-   *
+   * <p>
+   * Commit Comments use <a href=
+   * "https://developer.github.com/v3/repos/comments/#custom-media-types">these
+   * custom media types</a>. You can read more about the use of media types in the
+   * API <a href="https://developer.github.com/v3/media/">here</a>.
+   * </p>
+   * <p>
    * Comments are ordered by ascending ID.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/comments")
   @GET
   @Produces("application/json")
-  Response repos_list_commit_comments_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response repos_list_commit_comments_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Returns the contents of a single commit reference. You must have `read` access for the repository to use this endpoint.
-   *
-   * You can pass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch `diff` and `patch` formats. Diffs with binary data will have no `patch` property.
-   *
-   * To return only the SHA-1 hash of the commit reference, you can provide the `sha` custom [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) in the `Accept` header. You can use this endpoint to check if a remote reference's SHA-1 hash is the same as your local reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
-   *
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * <p>
+   * Returns the contents of a single commit reference. You must have
+   * <code>read</code> access for the repository to use this endpoint.
+   * </p>
+   * <p>
+   * You can pass the appropriate <a href=
+   * "https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests">media
+   * type</a> to fetch <code>diff</code> and <code>patch</code> formats. Diffs
+   * with binary data will have no <code>patch</code> property.
+   * </p>
+   * <p>
+   * To return only the SHA-1 hash of the commit reference, you can provide the
+   * <code>sha</code> custom <a href=
+   * "https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests">media
+   * type</a> in the <code>Accept</code> header. You can use this endpoint to
+   * check if a remote reference's SHA-1 hash is the same as your local
+   * reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
+   * </p>
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{ref}")
   @GET
@@ -1521,209 +2444,359 @@ public interface ReposResource {
       @PathParam("ref") String ref);
 
   /**
+   * <p>
    * View the latest published full release for the repository.
-   *
-   * The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
+   * </p>
+   * <p>
+   * The latest release is the most recent non-prerelease, non-draft release,
+   * sorted by the <code>created_at</code> attribute. The <code>created_at</code>
+   * attribute is the date of the commit used for the release, and not the date
+   * when the release was drafted or published.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/releases/latest")
   @GET
   @Produces("application/json")
-  Response repos_get_latest_release(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response repos_get_latest_release(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+   * <p>
+   * Returns a weekly aggregate of the number of additions and deletions pushed to
+   * a repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/stats/code_frequency")
   @GET
   @Produces("application/json")
-  List<Integer> repos_get_code_frequency_stats(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  List<Integer> repos_get_code_frequency_stats(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
-   *
-   * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
+   * <p>
+   * Lists contributors to the specified repository and sorts them by the number
+   * of commits per contributor in descending order. This endpoint may return
+   * information that is a few hours old because the GitHub REST API v3 caches
+   * contributor data to improve performance.
+   * </p>
+   * <p>
+   * GitHub identifies contributors by author email address. This endpoint groups
+   * contribution counts by GitHub user, which includes all associated email
+   * addresses. To improve performance, only the first 500 author email addresses
+   * in the repository link to GitHub users. The rest will appear as anonymous
+   * contributors without associated GitHub user information.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/contributors")
   @GET
   @Produces("application/json")
   Response repos_list_contributors(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @QueryParam("anon") String anon, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("anon") String anon, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
-   *
+   * <p>
+   * For organization-owned repositories, the list of collaborators includes
+   * outside collaborators, organization members that are direct collaborators,
+   * organization members with access through team memberships, organization
+   * members with access through default organization permissions, and
+   * organization owners.
+   * </p>
+   * <p>
    * Team members will include the members of child teams.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/collaborators")
   @GET
   @Produces("application/json")
-  Response repos_list_collaborators(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("affiliation") String affiliation,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response repos_list_collaborators(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("affiliation") String affiliation, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/merges")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response repos_merge(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response repos_merge(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Checks the repository permission of a collaborator. The possible repository permissions are `admin`, `write`, `read`, and `none`.
+   * <p>
+   * Checks the repository permission of a collaborator. The possible repository
+   * permissions are <code>admin</code>, <code>write</code>, <code>read</code>,
+   * and <code>none</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/collaborators/{username}/permission")
   @GET
   @Produces("application/json")
-  Response repos_get_collaborator_permission_level(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("username") String username);
+  Response repos_get_collaborator_permission_level(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("username") String username);
 
   /**
+   * <p>
    * List files larger than 100MB found during the import
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import/large_files")
   @GET
   @Produces("application/json")
-  Response migrations_get_large_files(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response migrations_get_large_files(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * View the progress of an import.
-   *
-   * **Import status**
-   *
-   * This section includes details about the possible values of the `status` field of the Import Progress response.
-   *
+   * </p>
+   * <p>
+   * <strong>Import status</strong>
+   * </p>
+   * <p>
+   * This section includes details about the possible values of the
+   * <code>status</code> field of the Import Progress response.
+   * </p>
+   * <p>
    * An import that does not have errors will progress through these steps:
-   *
-   * *   `detecting` - the "detection" step of the import is in progress because the request did not include a `vcs` parameter. The import is identifying the type of source control present at the URL.
-   * *   `importing` - the "raw" step of the import is in progress. This is where commit data is fetched from the original repository. The import progress response will include `commit_count` (the total number of raw commits that will be imported) and `percent` (0 - 100, the current progress through the import).
-   * *   `mapping` - the "rewrite" step of the import is in progress. This is where SVN branches are converted to Git branches, and where author updates are applied. The import progress response does not include progress information.
-   * *   `pushing` - the "push" step of the import is in progress. This is where the importer updates the repository on GitHub. The import progress response will include `push_percent`, which is the percent value reported by `git push` when it is "Writing objects".
-   * *   `complete` - the import is complete, and the repository is ready on GitHub.
-   *
-   * If there are problems, you will see one of these in the `status` field:
-   *
-   * *   `auth_failed` - the import requires authentication in order to connect to the original repository. To update authentication for the import, please see the [Update an import](https://developer.github.com/v3/migrations/source_imports/#update-an-import) section.
-   * *   `error` - the import encountered an error. The import progress response will include the `failed_step` and an error message. Contact [GitHub Support](https://github.com/contact) or [GitHub Premium Support](https://premium.githubsupport.com) for more information.
-   * *   `detection_needs_auth` - the importer requires authentication for the originating repository to continue detection. To update authentication for the import, please see the [Update an import](https://developer.github.com/v3/migrations/source_imports/#update-an-import) section.
-   * *   `detection_found_nothing` - the importer didn't recognize any source control at the URL. To resolve, [Cancel the import](https://developer.github.com/v3/migrations/source_imports/#cancel-an-import) and [retry](https://developer.github.com/v3/migrations/source_imports/#start-an-import) with the correct URL.
-   * *   `detection_found_multiple` - the importer found several projects or repositories at the provided URL. When this is the case, the Import Progress response will also include a `project_choices` field with the possible project choices as values. To update project choice, please see the [Update an import](https://developer.github.com/v3/migrations/source_imports/#update-an-import) section.
-   *
-   * **The project_choices field**
-   *
-   * When multiple projects are found at the provided URL, the response hash will include a `project_choices` field, the value of which is an array of hashes each representing a project choice. The exact key/value pairs of the project hashes will differ depending on the version control type.
-   *
-   * **Git LFS related fields**
-   *
-   * This section includes details about Git LFS related fields that may be present in the Import Progress response.
-   *
-   * *   `use_lfs` - describes whether the import has been opted in or out of using Git LFS. The value can be `opt_in`, `opt_out`, or `undecided` if no action has been taken.
-   * *   `has_large_files` - the boolean value describing whether files larger than 100MB were found during the `importing` step.
-   * *   `large_files_size` - the total size in gigabytes of files larger than 100MB found in the originating repository.
-   * *   `large_files_count` - the total number of files larger than 100MB found in the originating repository. To see a list of these files, make a "Get Large Files" request.
+   * </p>
+   * <ul>
+   * <li><code>detecting</code> - the &quot;detection&quot; step of the import is
+   * in progress because the request did not include a <code>vcs</code> parameter.
+   * The import is identifying the type of source control present at the URL.</li>
+   * <li><code>importing</code> - the &quot;raw&quot; step of the import is in
+   * progress. This is where commit data is fetched from the original repository.
+   * The import progress response will include <code>commit_count</code> (the
+   * total number of raw commits that will be imported) and <code>percent</code>
+   * (0 - 100, the current progress through the import).</li>
+   * <li><code>mapping</code> - the &quot;rewrite&quot; step of the import is in
+   * progress. This is where SVN branches are converted to Git branches, and where
+   * author updates are applied. The import progress response does not include
+   * progress information.</li>
+   * <li><code>pushing</code> - the &quot;push&quot; step of the import is in
+   * progress. This is where the importer updates the repository on GitHub. The
+   * import progress response will include <code>push_percent</code>, which is the
+   * percent value reported by <code>git push</code> when it is &quot;Writing
+   * objects&quot;.</li>
+   * <li><code>complete</code> - the import is complete, and the repository is
+   * ready on GitHub.</li>
+   * </ul>
+   * <p>
+   * If there are problems, you will see one of these in the <code>status</code>
+   * field:
+   * </p>
+   * <ul>
+   * <li><code>auth_failed</code> - the import requires authentication in order to
+   * connect to the original repository. To update authentication for the import,
+   * please see the <a href=
+   * "https://developer.github.com/v3/migrations/source_imports/#update-an-import">Update
+   * an import</a> section.</li>
+   * <li><code>error</code> - the import encountered an error. The import progress
+   * response will include the <code>failed_step</code> and an error message.
+   * Contact <a href="https://github.com/contact">GitHub Support</a> or
+   * <a href="https://premium.githubsupport.com">GitHub Premium Support</a> for
+   * more information.</li>
+   * <li><code>detection_needs_auth</code> - the importer requires authentication
+   * for the originating repository to continue detection. To update
+   * authentication for the import, please see the <a href=
+   * "https://developer.github.com/v3/migrations/source_imports/#update-an-import">Update
+   * an import</a> section.</li>
+   * <li><code>detection_found_nothing</code> - the importer didn't recognize any
+   * source control at the URL. To resolve, <a href=
+   * "https://developer.github.com/v3/migrations/source_imports/#cancel-an-import">Cancel
+   * the import</a> and <a href=
+   * "https://developer.github.com/v3/migrations/source_imports/#start-an-import">retry</a>
+   * with the correct URL.</li>
+   * <li><code>detection_found_multiple</code> - the importer found several
+   * projects or repositories at the provided URL. When this is the case, the
+   * Import Progress response will also include a <code>project_choices</code>
+   * field with the possible project choices as values. To update project choice,
+   * please see the <a href=
+   * "https://developer.github.com/v3/migrations/source_imports/#update-an-import">Update
+   * an import</a> section.</li>
+   * </ul>
+   * <p>
+   * <strong>The project_choices field</strong>
+   * </p>
+   * <p>
+   * When multiple projects are found at the provided URL, the response hash will
+   * include a <code>project_choices</code> field, the value of which is an array
+   * of hashes each representing a project choice. The exact key/value pairs of
+   * the project hashes will differ depending on the version control type.
+   * </p>
+   * <p>
+   * <strong>Git LFS related fields</strong>
+   * </p>
+   * <p>
+   * This section includes details about Git LFS related fields that may be
+   * present in the Import Progress response.
+   * </p>
+   * <ul>
+   * <li><code>use_lfs</code> - describes whether the import has been opted in or
+   * out of using Git LFS. The value can be <code>opt_in</code>,
+   * <code>opt_out</code>, or <code>undecided</code> if no action has been
+   * taken.</li>
+   * <li><code>has_large_files</code> - the boolean value describing whether files
+   * larger than 100MB were found during the <code>importing</code> step.</li>
+   * <li><code>large_files_size</code> - the total size in gigabytes of files
+   * larger than 100MB found in the originating repository.</li>
+   * <li><code>large_files_count</code> - the total number of files larger than
+   * 100MB found in the originating repository. To see a list of these files, make
+   * a &quot;Get Large Files&quot; request.</li>
+   * </ul>
+   * 
    */
   @Path("/{owner}/{repo}/import")
   @GET
   @Produces("application/json")
-  Response migrations_get_import_status(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response migrations_get_import_status(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * Start a source import to a GitHub repository using GitHub Importer.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response migrations_start_import(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response migrations_start_import(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
+   * <p>
    * Stop an import for a repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import")
   @DELETE
   void migrations_cancel_import(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * An import can be updated with credentials or a project choice by passing in the appropriate parameters in this API
-   * request. If no parameters are provided, the import will be restarted.
+   * <p>
+   * An import can be updated with credentials or a project choice by passing in
+   * the appropriate parameters in this API request. If no parameters are
+   * provided, the import will be restarted.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response migrations_update_import(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response migrations_update_import(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Update an author's identity for the import. Your application can continue updating authors any time before you push new commits to the repository.
+   * <p>
+   * Update an author's identity for the import. Your application can continue
+   * updating authors any time before you push new commits to the repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import/authors/{author_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response migrations_map_commit_author(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("author_id") Integer authorId, InputStream data);
+  Response migrations_map_commit_author(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("author_id") Integer authorId, InputStream data);
 
   /**
-   * Each type of source control system represents authors in a different way. For example, a Git commit author has a display name and an email address, but a Subversion commit author just has a username. The GitHub Importer will make the author information valid, but the author might not be correct. For example, it will change the bare Subversion username `hubot` into something like `hubot <hubot@12341234-abab-fefe-8787-fedcba987654>`.
-   *
-   * This endpoint and the [Map a commit author](https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author) endpoint allow you to provide correct Git author information.
+   * <p>
+   * Each type of source control system represents authors in a different way. For
+   * example, a Git commit author has a display name and an email address, but a
+   * Subversion commit author just has a username. The GitHub Importer will make
+   * the author information valid, but the author might not be correct. For
+   * example, it will change the bare Subversion username <code>hubot</code> into
+   * something like
+   * <code>hubot &lt;hubot@12341234-abab-fefe-8787-fedcba987654&gt;</code>.
+   * </p>
+   * <p>
+   * This endpoint and the <a href=
+   * "https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author">Map
+   * a commit author</a> endpoint allow you to provide correct Git author
+   * information.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import/authors")
   @GET
   @Produces("application/json")
-  Response migrations_get_commit_authors(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("since") String since);
+  Response migrations_get_commit_authors(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("since") String since);
 
   /**
-   * You can import repositories from Subversion, Mercurial, and TFS that include files larger than 100MB. This ability is powered by [Git LFS](https://git-lfs.github.com). You can learn more about our LFS feature and working with large files [on our help site](https://help.github.com/articles/versioning-large-files/).
+   * <p>
+   * You can import repositories from Subversion, Mercurial, and TFS that include
+   * files larger than 100MB. This ability is powered by
+   * <a href="https://git-lfs.github.com">Git LFS</a>. You can learn more about
+   * our LFS feature and working with large files
+   * <a href="https://help.github.com/articles/versioning-large-files/">on our
+   * help site</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/import/lfs")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response migrations_set_lfs_preference(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response migrations_set_lfs_preference(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
-   * Shows which group of GitHub users can interact with this repository and when the restriction expires. If there are no restrictions, you will see an empty response.
+   * <p>
+   * Shows which group of GitHub users can interact with this repository and when
+   * the restriction expires. If there are no restrictions, you will see an empty
+   * response.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/interaction-limits")
   @GET
   @Produces("application/json")
-  Response interactions_get_restrictions_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response interactions_get_restrictions_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Temporarily restricts interactions to certain GitHub users within the given repository. You must have owner or admin access to set restrictions.
+   * <p>
+   * Temporarily restricts interactions to certain GitHub users within the given
+   * repository. You must have owner or admin access to set restrictions.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/interaction-limits")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response interactions_set_restrictions_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response interactions_set_restrictions_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
-   * Removes all interaction restrictions from the given repository. You must have owner or admin access to remove restrictions.
+   * <p>
+   * Removes all interaction restrictions from the given repository. You must have
+   * owner or admin access to remove restrictions.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/interaction-limits")
   @DELETE
-  void interactions_remove_restrictions_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void interactions_remove_restrictions_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * This method returns the contents of the repository's license file, if one is detected.
-   *
-   * Similar to [Get repository content](https://developer.github.com/v3/repos/contents/#get-repository-content), this method also supports [custom media types](https://developer.github.com/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.
+   * <p>
+   * This method returns the contents of the repository's license file, if one is
+   * detected.
+   * </p>
+   * <p>
+   * Similar to <a href=
+   * "https://developer.github.com/v3/repos/contents/#get-repository-content">Get
+   * repository content</a>, this method also supports <a href=
+   * "https://developer.github.com/v3/repos/contents/#custom-media-types">custom
+   * media types</a> for retrieving the raw license content or rendered license
+   * HTML.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/license")
   @GET
@@ -1731,44 +2804,58 @@ public interface ReposResource {
   Response licenses_get_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/subscription")
   @GET
   @Produces("application/json")
-  Response activity_get_repo_subscription(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response activity_get_repo_subscription(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription) completely.
+   * <p>
+   * If you would like to watch a repository, set <code>subscribed</code> to
+   * <code>true</code>. If you would like to ignore notifications made within a
+   * repository, set <code>ignored</code> to <code>true</code>. If you would like
+   * to stop watching a repository, <a href=
+   * "https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription">delete
+   * the repository's subscription</a> completely.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/subscription")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
-  Response activity_set_repo_subscription(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response activity_set_repo_subscription(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
-   * This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](https://developer.github.com/v3/activity/watching/#set-a-repository-subscription).
+   * <p>
+   * This endpoint should only be used to stop watching a repository. To control
+   * whether or not you wish to receive notifications from a repository, <a href=
+   * "https://developer.github.com/v3/activity/watching/#set-a-repository-subscription">set
+   * the repository's subscription manually</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/subscription")
   @DELETE
-  void activity_delete_repo_subscription(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void activity_delete_repo_subscription(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/events")
   @GET
   @Produces("application/json")
-  Response activity_list_repo_events(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response activity_list_repo_events(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * List all notifications for the current user.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/notifications")
   @GET
@@ -1776,42 +2863,66 @@ public interface ReposResource {
   Response activity_list_repo_notifications_for_authenticated_user(@PathParam("owner") String owner,
       @PathParam("repo") String repo, @QueryParam("all") Boolean all,
       @QueryParam("participating") Boolean participating, @QueryParam("since") String since,
-      @QueryParam("before") String before, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("before") String before, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Marks all notifications in a repository as "read" removes them from the [default view on GitHub](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List repository notifications for the authenticated user](https://developer.github.com/v3/activity/notifications/#list-repository-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+   * <p>
+   * Marks all notifications in a repository as &quot;read&quot; removes them from
+   * the <a href="https://github.com/notifications">default view on GitHub</a>. If
+   * the number of notifications is too large to complete in one request, you will
+   * receive a <code>202 Accepted</code> status and GitHub will run an
+   * asynchronous process to mark notifications as &quot;read.&quot; To check
+   * whether any &quot;unread&quot; notifications remain, you can use the <a href=
+   * "https://developer.github.com/v3/activity/notifications/#list-repository-notifications-for-the-authenticated-user">List
+   * repository notifications for the authenticated user</a> endpoint and pass the
+   * query parameter <code>all=false</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/notifications")
   @PUT
   @Consumes("application/json")
-  void activity_mark_repo_notifications_as_read(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  void activity_mark_repo_notifications_as_read(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
+   * <p>
    * Lists the people watching the specified repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/subscribers")
   @GET
   @Produces("application/json")
-  Response activity_list_watchers_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response activity_list_watchers_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists the people that have starred the repository.
-   *
-   * You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:
+   * </p>
+   * <p>
+   * You can also find out <em>when</em> stars were created by passing the
+   * following custom <a href="https://developer.github.com/v3/media/">media
+   * type</a> via the <code>Accept</code> header:
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/stargazers")
   @GET
   @Produces({"application/json", "application/vnd.github.v3.star+json"})
-  Response activity_list_stargazers_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response activity_list_stargazers_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.
+   * <p>
+   * Lists annotations for a check run using the annotation <code>id</code>.
+   * GitHub Apps must have the <code>checks:read</code> permission on a private
+   * repository or pull access to a public repository to get annotations for a
+   * check run. OAuth Apps and authenticated users must have the <code>repo</code>
+   * scope to get annotations for a check run in a private repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-runs/{check_run_id}/annotations")
   @GET
@@ -1821,48 +2932,92 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
-   *
-   * Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array and a <code>null</code> value for
+   * <code>head_branch</code>.
+   * </p>
+   * <p>
+   * Lists check suites for a commit <code>ref</code>. The <code>ref</code> can be
+   * a SHA, branch name, or a tag name. GitHub Apps must have the
+   * <code>checks:read</code> permission on a private repository or pull access to
+   * a public repository to list check suites. OAuth Apps and authenticated users
+   * must have the <code>repo</code> scope to get check suites in a private
+   * repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{ref}/check-suites")
   @GET
   @Produces("application/json")
-  Response checks_list_suites_for_ref(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("ref") String ref,
-      @QueryParam("app_id") Integer appId, @QueryParam("check_name") String checkName,
+  Response checks_list_suites_for_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("ref") String ref, @QueryParam("app_id") Integer appId, @QueryParam("check_name") String checkName,
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
-   *
-   * Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array.
+   * </p>
+   * <p>
+   * Lists check runs for a commit ref. The <code>ref</code> can be a SHA, branch
+   * name, or a tag name. GitHub Apps must have the <code>checks:read</code>
+   * permission on a private repository or pull access to a public repository to
+   * get check runs. OAuth Apps and authenticated users must have the
+   * <code>repo</code> scope to get check runs in a private repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/commits/{ref}/check-runs")
   @GET
   @Produces("application/json")
   Response checks_list_for_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("ref") String ref, @QueryParam("check_name") String checkName,
-      @QueryParam("status") String status, @QueryParam("filter") String filter,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+      @PathParam("ref") String ref, @QueryParam("check_name") String checkName, @QueryParam("status") String status,
+      @QueryParam("filter") String filter, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
-   *
-   * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array.
+   * </p>
+   * <p>
+   * Lists check runs for a check suite using its <code>id</code>. GitHub Apps
+   * must have the <code>checks:read</code> permission on a private repository or
+   * pull access to a public repository to get check runs. OAuth Apps and
+   * authenticated users must have the <code>repo</code> scope to get check runs
+   * in a private repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-suites/{check_suite_id}/check-runs")
   @GET
   @Produces("application/json")
   Response checks_list_for_suite(@PathParam("owner") String owner, @PathParam("repo") String repo,
       @PathParam("check_suite_id") Integer checkSuiteId, @QueryParam("check_name") String checkName,
-      @QueryParam("status") String status, @QueryParam("filter") String filter,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+      @QueryParam("status") String status, @QueryParam("filter") String filter, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
-   *
-   * Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array.
+   * </p>
+   * <p>
+   * Gets a single check run using its <code>id</code>. GitHub Apps must have the
+   * <code>checks:read</code> permission on a private repository or pull access to
+   * a public repository to get check runs. OAuth Apps and authenticated users
+   * must have the <code>repo</code> scope to get check runs in a private
+   * repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-runs/{check_run_id}")
   @GET
@@ -1871,9 +3026,17 @@ public interface ReposResource {
       @PathParam("check_run_id") Integer checkRunId);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
-   *
-   * Updates a check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to edit check runs.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array.
+   * </p>
+   * <p>
+   * Updates a check run for a specific commit in a repository. Your GitHub App
+   * must have the <code>checks:write</code> permission to edit check runs.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-runs/{check_run_id}")
   @PATCH
@@ -1883,21 +3046,45 @@ public interface ReposResource {
       @PathParam("check_run_id") Integer checkRunId, InputStream data);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
-   *
-   * By default, check suites are automatically created when you create a [check run](https://developer.github.com/v3/checks/runs/). You only need to use this endpoint for manually creating check suites when you've disabled automatic creation using "[Update repository preferences for check suites](https://developer.github.com/v3/checks/suites/#update-repository-preferences-for-check-suites)". Your GitHub App must have the `checks:write` permission to create check suites.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array and a <code>null</code> value for
+   * <code>head_branch</code>.
+   * </p>
+   * <p>
+   * By default, check suites are automatically created when you create a
+   * <a href="https://developer.github.com/v3/checks/runs/">check run</a>. You
+   * only need to use this endpoint for manually creating check suites when you've
+   * disabled automatic creation using &quot;<a href=
+   * "https://developer.github.com/v3/checks/suites/#update-repository-preferences-for-check-suites">Update
+   * repository preferences for check suites</a>&quot;. Your GitHub App must have
+   * the <code>checks:write</code> permission to create check suites.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-suites")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response checks_create_suite(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response checks_create_suite(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository. This endpoint will trigger the [`check_suite` webhook](https://developer.github.com/webhooks/event-payloads/#check_suite) event with the action `rerequested`. When a check suite is `rerequested`, its `status` is reset to `queued` and the `conclusion` is cleared.
-   *
-   * To rerequest a check suite, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.
+   * <p>
+   * Triggers GitHub to rerequest an existing check suite, without pushing new
+   * code to a repository. This endpoint will trigger the <a href=
+   * "https://developer.github.com/webhooks/event-payloads/#check_suite"><code>check_suite</code>
+   * webhook</a> event with the action <code>rerequested</code>. When a check
+   * suite is <code>rerequested</code>, its <code>status</code> is reset to
+   * <code>queued</code> and the <code>conclusion</code> is cleared.
+   * </p>
+   * <p>
+   * To rerequest a check suite, your GitHub App must have the
+   * <code>checks:read</code> permission on a private repository or pull access to
+   * a public repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-suites/{check_suite_id}/rerequest")
   @POST
@@ -1905,31 +3092,59 @@ public interface ReposResource {
       @PathParam("check_suite_id") Integer checkSuiteId);
 
   /**
-   * Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://developer.github.com/v3/checks/suites/#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.
+   * <p>
+   * Changes the default automatic flow when creating check suites. By default, a
+   * check suite is automatically created each time code is pushed to a
+   * repository. When you disable the automatic creation of check suites, you can
+   * manually <a href=
+   * "https://developer.github.com/v3/checks/suites/#create-a-check-suite">Create
+   * a check suite</a>. You must have admin permissions in the repository to set
+   * preferences for check suites.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-suites/preferences")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response checks_set_suites_preferences(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response checks_set_suites_preferences(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      InputStream data);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
-   *
-   * Creates a new check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to create check runs.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array.
+   * </p>
+   * <p>
+   * Creates a new check run for a specific commit in a repository. Your GitHub
+   * App must have the <code>checks:write</code> permission to create check runs.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-runs")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response checks_create(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response checks_create(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
-   *
-   * Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+   * <p>
+   * <strong>Note:</strong> The Checks API only looks for pushes in the repository
+   * where the check suite or check run were created. Pushes to a branch in a
+   * forked repository are not detected and return an empty
+   * <code>pull_requests</code> array and a <code>null</code> value for
+   * <code>head_branch</code>.
+   * </p>
+   * <p>
+   * Gets a single check suite using its <code>id</code>. GitHub Apps must have
+   * the <code>checks:read</code> permission on a private repository or pull
+   * access to a public repository to get check suites. OAuth Apps and
+   * authenticated users must have the <code>repo</code> scope to get check suites
+   * in a private repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/check-suites/{check_suite_id}")
   @GET
@@ -1938,81 +3153,118 @@ public interface ReposResource {
       @PathParam("check_suite_id") Integer checkSuiteId);
 
   /**
-   * Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+   * <p>
+   * Lists the projects in a repository. Returns a <code>404 Not Found</code>
+   * status if projects are disabled in the repository. If you do not have
+   * sufficient privileges to perform this action, a <code>401 Unauthorized</code>
+   * or <code>410 Gone</code> status is returned.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/projects")
   @GET
   @Produces("application/json")
   Response projects_list_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @QueryParam("state") String state, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("state") String state, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Creates a repository project board. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+   * <p>
+   * Creates a repository project board. Returns a <code>404 Not Found</code>
+   * status if projects are disabled in the repository. If you do not have
+   * sufficient privileges to perform this action, a <code>401 Unauthorized</code>
+   * or <code>410 Gone</code> status is returned.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/projects")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response projects_create_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, InputStream data);
+  Response projects_create_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * List the reactions to an [issue comment](https://developer.github.com/v3/issues/comments/).
+   * <p>
+   * List the reactions to an
+   * <a href="https://developer.github.com/v3/issues/comments/">issue comment</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments/{comment_id}/reactions")
   @GET
   @Produces("application/json")
-  Response reactions_list_for_issue_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId,
-      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response reactions_list_for_issue_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, @QueryParam("content") String content,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Create a reaction to an [issue comment](https://developer.github.com/v3/issues/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue comment.
+   * <p>
+   * Create a reaction to an
+   * <a href="https://developer.github.com/v3/issues/comments/">issue comment</a>.
+   * A response with a <code>Status: 200 OK</code> means that you already added
+   * the reaction type to this issue comment.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments/{comment_id}/reactions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response reactions_create_for_issue_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId, InputStream data);
+  Response reactions_create_for_issue_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * List the reactions to an [issue](https://developer.github.com/v3/issues/).
+   * <p>
+   * List the reactions to an
+   * <a href="https://developer.github.com/v3/issues/">issue</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/reactions")
   @GET
   @Produces("application/json")
-  Response reactions_list_for_issue(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("issue_number") Integer issueNumber,
-      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response reactions_list_for_issue(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("issue_number") Integer issueNumber, @QueryParam("content") String content,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Create a reaction to an [issue](https://developer.github.com/v3/issues/). A response with a `Status: 200 OK` means that you already added the reaction type to this issue.
+   * <p>
+   * Create a reaction to an
+   * <a href="https://developer.github.com/v3/issues/">issue</a>. A response with
+   * a <code>Status: 200 OK</code> means that you already added the reaction type
+   * to this issue.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/reactions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response reactions_create_for_issue(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("issue_number") Integer issueNumber,
-      InputStream data);
+  Response reactions_create_for_issue(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
-   * List the reactions to a [pull request review comment](https://developer.github.com/v3/pulls/comments/).
+   * <p>
+   * List the reactions to a
+   * <a href="https://developer.github.com/v3/pulls/comments/">pull request review
+   * comment</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments/{comment_id}/reactions")
   @GET
   @Produces("application/json")
   Response reactions_list_for_pull_request_review_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId,
-      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId, @QueryParam("content") String content,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Create a reaction to a [pull request review comment](https://developer.github.com/v3/pulls/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this pull request review comment.
+   * <p>
+   * Create a reaction to a
+   * <a href="https://developer.github.com/v3/pulls/comments/">pull request review
+   * comment</a>. A response with a <code>Status: 200 OK</code> means that you
+   * already added the reaction type to this pull request review comment.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments/{comment_id}/reactions")
   @POST
@@ -2022,31 +3274,50 @@ public interface ReposResource {
       @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/comments/:comment_id/reactions/:reaction_id`.
-   *
-   * Delete a reaction to a [commit comment](https://developer.github.com/v3/repos/comments/).
+   * <p>
+   * <strong>Note:</strong> You can also specify a repository by
+   * <code>repository_id</code> using the route
+   * <code>DELETE /repositories/:repository_id/comments/:comment_id/reactions/:reaction_id</code>.
+   * </p>
+   * <p>
+   * Delete a reaction to a
+   * <a href="https://developer.github.com/v3/repos/comments/">commit comment</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}")
   @DELETE
-  void reactions_delete_for_commit_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId,
-      @PathParam("reaction_id") Integer reactionId);
+  void reactions_delete_for_commit_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, @PathParam("reaction_id") Integer reactionId);
 
   /**
-   * **Note:** You can also specify a repository by `repository_id` using the route `DELETE delete /repositories/:repository_id/issues/comments/:comment_id/reactions/:reaction_id`.
-   *
-   * Delete a reaction to an [issue comment](https://developer.github.com/v3/issues/comments/).
+   * <p>
+   * <strong>Note:</strong> You can also specify a repository by
+   * <code>repository_id</code> using the route
+   * <code>DELETE delete /repositories/:repository_id/issues/comments/:comment_id/reactions/:reaction_id</code>.
+   * </p>
+   * <p>
+   * Delete a reaction to an
+   * <a href="https://developer.github.com/v3/issues/comments/">issue comment</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}")
   @DELETE
-  void reactions_delete_for_issue_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId,
-      @PathParam("reaction_id") Integer reactionId);
+  void reactions_delete_for_issue_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, @PathParam("reaction_id") Integer reactionId);
 
   /**
-   * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/issues/:issue_number/reactions/:reaction_id`.
-   *
-   * Delete a reaction to an [issue](https://developer.github.com/v3/issues/).
+   * <p>
+   * <strong>Note:</strong> You can also specify a repository by
+   * <code>repository_id</code> using the route
+   * <code>DELETE /repositories/:repository_id/issues/:issue_number/reactions/:reaction_id</code>.
+   * </p>
+   * <p>
+   * Delete a reaction to an
+   * <a href="https://developer.github.com/v3/issues/">issue</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}")
   @DELETE
@@ -2054,114 +3325,195 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, @PathParam("reaction_id") Integer reactionId);
 
   /**
-   * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/pulls/comments/:comment_id/reactions/:reaction_id.`
-   *
-   * Delete a reaction to a [pull request review comment](https://developer.github.com/v3/pulls/comments/).
+   * <p>
+   * <strong>Note:</strong> You can also specify a repository by
+   * <code>repository_id</code> using the route
+   * <code>DELETE /repositories/:repository_id/pulls/comments/:comment_id/reactions/:reaction_id.</code>
+   * </p>
+   * <p>
+   * Delete a reaction to a
+   * <a href="https://developer.github.com/v3/pulls/comments/">pull request review
+   * comment</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}")
   @DELETE
-  void reactions_delete_for_pull_request_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId,
-      @PathParam("reaction_id") Integer reactionId);
+  void reactions_delete_for_pull_request_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, @PathParam("reaction_id") Integer reactionId);
 
   /**
-   * List the reactions to a [commit comment](https://developer.github.com/v3/repos/comments/).
+   * <p>
+   * List the reactions to a
+   * <a href="https://developer.github.com/v3/repos/comments/">commit comment</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/comments/{comment_id}/reactions")
   @GET
   @Produces("application/json")
-  Response reactions_list_for_commit_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId,
-      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response reactions_list_for_commit_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, @QueryParam("content") String content,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Create a reaction to a [commit comment](https://developer.github.com/v3/repos/comments/). A response with a `Status: 200 OK` means that you already added the reaction type to this commit comment.
+   * <p>
+   * Create a reaction to a
+   * <a href="https://developer.github.com/v3/repos/comments/">commit comment</a>.
+   * A response with a <code>Status: 200 OK</code> means that you already added
+   * the reaction type to this commit comment.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/comments/{comment_id}/reactions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response reactions_create_for_commit_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId, InputStream data);
+  Response reactions_create_for_commit_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * This method returns the contents of the repository's code of conduct file, if one is detected.
+   * <p>
+   * This method returns the contents of the repository's code of conduct file, if
+   * one is detected.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/community/code_of_conduct")
   @GET
   @Produces("application/json")
-  Response codes_of_conduct_get_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response codes_of_conduct_get_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Lists the workflows in a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Lists the workflows in a repository. Anyone with read access to the
+   * repository can use this endpoint. If the repository is private you must use
+   * an access token with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/workflows")
   @GET
   @Produces("application/json")
-  Response actions_list_repo_workflows(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response actions_list_repo_workflows(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * You can use this endpoint to manually trigger a GitHub Actions workflow run. You can also replace `{workflow_id}` with the workflow file name. For example, you could use `main.yml`.
-   *
-   * You must configure your GitHub Actions workflow to run when the [`workflow_dispatch` webhook](/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch) event occurs. The `inputs` are configured in the workflow file. For more information about how to configure the `workflow_dispatch` event in the workflow file, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#workflow_dispatch)."
-   *
-   * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)."
+   * <p>
+   * You can use this endpoint to manually trigger a GitHub Actions workflow run.
+   * You can also replace <code>{workflow_id}</code> with the workflow file name.
+   * For example, you could use <code>main.yml</code>.
+   * </p>
+   * <p>
+   * You must configure your GitHub Actions workflow to run when the <a href=
+   * "/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch"><code>workflow_dispatch</code>
+   * webhook</a> event occurs. The <code>inputs</code> are configured in the
+   * workflow file. For more information about how to configure the
+   * <code>workflow_dispatch</code> event in the workflow file, see &quot;<a href=
+   * "/actions/reference/events-that-trigger-workflows#workflow_dispatch">Events
+   * that trigger workflows</a>.&quot;
+   * </p>
+   * <p>
+   * You must authenticate using an access token with the <code>repo</code> scope
+   * to use this endpoint. GitHub Apps must have the <code>actions:write</code>
+   * permission to use this endpoint. For more information, see &quot;<a href=
+   * "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line">Creating
+   * a personal access token for the command line</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches")
   @POST
   @Consumes("application/json")
-  void actions_create_workflow_dispatch(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("workflow_id") Integer workflowId,
-      InputStream data);
+  void actions_create_workflow_dispatch(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("workflow_id") Integer workflowId, InputStream data);
 
   /**
-   * Lists binaries for the runner application that you can download and run. You must authenticate using an access token with the `repo` scope to use this endpoint.
+   * <p>
+   * Lists binaries for the runner application that you can download and run. You
+   * must authenticate using an access token with the <code>repo</code> scope to
+   * use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runners/downloads")
   @GET
   @Produces("application/json")
-  Response actions_list_runner_applications_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response actions_list_runner_applications_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Lists all artifacts for a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Lists all artifacts for a repository. Anyone with read access to the
+   * repository can use this endpoint. If the repository is private you must use
+   * an access token with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/artifacts")
   @GET
   @Produces("application/json")
-  Response actions_list_artifacts_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response actions_list_artifacts_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Lists all secrets available in a repository without revealing their encrypted values. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+   * <p>
+   * Lists all secrets available in a repository without revealing their encrypted
+   * values. You must authenticate using an access token with the
+   * <code>repo</code> scope to use this endpoint. GitHub Apps must have the
+   * <code>secrets</code> repository permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/secrets")
   @GET
   @Produces("application/json")
-  Response actions_list_repo_secrets(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response actions_list_repo_secrets(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Warning:** This GitHub Actions usage endpoint is currently in public beta and subject to change. For more information, see "[GitHub Actions API workflow usage](https://developer.github.com/changes/2020-05-15-actions-api-workflow-usage)."
-   *
-   * Gets the number of billable minutes used by a specific workflow during the current billing cycle. Billable minutes only apply to workflows in private repositories that use GitHub-hosted runners. Usage is listed for each GitHub-hosted runner operating system in milliseconds. Any job re-runs are also included in the usage. The usage does not include the multiplier for macOS and Windows runners and is not rounded up to the nearest whole minute. For more information, see "[Managing billing for GitHub Actions](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions)".
-   *
-   * You can also replace `:workflow_id` with `:workflow_file_name`. For example, you could use `main.yml`. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * <strong>Warning:</strong> This GitHub Actions usage endpoint is currently in
+   * public beta and subject to change. For more information, see &quot;<a href=
+   * "https://developer.github.com/changes/2020-05-15-actions-api-workflow-usage">GitHub
+   * Actions API workflow usage</a>.&quot;
+   * </p>
+   * <p>
+   * Gets the number of billable minutes used by a specific workflow during the
+   * current billing cycle. Billable minutes only apply to workflows in private
+   * repositories that use GitHub-hosted runners. Usage is listed for each
+   * GitHub-hosted runner operating system in milliseconds. Any job re-runs are
+   * also included in the usage. The usage does not include the multiplier for
+   * macOS and Windows runners and is not rounded up to the nearest whole minute.
+   * For more information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions">Managing
+   * billing for GitHub Actions</a>&quot;.
+   * </p>
+   * <p>
+   * You can also replace <code>:workflow_id</code> with
+   * <code>:workflow_file_name</code>. For example, you could use
+   * <code>main.yml</code>. Anyone with read access to the repository can use this
+   * endpoint. If the repository is private you must use an access token with the
+   * <code>repo</code> scope. GitHub Apps must have the <code>actions:read</code>
+   * permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/workflows/{workflow_id}/timing")
   @GET
   @Produces("application/json")
-  Response actions_get_workflow_usage(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("workflow_id") Integer workflowId);
+  Response actions_get_workflow_usage(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("workflow_id") Integer workflowId);
 
   /**
-   * Gets a specific artifact for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a specific artifact for a workflow run. Anyone with read access to the
+   * repository can use this endpoint. If the repository is private you must use
+   * an access token with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/artifacts/{artifact_id}")
   @GET
@@ -2170,7 +3522,12 @@ public interface ReposResource {
       @PathParam("artifact_id") Integer artifactId);
 
   /**
-   * Deletes an artifact for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+   * <p>
+   * Deletes an artifact for a workflow run. You must authenticate using an access
+   * token with the <code>repo</code> scope to use this endpoint. GitHub Apps must
+   * have the <code>actions:write</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/artifacts/{artifact_id}")
   @DELETE
@@ -2178,7 +3535,13 @@ public interface ReposResource {
       @PathParam("artifact_id") Integer artifactId);
 
   /**
-   * Gets a single repository secret without revealing its encrypted value. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+   * <p>
+   * Gets a single repository secret without revealing its encrypted value. You
+   * must authenticate using an access token with the <code>repo</code> scope to
+   * use this endpoint. GitHub Apps must have the <code>secrets</code> repository
+   * permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/secrets/{secret_name}")
   @GET
@@ -2187,91 +3550,113 @@ public interface ReposResource {
       @PathParam("secret_name") String secretName);
 
   /**
-   * Creates or updates a repository secret with an encrypted value. Encrypt your secret using
-   * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
-   * token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use
-   * this endpoint.
-   *
-   * #### Example encrypting a secret using Node.js
-   *
-   * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
-   *
-   * ```
-   * const sodium = require('tweetsodium');
-   *
-   * const key = "base64-encoded-public-key";
-   * const value = "plain-text-secret";
-   *
-   * // Convert the message and key to Uint8Array's (Buffer implements that interface)
-   * const messageBytes = Buffer.from(value);
-   * const keyBytes = Buffer.from(key, 'base64');
-   *
-   * // Encrypt using LibSodium.
-   * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
-   *
-   * // Base64 the encrypted secret
-   * const encrypted = Buffer.from(encryptedBytes).toString('base64');
-   *
-   * console.log(encrypted);
-   * ```
-   *
-   *
-   * #### Example encrypting a secret using Python
-   *
-   * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
-   *
-   * ```
-   * from base64 import b64encode
-   * from nacl import encoding, public
-   *
-   * def encrypt(public_key: str, secret_value: str) -> str:
-   *   """Encrypt a Unicode string using the public key."""
-   *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
-   *   sealed_box = public.SealedBox(public_key)
-   *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
-   *   return b64encode(encrypted).decode("utf-8")
-   * ```
-   *
-   * #### Example encrypting a secret using C#
-   *
-   * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
-   *
-   * ```
-   * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
-   * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
-   *
-   * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
-   *
-   * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
-   * ```
-   *
-   * #### Example encrypting a secret using Ruby
-   *
-   * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
-   *
-   * ```ruby
-   * require "rbnacl"
-   * require "base64"
-   *
-   * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
-   * public_key = RbNaCl::PublicKey.new(key)
-   *
-   * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
-   * encrypted_secret = box.encrypt("my_secret")
-   *
-   * # Print the base64 encoded secret
-   * puts Base64.strict_encode64(encrypted_secret)
-   * ```
+   * <p>
+   * Creates or updates a repository secret with an encrypted value. Encrypt your
+   * secret using <a href=
+   * "https://libsodium.gitbook.io/doc/bindings_for_other_languages">LibSodium</a>.
+   * You must authenticate using an access token with the <code>repo</code> scope
+   * to use this endpoint. GitHub Apps must have the <code>secrets</code>
+   * repository permission to use this endpoint.
+   * </p>
+   * <h4>Example encrypting a secret using Node.js</h4>
+   * <p>
+   * Encrypt your secret using the
+   * <a href="https://github.com/github/tweetsodium">tweetsodium</a> library.
+   * </p>
+   * 
+   * <pre>
+   * <code>const sodium = require('tweetsodium');
+  
+  const key = &quot;base64-encoded-public-key&quot;;
+  const value = &quot;plain-text-secret&quot;;
+  
+  // Convert the message and key to Uint8Array's (Buffer implements that interface)
+  const messageBytes = Buffer.from(value);
+  const keyBytes = Buffer.from(key, 'base64');
+  
+  // Encrypt using LibSodium.
+  const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+  
+  // Base64 the encrypted secret
+  const encrypted = Buffer.from(encryptedBytes).toString('base64');
+  
+  console.log(encrypted);
+  </code>
+   * </pre>
+   * 
+   * <h4>Example encrypting a secret using Python</h4>
+   * <p>
+   * Encrypt your secret using <a href=
+   * "https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox">pynacl</a>
+   * with Python 3.
+   * </p>
+   * 
+   * <pre>
+   * <code>from base64 import b64encode
+  from nacl import encoding, public
+  
+  def encrypt(public_key: str, secret_value: str) -&gt; str:
+    &quot;&quot;&quot;Encrypt a Unicode string using the public key.&quot;&quot;&quot;
+    public_key = public.PublicKey(public_key.encode(&quot;utf-8&quot;), encoding.Base64Encoder())
+    sealed_box = public.SealedBox(public_key)
+    encrypted = sealed_box.encrypt(secret_value.encode(&quot;utf-8&quot;))
+    return b64encode(encrypted).decode(&quot;utf-8&quot;)
+  </code>
+   * </pre>
+   * 
+   * <h4>Example encrypting a secret using C#</h4>
+   * <p>
+   * Encrypt your secret using the
+   * <a href="https://www.nuget.org/packages/Sodium.Core/">Sodium.Core</a>
+   * package.
+   * </p>
+   * 
+   * <pre>
+   * <code>var secretValue = System.Text.Encoding.UTF8.GetBytes(&quot;mySecret&quot;);
+  var publicKey = Convert.FromBase64String(&quot;2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=&quot;);
+  
+  var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+  
+  Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+  </code>
+   * </pre>
+   * 
+   * <h4>Example encrypting a secret using Ruby</h4>
+   * <p>
+   * Encrypt your secret using the
+   * <a href="https://github.com/RubyCrypto/rbnacl">rbnacl</a> gem.
+   * </p>
+   * 
+   * <pre>
+   * <code class="language-ruby">require &quot;rbnacl&quot;
+  require &quot;base64&quot;
+  
+  key = Base64.decode64(&quot;+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=&quot;)
+  public_key = RbNaCl::PublicKey.new(key)
+  
+  box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+  encrypted_secret = box.encrypt(&quot;my_secret&quot;)
+  
+  # Print the base64 encoded secret
+  puts Base64.strict_encode64(encrypted_secret)
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{owner}/{repo}/actions/secrets/{secret_name}")
   @PUT
   @Consumes("application/json")
-  void actions_create_or_update_repo_secret(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("secret_name") String secretName,
-      InputStream data);
+  void actions_create_or_update_repo_secret(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("secret_name") String secretName, InputStream data);
 
   /**
-   * Deletes a secret in a repository using the secret name. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+   * <p>
+   * Deletes a secret in a repository using the secret name. You must authenticate
+   * using an access token with the <code>repo</code> scope to use this endpoint.
+   * GitHub Apps must have the <code>secrets</code> repository permission to use
+   * this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/secrets/{secret_name}")
   @DELETE
@@ -2279,68 +3664,107 @@ public interface ReposResource {
       @PathParam("secret_name") String secretName);
 
   /**
-   * Gets a redirect URL to download an archive for a repository. This URL expires after 1 minute. Look for `Location:` in
-   * the response header to find the URL for the download. The `:archive_format` must be `zip`. Anyone with read access to
-   * the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
-   * GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a redirect URL to download an archive for a repository. This URL expires
+   * after 1 minute. Look for <code>Location:</code> in the response header to
+   * find the URL for the download. The <code>:archive_format</code> must be
+   * <code>zip</code>. Anyone with read access to the repository can use this
+   * endpoint. If the repository is private you must use an access token with the
+   * <code>repo</code> scope. GitHub Apps must have the <code>actions:read</code>
+   * permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}")
   @GET
   void actions_download_artifact(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("artifact_id") Integer artifactId,
-      @PathParam("archive_format") String archiveFormat);
+      @PathParam("artifact_id") Integer artifactId, @PathParam("archive_format") String archiveFormat);
 
   /**
-   * Gets a specific self-hosted runner. You must authenticate using an access token with the `repo` scope to use this endpoint.
+   * <p>
+   * Gets a specific self-hosted runner. You must authenticate using an access
+   * token with the <code>repo</code> scope to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runners/{runner_id}")
   @GET
   @Produces("application/json")
-  Response actions_get_self_hosted_runner_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("runner_id") Integer runnerId);
+  Response actions_get_self_hosted_runner_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("runner_id") Integer runnerId);
 
   /**
-   * Forces the removal of a self-hosted runner from a repository. You can use this endpoint to completely remove the runner when the machine you were using no longer exists. You must authenticate using an access token with the `repo` scope to use this endpoint.
+   * <p>
+   * Forces the removal of a self-hosted runner from a repository. You can use
+   * this endpoint to completely remove the runner when the machine you were using
+   * no longer exists. You must authenticate using an access token with the
+   * <code>repo</code> scope to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runners/{runner_id}")
   @DELETE
-  void actions_delete_self_hosted_runner_from_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("runner_id") Integer runnerId);
+  void actions_delete_self_hosted_runner_from_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("runner_id") Integer runnerId);
 
   /**
-   * Gets a redirect URL to download a plain text file of logs for a workflow job. This link expires after 1 minute. Look
-   * for `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can
-   * use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must
-   * have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a redirect URL to download a plain text file of logs for a workflow job.
+   * This link expires after 1 minute. Look for <code>Location:</code> in the
+   * response header to find the URL for the download. Anyone with read access to
+   * the repository can use this endpoint. If the repository is private you must
+   * use an access token with the <code>repo</code> scope. GitHub Apps must have
+   * the <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/jobs/{job_id}/logs")
   @GET
-  void actions_download_job_logs_for_workflow_run(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("job_id") Integer jobId);
+  void actions_download_job_logs_for_workflow_run(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("job_id") Integer jobId);
 
   /**
-   * Lists jobs for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://developer.github.com/v3/#parameters).
+   * <p>
+   * Lists jobs for a workflow run. Anyone with read access to the repository can
+   * use this endpoint. If the repository is private you must use an access token
+   * with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint. You can use
+   * parameters to narrow the list of results. For more information about using
+   * parameters, see
+   * <a href="https://developer.github.com/v3/#parameters">Parameters</a>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/jobs")
   @GET
   @Produces("application/json")
-  Response actions_list_jobs_for_workflow_run(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("run_id") Integer runId,
-      @QueryParam("filter") String filter, @QueryParam("per_page") Integer perPage,
+  Response actions_list_jobs_for_workflow_run(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("run_id") Integer runId, @QueryParam("filter") String filter, @QueryParam("per_page") Integer perPage,
       @QueryParam("page") Integer page);
 
   /**
-   * Lists all self-hosted runners for a repository. You must authenticate using an access token with the `repo` scope to use this endpoint.
+   * <p>
+   * Lists all self-hosted runners for a repository. You must authenticate using
+   * an access token with the <code>repo</code> scope to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runners")
   @GET
   @Produces("application/json")
-  Response actions_list_self_hosted_runners_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response actions_list_self_hosted_runners_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Gets a specific workflow. You can also replace `:workflow_id` with `:workflow_file_name`. For example, you could use `main.yml`. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a specific workflow. You can also replace <code>:workflow_id</code> with
+   * <code>:workflow_file_name</code>. For example, you could use
+   * <code>main.yml</code>. Anyone with read access to the repository can use this
+   * endpoint. If the repository is private you must use an access token with the
+   * <code>repo</code> scope. GitHub Apps must have the <code>actions:read</code>
+   * permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/workflows/{workflow_id}")
   @GET
@@ -2349,16 +3773,28 @@ public interface ReposResource {
       @PathParam("workflow_id") Integer workflowId);
 
   /**
-   * Gets a specific job in a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a specific job in a workflow run. Anyone with read access to the
+   * repository can use this endpoint. If the repository is private you must use
+   * an access token with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/jobs/{job_id}")
   @GET
   @Produces("application/json")
-  Response actions_get_job_for_workflow_run(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("job_id") Integer jobId);
+  Response actions_get_job_for_workflow_run(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("job_id") Integer jobId);
 
   /**
-   * Cancels a workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+   * <p>
+   * Cancels a workflow run using its <code>id</code>. You must authenticate using
+   * an access token with the <code>repo</code> scope to use this endpoint. GitHub
+   * Apps must have the <code>actions:write</code> permission to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/cancel")
   @POST
@@ -2366,26 +3802,42 @@ public interface ReposResource {
       @PathParam("run_id") Integer runId);
 
   /**
-   * Gets a redirect URL to download an archive of log files for a workflow run. This link expires after 1 minute. Look for
-   * `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can use
-   * this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have
-   * the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a redirect URL to download an archive of log files for a workflow run.
+   * This link expires after 1 minute. Look for <code>Location:</code> in the
+   * response header to find the URL for the download. Anyone with read access to
+   * the repository can use this endpoint. If the repository is private you must
+   * use an access token with the <code>repo</code> scope. GitHub Apps must have
+   * the <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/logs")
   @GET
-  void actions_download_workflow_run_logs(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("run_id") Integer runId);
+  void actions_download_workflow_run_logs(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("run_id") Integer runId);
 
   /**
-   * Deletes all logs for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+   * <p>
+   * Deletes all logs for a workflow run. You must authenticate using an access
+   * token with the <code>repo</code> scope to use this endpoint. GitHub Apps must
+   * have the <code>actions:write</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/logs")
   @DELETE
-  void actions_delete_workflow_run_logs(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("run_id") Integer runId);
+  void actions_delete_workflow_run_logs(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("run_id") Integer runId);
 
   /**
-   * Re-runs your workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+   * <p>
+   * Re-runs your workflow run using its <code>id</code>. You must authenticate
+   * using an access token with the <code>repo</code> scope to use this endpoint.
+   * GitHub Apps must have the <code>actions:write</code> permission to use this
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/rerun")
   @POST
@@ -2393,18 +3845,28 @@ public interface ReposResource {
       @PathParam("run_id") Integer runId);
 
   /**
-   * Gets a specific workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Gets a specific workflow run. Anyone with read access to the repository can
+   * use this endpoint. If the repository is private you must use an access token
+   * with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}")
   @GET
   @Produces("application/json")
-  Response actions_get_workflow_run(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("run_id") Integer runId);
+  Response actions_get_workflow_run(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("run_id") Integer runId);
 
   /**
-   * Delete a specific workflow run. Anyone with write access to the repository can use this endpoint. If the repository is
-   * private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:write` permission to use
-   * this endpoint.
+   * <p>
+   * Delete a specific workflow run. Anyone with write access to the repository
+   * can use this endpoint. If the repository is private you must use an access
+   * token with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:write</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}")
   @DELETE
@@ -2412,132 +3874,225 @@ public interface ReposResource {
       @PathParam("run_id") Integer runId);
 
   /**
-   * **Warning:** This GitHub Actions usage endpoint is currently in public beta and subject to change. For more information, see "[GitHub Actions API workflow usage](https://developer.github.com/changes/2020-05-15-actions-api-workflow-usage)."
-   *
-   * Gets the number of billable minutes and total run time for a specific workflow run. Billable minutes only apply to workflows in private repositories that use GitHub-hosted runners. Usage is listed for each GitHub-hosted runner operating system in milliseconds. Any job re-runs are also included in the usage. The usage does not include the multiplier for macOS and Windows runners and is not rounded up to the nearest whole minute. For more information, see "[Managing billing for GitHub Actions](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions)".
-   *
-   * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * <strong>Warning:</strong> This GitHub Actions usage endpoint is currently in
+   * public beta and subject to change. For more information, see &quot;<a href=
+   * "https://developer.github.com/changes/2020-05-15-actions-api-workflow-usage">GitHub
+   * Actions API workflow usage</a>.&quot;
+   * </p>
+   * <p>
+   * Gets the number of billable minutes and total run time for a specific
+   * workflow run. Billable minutes only apply to workflows in private
+   * repositories that use GitHub-hosted runners. Usage is listed for each
+   * GitHub-hosted runner operating system in milliseconds. Any job re-runs are
+   * also included in the usage. The usage does not include the multiplier for
+   * macOS and Windows runners and is not rounded up to the nearest whole minute.
+   * For more information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions">Managing
+   * billing for GitHub Actions</a>&quot;.
+   * </p>
+   * <p>
+   * Anyone with read access to the repository can use this endpoint. If the
+   * repository is private you must use an access token with the <code>repo</code>
+   * scope. GitHub Apps must have the <code>actions:read</code> permission to use
+   * this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/timing")
   @GET
   @Produces("application/json")
-  Response actions_get_workflow_run_usage(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("run_id") Integer runId);
+  Response actions_get_workflow_run_usage(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("run_id") Integer runId);
 
   /**
-   * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+   * <p>
+   * Gets your public key, which you need to encrypt secrets. You need to encrypt
+   * a secret before you can create or update secrets. Anyone with read access to
+   * the repository can use this endpoint. If the repository is private you must
+   * use an access token with the <code>repo</code> scope. GitHub Apps must have
+   * the <code>secrets</code> repository permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/secrets/public-key")
   @GET
   @Produces("application/json")
-  Response actions_get_repo_public_key(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response actions_get_repo_public_key(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Lists artifacts for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Lists artifacts for a workflow run. Anyone with read access to the repository
+   * can use this endpoint. If the repository is private you must use an access
+   * token with the <code>repo</code> scope. GitHub Apps must have the
+   * <code>actions:read</code> permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs/{run_id}/artifacts")
   @GET
   @Produces("application/json")
-  Response actions_list_workflow_run_artifacts(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("run_id") Integer runId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response actions_list_workflow_run_artifacts(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("run_id") Integer runId, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Returns a token that you can pass to the `config` script. The token expires after one hour. You must authenticate
-   * using an access token with the `repo` scope to use this endpoint.
-   *
-   * #### Example using registration token
-   *  
-   * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
-   *
-   * ```
-   * ./config.sh --url https://github.com/octo-org/octo-repo-artifacts --token TOKEN
-   * ```
+   * <p>
+   * Returns a token that you can pass to the <code>config</code> script. The
+   * token expires after one hour. You must authenticate using an access token
+   * with the <code>repo</code> scope to use this endpoint.
+   * </p>
+   * <h4>Example using registration token</h4>
+   * <p>
+   * Configure your self-hosted runner, replacing <code>TOKEN</code> with the
+   * registration token provided by this endpoint.
+   * </p>
+   * 
+   * <pre>
+   * <code>./config.sh --url https://github.com/octo-org/octo-repo-artifacts --token TOKEN
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runners/registration-token")
   @POST
   @Produces("application/json")
-  Response actions_create_registration_token_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response actions_create_registration_token_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * Returns a token that you can pass to remove a self-hosted runner from a repository. The token expires after one hour.
-   * You must authenticate using an access token with the `repo` scope to use this endpoint.
-   *
-   * #### Example using remove token
-   *  
-   * To remove your self-hosted runner from a repository, replace TOKEN with the remove token provided by this endpoint.
-   *
-   * ```
-   * ./config.sh remove --token TOKEN
-   * ```
+   * <p>
+   * Returns a token that you can pass to remove a self-hosted runner from a
+   * repository. The token expires after one hour. You must authenticate using an
+   * access token with the <code>repo</code> scope to use this endpoint.
+   * </p>
+   * <h4>Example using remove token</h4>
+   * <p>
+   * To remove your self-hosted runner from a repository, replace TOKEN with the
+   * remove token provided by this endpoint.
+   * </p>
+   * 
+   * <pre>
+   * <code>./config.sh remove --token TOKEN
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runners/remove-token")
   @POST
   @Produces("application/json")
-  Response actions_create_remove_token_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response actions_create_remove_token_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * List all workflow runs for a workflow. You can also replace `:workflow_id` with `:workflow_file_name`. For example, you could use `main.yml`. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://developer.github.com/v3/#parameters).
-   *
-   * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+   * <p>
+   * List all workflow runs for a workflow. You can also replace
+   * <code>:workflow_id</code> with <code>:workflow_file_name</code>. For example,
+   * you could use <code>main.yml</code>. You can use parameters to narrow the
+   * list of results. For more information about using parameters, see
+   * <a href="https://developer.github.com/v3/#parameters">Parameters</a>.
+   * </p>
+   * <p>
+   * Anyone with read access to the repository can use this endpoint. If the
+   * repository is private you must use an access token with the <code>repo</code>
+   * scope.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/workflows/{workflow_id}/runs")
   @GET
   @Produces("application/json")
-  Response actions_list_workflow_runs(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("workflow_id") Integer workflowId,
-      @QueryParam("actor") String actor, @QueryParam("branch") String branch,
-      @QueryParam("event") String event, @QueryParam("status") String status,
+  Response actions_list_workflow_runs(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("workflow_id") Integer workflowId, @QueryParam("actor") String actor,
+      @QueryParam("branch") String branch, @QueryParam("event") String event, @QueryParam("status") String status,
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Lists all workflow runs for a repository. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://developer.github.com/v3/#parameters).
-   *
-   * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+   * <p>
+   * Lists all workflow runs for a repository. You can use parameters to narrow
+   * the list of results. For more information about using parameters, see
+   * <a href="https://developer.github.com/v3/#parameters">Parameters</a>.
+   * </p>
+   * <p>
+   * Anyone with read access to the repository can use this endpoint. If the
+   * repository is private you must use an access token with the <code>repo</code>
+   * scope. GitHub Apps must have the <code>actions:read</code> permission to use
+   * this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/actions/runs")
   @GET
   @Produces("application/json")
-  Response actions_list_workflow_runs_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("actor") String actor,
-      @QueryParam("branch") String branch, @QueryParam("event") String event,
-      @QueryParam("status") String status, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response actions_list_workflow_runs_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("actor") String actor, @QueryParam("branch") String branch, @QueryParam("event") String event,
+      @QueryParam("status") String status, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Note:** Multi-line comments on pull requests are currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Note:</strong> Multi-line comments on pull requests are currently in
+   * public beta and subject to change.
+   * </p>
+   * <p>
    * Provides details for a review comment.
-   *
-   * **Multi-line comment summary**
-   *
-   * **Note:** New parameters and response fields are available for developers to preview. During the preview period, these response fields may change without advance notice. Please see the [blog post](https://developer.github.com/changes/2019-10-03-multi-line-comments) for full details.
-   *
-   * Use the `comfort-fade` preview header and the `line` parameter to show multi-line comment-supported fields in the response.
-   *
-   * If you use the `comfort-fade` preview header, your response will show:
-   *
-   * *   For multi-line comments, values for `start_line`, `original_start_line`, `start_side`, `line`, `original_line`, and `side`.
-   * *   For single-line comments, values for `line`, `original_line`, and `side` and a `null` value for `start_line`, `original_start_line`, and `start_side`.
-   *
-   * If you don't use the `comfort-fade` preview header, multi-line and single-line comments will appear the same way in the response with a single `position` attribute. Your response will show:
-   *
-   * *   For multi-line comments, the last line of the comment range for the `position` attribute.
-   * *   For single-line comments, the diff-positioned way of referencing comments for the `position` attribute. For more information, see `position` in the [input parameters](https://developer.github.com/v3/pulls/comments/#parameters-2) table.
-   *
-   * The `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](https://developer.github.com/v3/reactions) reactions.
+   * </p>
+   * <p>
+   * <strong>Multi-line comment summary</strong>
+   * </p>
+   * <p>
+   * <strong>Note:</strong> New parameters and response fields are available for
+   * developers to preview. During the preview period, these response fields may
+   * change without advance notice. Please see the <a href=
+   * "https://developer.github.com/changes/2019-10-03-multi-line-comments">blog
+   * post</a> for full details.
+   * </p>
+   * <p>
+   * Use the <code>comfort-fade</code> preview header and the <code>line</code>
+   * parameter to show multi-line comment-supported fields in the response.
+   * </p>
+   * <p>
+   * If you use the <code>comfort-fade</code> preview header, your response will
+   * show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, values for <code>start_line</code>,
+   * <code>original_start_line</code>, <code>start_side</code>, <code>line</code>,
+   * <code>original_line</code>, and <code>side</code>.</li>
+   * <li>For single-line comments, values for <code>line</code>,
+   * <code>original_line</code>, and <code>side</code> and a <code>null</code>
+   * value for <code>start_line</code>, <code>original_start_line</code>, and
+   * <code>start_side</code>.</li>
+   * </ul>
+   * <p>
+   * If you don't use the <code>comfort-fade</code> preview header, multi-line and
+   * single-line comments will appear the same way in the response with a single
+   * <code>position</code> attribute. Your response will show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, the last line of the comment range for the
+   * <code>position</code> attribute.</li>
+   * <li>For single-line comments, the diff-positioned way of referencing comments
+   * for the <code>position</code> attribute. For more information, see
+   * <code>position</code> in the
+   * <a href="https://developer.github.com/v3/pulls/comments/#parameters-2">input
+   * parameters</a> table.</li>
+   * </ul>
+   * <p>
+   * The <code>reactions</code> key will have the following payload where
+   * <code>url</code> can be used to construct the API location for
+   * <a href="https://developer.github.com/v3/reactions">listing and creating</a>
+   * reactions.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments/{comment_id}")
   @GET
   @Produces("application/json")
-  Response pulls_get_review_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId);
+  Response pulls_get_review_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId);
 
   /**
+   * <p>
    * Deletes a review comment.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments/{comment_id}")
   @DELETE
@@ -2545,133 +4100,286 @@ public interface ReposResource {
       @PathParam("comment_id") Integer commentId);
 
   /**
-   * **Note:** Multi-line comments on pull requests are currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Note:</strong> Multi-line comments on pull requests are currently in
+   * public beta and subject to change.
+   * </p>
+   * <p>
    * Enables you to edit a review comment.
-   *
-   * **Multi-line comment summary**
-   *
-   * **Note:** New parameters and response fields are available for developers to preview. During the preview period, these response fields may change without advance notice. Please see the [blog post](https://developer.github.com/changes/2019-10-03-multi-line-comments) for full details.
-   *
-   * Use the `comfort-fade` preview header and the `line` parameter to show multi-line comment-supported fields in the response.
-   *
-   * If you use the `comfort-fade` preview header, your response will show:
-   *
-   * *   For multi-line comments, values for `start_line`, `original_start_line`, `start_side`, `line`, `original_line`, and `side`.
-   * *   For single-line comments, values for `line`, `original_line`, and `side` and a `null` value for `start_line`, `original_start_line`, and `start_side`.
-   *
-   * If you don't use the `comfort-fade` preview header, multi-line and single-line comments will appear the same way in the response with a single `position` attribute. Your response will show:
-   *
-   * *   For multi-line comments, the last line of the comment range for the `position` attribute.
-   * *   For single-line comments, the diff-positioned way of referencing comments for the `position` attribute. For more information, see `position` in the [input parameters](https://developer.github.com/v3/pulls/comments/#parameters-2) table.
+   * </p>
+   * <p>
+   * <strong>Multi-line comment summary</strong>
+   * </p>
+   * <p>
+   * <strong>Note:</strong> New parameters and response fields are available for
+   * developers to preview. During the preview period, these response fields may
+   * change without advance notice. Please see the <a href=
+   * "https://developer.github.com/changes/2019-10-03-multi-line-comments">blog
+   * post</a> for full details.
+   * </p>
+   * <p>
+   * Use the <code>comfort-fade</code> preview header and the <code>line</code>
+   * parameter to show multi-line comment-supported fields in the response.
+   * </p>
+   * <p>
+   * If you use the <code>comfort-fade</code> preview header, your response will
+   * show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, values for <code>start_line</code>,
+   * <code>original_start_line</code>, <code>start_side</code>, <code>line</code>,
+   * <code>original_line</code>, and <code>side</code>.</li>
+   * <li>For single-line comments, values for <code>line</code>,
+   * <code>original_line</code>, and <code>side</code> and a <code>null</code>
+   * value for <code>start_line</code>, <code>original_start_line</code>, and
+   * <code>start_side</code>.</li>
+   * </ul>
+   * <p>
+   * If you don't use the <code>comfort-fade</code> preview header, multi-line and
+   * single-line comments will appear the same way in the response with a single
+   * <code>position</code> attribute. Your response will show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, the last line of the comment range for the
+   * <code>position</code> attribute.</li>
+   * <li>For single-line comments, the diff-positioned way of referencing comments
+   * for the <code>position</code> attribute. For more information, see
+   * <code>position</code> in the
+   * <a href="https://developer.github.com/v3/pulls/comments/#parameters-2">input
+   * parameters</a> table.</li>
+   * </ul>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments/{comment_id}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response pulls_update_review_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("comment_id") Integer commentId, InputStream data);
+  Response pulls_update_review_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * **Note:** Multi-line comments on pull requests are currently in public beta and subject to change.
-   *
-   * Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
-   *
-   * **Multi-line comment summary**
-   *
-   * **Note:** New parameters and response fields are available for developers to preview. During the preview period, these response fields may change without advance notice. Please see the [blog post](https://developer.github.com/changes/2019-10-03-multi-line-comments) for full details.
-   *
-   * Use the `comfort-fade` preview header and the `line` parameter to show multi-line comment-supported fields in the response.
-   *
-   * If you use the `comfort-fade` preview header, your response will show:
-   *
-   * *   For multi-line comments, values for `start_line`, `original_start_line`, `start_side`, `line`, `original_line`, and `side`.
-   * *   For single-line comments, values for `line`, `original_line`, and `side` and a `null` value for `start_line`, `original_start_line`, and `start_side`.
-   *
-   * If you don't use the `comfort-fade` preview header, multi-line and single-line comments will appear the same way in the response with a single `position` attribute. Your response will show:
-   *
-   * *   For multi-line comments, the last line of the comment range for the `position` attribute.
-   * *   For single-line comments, the diff-positioned way of referencing comments for the `position` attribute. For more information, see `position` in the [input parameters](https://developer.github.com/v3/pulls/comments/#parameters-2) table.
-   *
-   * The `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](https://developer.github.com/v3/reactions) reactions.
+   * <p>
+   * <strong>Note:</strong> Multi-line comments on pull requests are currently in
+   * public beta and subject to change.
+   * </p>
+   * <p>
+   * Lists all review comments for a pull request. By default, review comments are
+   * in ascending order by ID.
+   * </p>
+   * <p>
+   * <strong>Multi-line comment summary</strong>
+   * </p>
+   * <p>
+   * <strong>Note:</strong> New parameters and response fields are available for
+   * developers to preview. During the preview period, these response fields may
+   * change without advance notice. Please see the <a href=
+   * "https://developer.github.com/changes/2019-10-03-multi-line-comments">blog
+   * post</a> for full details.
+   * </p>
+   * <p>
+   * Use the <code>comfort-fade</code> preview header and the <code>line</code>
+   * parameter to show multi-line comment-supported fields in the response.
+   * </p>
+   * <p>
+   * If you use the <code>comfort-fade</code> preview header, your response will
+   * show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, values for <code>start_line</code>,
+   * <code>original_start_line</code>, <code>start_side</code>, <code>line</code>,
+   * <code>original_line</code>, and <code>side</code>.</li>
+   * <li>For single-line comments, values for <code>line</code>,
+   * <code>original_line</code>, and <code>side</code> and a <code>null</code>
+   * value for <code>start_line</code>, <code>original_start_line</code>, and
+   * <code>start_side</code>.</li>
+   * </ul>
+   * <p>
+   * If you don't use the <code>comfort-fade</code> preview header, multi-line and
+   * single-line comments will appear the same way in the response with a single
+   * <code>position</code> attribute. Your response will show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, the last line of the comment range for the
+   * <code>position</code> attribute.</li>
+   * <li>For single-line comments, the diff-positioned way of referencing comments
+   * for the <code>position</code> attribute. For more information, see
+   * <code>position</code> in the
+   * <a href="https://developer.github.com/v3/pulls/comments/#parameters-2">input
+   * parameters</a> table.</li>
+   * </ul>
+   * <p>
+   * The <code>reactions</code> key will have the following payload where
+   * <code>url</code> can be used to construct the API location for
+   * <a href="https://developer.github.com/v3/reactions">listing and creating</a>
+   * reactions.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/comments")
   @GET
   @Produces("application/json")
-  Response pulls_list_review_comments(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response pulls_list_review_comments(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("since") String since,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Note:** Multi-line comments on pull requests are currently in public beta and subject to change.
-   *
-   * Creates a review comment in the pull request diff. To add a regular comment to a pull request timeline, see "[Create an issue comment](https://developer.github.com/v3/issues/comments/#create-an-issue-comment)." We recommend creating a review comment using `line`, `side`, and optionally `start_line` and `start_side` if your comment applies to more than one line in the pull request diff.
-   *
-   * You can still create a review comment using the `position` parameter. When you use `position`, the `line`, `side`, `start_line`, and `start_side` parameters are not required. For more information, see [Multi-line comment summary](https://developer.github.com/v3/pulls/comments/#multi-line-comment-summary-3).
-   *
-   * **Note:** The position value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
-   *
-   * **Multi-line comment summary**
-   *
-   * **Note:** New parameters and response fields are available for developers to preview. During the preview period, these response fields may change without advance notice. Please see the [blog post](https://developer.github.com/changes/2019-10-03-multi-line-comments) for full details.
-   *
-   * Use the `comfort-fade` preview header and the `line` parameter to show multi-line comment-supported fields in the response.
-   *
-   * If you use the `comfort-fade` preview header, your response will show:
-   *
-   * *   For multi-line comments, values for `start_line`, `original_start_line`, `start_side`, `line`, `original_line`, and `side`.
-   * *   For single-line comments, values for `line`, `original_line`, and `side` and a `null` value for `start_line`, `original_start_line`, and `start_side`.
-   *
-   * If you don't use the `comfort-fade` preview header, multi-line and single-line comments will appear the same way in the response with a single `position` attribute. Your response will show:
-   *
-   * *   For multi-line comments, the last line of the comment range for the `position` attribute.
-   * *   For single-line comments, the diff-positioned way of referencing comments for the `position` attribute. For more information, see `position` in the [input parameters](https://developer.github.com/v3/pulls/comments/#parameters-2) table.
+   * <p>
+   * <strong>Note:</strong> Multi-line comments on pull requests are currently in
+   * public beta and subject to change.
+   * </p>
+   * <p>
+   * Creates a review comment in the pull request diff. To add a regular comment
+   * to a pull request timeline, see &quot;<a href=
+   * "https://developer.github.com/v3/issues/comments/#create-an-issue-comment">Create
+   * an issue comment</a>.&quot; We recommend creating a review comment using
+   * <code>line</code>, <code>side</code>, and optionally <code>start_line</code>
+   * and <code>start_side</code> if your comment applies to more than one line in
+   * the pull request diff.
+   * </p>
+   * <p>
+   * You can still create a review comment using the <code>position</code>
+   * parameter. When you use <code>position</code>, the <code>line</code>,
+   * <code>side</code>, <code>start_line</code>, and <code>start_side</code>
+   * parameters are not required. For more information, see <a href=
+   * "https://developer.github.com/v3/pulls/comments/#multi-line-comment-summary-3">Multi-line
+   * comment summary</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> The position value equals the number of lines down
+   * from the first &quot;@@&quot; hunk header in the file you want to add a
+   * comment. The line just below the &quot;@@&quot; line is position 1, the next
+   * line is position 2, and so on. The position in the diff continues to increase
+   * through lines of whitespace and additional hunks until the beginning of a new
+   * file.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * <p>
+   * <strong>Multi-line comment summary</strong>
+   * </p>
+   * <p>
+   * <strong>Note:</strong> New parameters and response fields are available for
+   * developers to preview. During the preview period, these response fields may
+   * change without advance notice. Please see the <a href=
+   * "https://developer.github.com/changes/2019-10-03-multi-line-comments">blog
+   * post</a> for full details.
+   * </p>
+   * <p>
+   * Use the <code>comfort-fade</code> preview header and the <code>line</code>
+   * parameter to show multi-line comment-supported fields in the response.
+   * </p>
+   * <p>
+   * If you use the <code>comfort-fade</code> preview header, your response will
+   * show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, values for <code>start_line</code>,
+   * <code>original_start_line</code>, <code>start_side</code>, <code>line</code>,
+   * <code>original_line</code>, and <code>side</code>.</li>
+   * <li>For single-line comments, values for <code>line</code>,
+   * <code>original_line</code>, and <code>side</code> and a <code>null</code>
+   * value for <code>start_line</code>, <code>original_start_line</code>, and
+   * <code>start_side</code>.</li>
+   * </ul>
+   * <p>
+   * If you don't use the <code>comfort-fade</code> preview header, multi-line and
+   * single-line comments will appear the same way in the response with a single
+   * <code>position</code> attribute. Your response will show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, the last line of the comment range for the
+   * <code>position</code> attribute.</li>
+   * <li>For single-line comments, the diff-positioned way of referencing comments
+   * for the <code>position</code> attribute. For more information, see
+   * <code>position</code> in the
+   * <a href="https://developer.github.com/v3/pulls/comments/#parameters-2">input
+   * parameters</a> table.</li>
+   * </ul>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/comments")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response pulls_create_review_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      InputStream data);
+  Response pulls_create_review_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
-   * **Note:** Multi-line comments on pull requests are currently in public beta and subject to change.
-   *
-   * Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
-   *
-   * **Multi-line comment summary**
-   *
-   * **Note:** New parameters and response fields are available for developers to preview. During the preview period, these response fields may change without advance notice. Please see the [blog post](https://developer.github.com/changes/2019-10-03-multi-line-comments) for full details.
-   *
-   * Use the `comfort-fade` preview header and the `line` parameter to show multi-line comment-supported fields in the response.
-   *
-   * If you use the `comfort-fade` preview header, your response will show:
-   *
-   * *   For multi-line comments, values for `start_line`, `original_start_line`, `start_side`, `line`, `original_line`, and `side`.
-   * *   For single-line comments, values for `line`, `original_line`, and `side` and a `null` value for `start_line`, `original_start_line`, and `start_side`.
-   *
-   * If you don't use the `comfort-fade` preview header, multi-line and single-line comments will appear the same way in the response with a single `position` attribute. Your response will show:
-   *
-   * *   For multi-line comments, the last line of the comment range for the `position` attribute.
-   * *   For single-line comments, the diff-positioned way of referencing comments for the `position` attribute. For more information, see `position` in the [input parameters](https://developer.github.com/v3/pulls/comments/#parameters-2) table.
-   *
-   * The `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](https://developer.github.com/v3/reactions) reactions.
+   * <p>
+   * <strong>Note:</strong> Multi-line comments on pull requests are currently in
+   * public beta and subject to change.
+   * </p>
+   * <p>
+   * Lists review comments for all pull requests in a repository. By default,
+   * review comments are in ascending order by ID.
+   * </p>
+   * <p>
+   * <strong>Multi-line comment summary</strong>
+   * </p>
+   * <p>
+   * <strong>Note:</strong> New parameters and response fields are available for
+   * developers to preview. During the preview period, these response fields may
+   * change without advance notice. Please see the <a href=
+   * "https://developer.github.com/changes/2019-10-03-multi-line-comments">blog
+   * post</a> for full details.
+   * </p>
+   * <p>
+   * Use the <code>comfort-fade</code> preview header and the <code>line</code>
+   * parameter to show multi-line comment-supported fields in the response.
+   * </p>
+   * <p>
+   * If you use the <code>comfort-fade</code> preview header, your response will
+   * show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, values for <code>start_line</code>,
+   * <code>original_start_line</code>, <code>start_side</code>, <code>line</code>,
+   * <code>original_line</code>, and <code>side</code>.</li>
+   * <li>For single-line comments, values for <code>line</code>,
+   * <code>original_line</code>, and <code>side</code> and a <code>null</code>
+   * value for <code>start_line</code>, <code>original_start_line</code>, and
+   * <code>start_side</code>.</li>
+   * </ul>
+   * <p>
+   * If you don't use the <code>comfort-fade</code> preview header, multi-line and
+   * single-line comments will appear the same way in the response with a single
+   * <code>position</code> attribute. Your response will show:
+   * </p>
+   * <ul>
+   * <li>For multi-line comments, the last line of the comment range for the
+   * <code>position</code> attribute.</li>
+   * <li>For single-line comments, the diff-positioned way of referencing comments
+   * for the <code>position</code> attribute. For more information, see
+   * <code>position</code> in the
+   * <a href="https://developer.github.com/v3/pulls/comments/#parameters-2">input
+   * parameters</a> table.</li>
+   * </ul>
+   * <p>
+   * The <code>reactions</code> key will have the following payload where
+   * <code>url</code> can be used to construct the API location for
+   * <a href="https://developer.github.com/v3/reactions">listing and creating</a>
+   * reactions.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/comments")
   @GET
   @Produces("application/json")
-  Response pulls_list_review_comments_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("sort") String sort,
-      @QueryParam("direction") String direction, @QueryParam("since") String since,
+  Response pulls_list_review_comments_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("sort") String sort, @QueryParam("direction") String direction, @QueryParam("since") String since,
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}")
   @GET
@@ -2680,49 +4388,65 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId);
 
   /**
+   * <p>
    * Update the review summary comment with new text.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
   Response pulls_update_review(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId,
-      InputStream data);
+      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}")
   @DELETE
   @Produces("application/json")
-  Response pulls_delete_pending_review(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      @PathParam("review_id") Integer reviewId);
+  Response pulls_delete_pending_review(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId);
 
   /**
-   * **Note:** To dismiss a pull request review on a [protected branch](https://developer.github.com/v3/repos/branches/), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.
+   * <p>
+   * <strong>Note:</strong> To dismiss a pull request review on a
+   * <a href="https://developer.github.com/v3/repos/branches/">protected
+   * branch</a>, you must be a repository administrator or be included in the list
+   * of people or teams who can dismiss pull request reviews.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals")
   @PUT
   @Produces("application/json")
   @Consumes("application/json")
   Response pulls_dismiss_review(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId,
-      InputStream data);
+      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")
   @GET
   @Produces("application/json")
-  Response pulls_list_requested_reviewers(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response pulls_list_requested_reviewers(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")
   @POST
@@ -2732,31 +4456,76 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")
   @DELETE
   @Consumes("application/json")
-  void pulls_remove_requested_reviewers(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      InputStream data);
+  void pulls_remove_requested_reviewers(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
-   * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * Draft pull requests are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, GitHub Pro, and legacy per-repository billing
+   * plans, and in public and private repositories with GitHub Team and GitHub
+   * Enterprise Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * Lists details of a pull request by providing its number.
-   *
-   * When you get, [create](https://developer.github.com/v3/pulls/#create-a-pull-request), or [edit](https://developer.github.com/v3/pulls/#update-a-pull-request) a pull request, GitHub creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests)".
-   *
-   * The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the _test_ merge commit.
-   *
-   * The value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
-   *
-   * *   If merged as a [merge commit](https://help.github.com/articles/about-merge-methods-on-github/), `merge_commit_sha` represents the SHA of the merge commit.
-   * *   If merged via a [squash](https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits), `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
-   * *   If [rebased](https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits), `merge_commit_sha` represents the commit that the base branch was updated to.
-   *
-   * Pass the appropriate [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+   * </p>
+   * <p>
+   * When you get, <a href=
+   * "https://developer.github.com/v3/pulls/#create-a-pull-request">create</a>, or
+   * <a href=
+   * "https://developer.github.com/v3/pulls/#update-a-pull-request">edit</a> a
+   * pull request, GitHub creates a merge commit to test whether the pull request
+   * can be automatically merged into the base branch. This test commit is not
+   * added to the base branch or the head branch. You can review the status of the
+   * test commit using the <code>mergeable</code> key. For more information, see
+   * &quot;<a href=
+   * "https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests">Checking
+   * mergeability of pull requests</a>&quot;.
+   * </p>
+   * <p>
+   * The value of the <code>mergeable</code> attribute can be <code>true</code>,
+   * <code>false</code>, or <code>null</code>. If the value is <code>null</code>,
+   * then GitHub has started a background job to compute the mergeability. After
+   * giving the job time to complete, resubmit the request. When the job finishes,
+   * you will see a non-<code>null</code> value for the <code>mergeable</code>
+   * attribute in the response. If <code>mergeable</code> is <code>true</code>,
+   * then <code>merge_commit_sha</code> will be the SHA of the <em>test</em> merge
+   * commit.
+   * </p>
+   * <p>
+   * The value of the <code>merge_commit_sha</code> attribute changes depending on
+   * the state of the pull request. Before merging a pull request, the
+   * <code>merge_commit_sha</code> attribute holds the SHA of the <em>test</em>
+   * merge commit. After merging a pull request, the <code>merge_commit_sha</code>
+   * attribute changes depending on how you merged the pull request:
+   * </p>
+   * <ul>
+   * <li>If merged as a <a href=
+   * "https://help.github.com/articles/about-merge-methods-on-github/">merge
+   * commit</a>, <code>merge_commit_sha</code> represents the SHA of the merge
+   * commit.</li>
+   * <li>If merged via a <a href=
+   * "https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits">squash</a>,
+   * <code>merge_commit_sha</code> represents the SHA of the squashed commit on
+   * the base branch.</li>
+   * <li>If <a href=
+   * "https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits">rebased</a>,
+   * <code>merge_commit_sha</code> represents the commit that the base branch was
+   * updated to.</li>
+   * </ul>
+   * <p>
+   * Pass the appropriate <a href=
+   * "https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests">media
+   * type</a> to fetch diff and patch formats.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}")
   @GET
@@ -2765,9 +4534,21 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber);
 
   /**
-   * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+   * <p>
+   * Draft pull requests are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, GitHub Pro, and legacy per-repository billing
+   * plans, and in public and private repositories with GitHub Team and GitHub
+   * Enterprise Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * To open or update a pull request in a public repository, you must have write
+   * access to the head or the source branch. For organization-owned repositories,
+   * you must be a member of the organization that owns the repository to open or
+   * update a pull request.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}")
   @PATCH
@@ -2777,7 +4558,10 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
+   * <p>
    * The list of reviews returns in chronological order.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews")
   @GET
@@ -2787,13 +4571,38 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
-   *
-   * Pull request reviews created in the `PENDING` state do not include the `submitted_at` property in the response.
-   *
-   * **Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://developer.github.com/v3/pulls/#get-a-pull-request) endpoint.
-   *
-   * The `position` value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * <p>
+   * Pull request reviews created in the <code>PENDING</code> state do not include
+   * the <code>submitted_at</code> property in the response.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> To comment on a specific line in a file, you need to
+   * first determine the <em>position</em> of that line in the diff. The GitHub
+   * REST API v3 offers the <code>application/vnd.github.v3.diff</code> <a href=
+   * "https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests">media
+   * type</a>. To see a pull request diff, add this media type to the
+   * <code>Accept</code> header of a call to the
+   * <a href="https://developer.github.com/v3/pulls/#get-a-pull-request">single
+   * pull request</a> endpoint.
+   * </p>
+   * <p>
+   * The <code>position</code> value equals the number of lines down from the
+   * first &quot;@@&quot; hunk header in the file you want to add a comment. The
+   * line just below the &quot;@@&quot; line is position 1, the next line is
+   * position 2, and so on. The position in the diff continues to increase through
+   * lines of whitespace and additional hunks until the beginning of a new file.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews")
   @POST
@@ -2803,7 +4612,7 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/merge")
   @GET
@@ -2811,7 +4620,17 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber);
 
   /**
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/merge")
   @PUT
@@ -2821,7 +4640,11 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
-   * Updates the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch.
+   * <p>
+   * Updates the pull request branch with the latest upstream changes by merging
+   * HEAD from the base branch into the pull request branch.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/update-branch")
   @PUT
@@ -2831,7 +4654,11 @@ public interface ReposResource {
       @PathParam("pull_number") Integer pullNumber, InputStream data);
 
   /**
-   * **Note:** Responses include a maximum of 3000 files. The paginated response returns 30 files per page by default.
+   * <p>
+   * <strong>Note:</strong> Responses include a maximum of 3000 files. The
+   * paginated response returns 30 files per page by default.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/files")
   @GET
@@ -2841,48 +4668,94 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
-   * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+   * <p>
+   * Draft pull requests are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, GitHub Pro, and legacy per-repository billing
+   * plans, and in public and private repositories with GitHub Team and GitHub
+   * Enterprise Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls")
   @GET
   @Produces("application/json")
   Response pulls_list(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @QueryParam("state") String state, @QueryParam("head") String head,
-      @QueryParam("base") String base, @QueryParam("sort") String sort,
-      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("state") String state, @QueryParam("head") String head, @QueryParam("base") String base,
+      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
-   *
+   * <p>
+   * Draft pull requests are available in public repositories with GitHub Free and
+   * GitHub Free for organizations, GitHub Pro, and legacy per-repository billing
+   * plans, and in public and private repositories with GitHub Team and GitHub
+   * Enterprise Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * To open or update a pull request in a public repository, you must have write
+   * access to the head or the source branch. For organization-owned repositories,
+   * you must be a member of the organization that owns the repository to open or
+   * update a pull request.
+   * </p>
+   * <p>
    * You can create a new pull request.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response pulls_create(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response pulls_create(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Creates a reply to a review comment for a pull request. For the `comment_id`, provide the ID of the review comment you are replying to. This must be the ID of a _top-level review comment_, not a reply to that comment. Replies to replies are not supported.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * Creates a reply to a review comment for a pull request. For the
+   * <code>comment_id</code>, provide the ID of the review comment you are
+   * replying to. This must be the ID of a <em>top-level review comment</em>, not
+   * a reply to that comment. Replies to replies are not supported.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response pulls_create_reply_for_review_comment(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      @PathParam("comment_id") Integer commentId, InputStream data);
+  Response pulls_create_reply_for_review_comment(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * Lists a maximum of 250 commits for a pull request. To receive a complete commit list for pull requests with more than 250 commits, use the [List commits](https://developer.github.com/v3/repos/commits/#list-commits) endpoint.
+   * <p>
+   * Lists a maximum of 250 commits for a pull request. To receive a complete
+   * commit list for pull requests with more than 250 commits, use the
+   * <a href="https://developer.github.com/v3/repos/commits/#list-commits">List
+   * commits</a> endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/commits")
   @GET
@@ -2892,41 +4765,57 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
   Response pulls_submit_review(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId,
-      InputStream data);
+      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId, InputStream data);
 
   /**
+   * <p>
    * List comments for a specific pull request review.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments")
   @GET
   @Produces("application/json")
-  Response pulls_list_comments_for_review(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("pull_number") Integer pullNumber,
-      @PathParam("review_id") Integer reviewId, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response pulls_list_comments_for_review(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("pull_number") Integer pullNumber, @PathParam("review_id") Integer reviewId,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Lists all open code scanning alerts for the default branch (usually `master`) and protected branches in a repository. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` read permission to use this endpoint.
+   * <p>
+   * Lists all open code scanning alerts for the default branch (usually
+   * <code>master</code>) and protected branches in a repository. You must use an
+   * access token with the <code>security_events</code> scope to use this
+   * endpoint. GitHub Apps must have the <code>security_events</code> read
+   * permission to use this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/code-scanning/alerts")
   @GET
   @Produces("application/json")
-  Response code_scanning_list_alerts_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("state") String state,
-      @QueryParam("ref") String ref);
+  Response code_scanning_list_alerts_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("state") String state, @QueryParam("ref") String ref);
 
   /**
-   * Gets a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` read permission to use this endpoint.
-   *
-   * The security `alert_id` is found at the end of the security alert's URL. For example, the security alert ID for `https://github.com/Octo-org/octo-repo/security/code-scanning/88` is `88`.
+   * <p>
+   * Gets a single code scanning alert. You must use an access token with the
+   * <code>security_events</code> scope to use this endpoint. GitHub Apps must
+   * have the <code>security_events</code> read permission to use this endpoint.
+   * </p>
+   * <p>
+   * The security <code>alert_id</code> is found at the end of the security
+   * alert's URL. For example, the security alert ID for
+   * <code>https://github.com/Octo-org/octo-repo/security/code-scanning/88</code>
+   * is <code>88</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/code-scanning/alerts/{alert_id}")
   @GET
@@ -2935,9 +4824,17 @@ public interface ReposResource {
       @PathParam("alert_id") Integer alertId);
 
   /**
+   * <p>
    * Users with push access can lock an issue or pull request's conversation.
-   *
-   * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
+   * </p>
+   * <p>
+   * Note that, if you choose not to pass any parameters, you'll need to set
+   * <code>Content-Length</code> to zero when calling out to this endpoint. For
+   * more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/lock")
   @PUT
@@ -2946,7 +4843,10 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
+   * <p>
    * Users with push access can unlock an issue's conversation.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/lock")
   @DELETE
@@ -2954,7 +4854,7 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/milestones/{milestone_number}")
   @GET
@@ -2963,7 +4863,7 @@ public interface ReposResource {
       @PathParam("milestone_number") Integer milestoneNumber);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/milestones/{milestone_number}")
   @DELETE
@@ -2971,7 +4871,7 @@ public interface ReposResource {
       @PathParam("milestone_number") Integer milestoneNumber);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/milestones/{milestone_number}")
   @PATCH
@@ -2981,7 +4881,12 @@ public interface ReposResource {
       @PathParam("milestone_number") Integer milestoneNumber, InputStream data);
 
   /**
-   * Removes the specified label from the issue, and returns the remaining labels on the issue. This endpoint returns a `404 Not Found` status if the label does not exist.
+   * <p>
+   * Removes the specified label from the issue, and returns the remaining labels
+   * on the issue. This endpoint returns a <code>404 Not Found</code> status if
+   * the label does not exist.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/labels/{name}")
   @DELETE
@@ -2990,28 +4895,26 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, @PathParam("name") String name);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/milestones")
   @GET
   @Produces("application/json")
   Response issues_list_milestones(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @QueryParam("state") String state, @QueryParam("sort") String sort,
-      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("state") String state, @QueryParam("sort") String sort, @QueryParam("direction") String direction,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/milestones")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response issues_create_milestone(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response issues_create_milestone(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments/{comment_id}")
   @GET
@@ -3020,7 +4923,7 @@ public interface ReposResource {
       @PathParam("comment_id") Integer commentId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments/{comment_id}")
   @DELETE
@@ -3028,7 +4931,7 @@ public interface ReposResource {
       @PathParam("comment_id") Integer commentId);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments/{comment_id}")
   @PATCH
@@ -3038,17 +4941,32 @@ public interface ReposResource {
       @PathParam("comment_id") Integer commentId, InputStream data);
 
   /**
-   * The API returns a [`301 Moved Permanently` status](https://developer.github.com/v3/#http-redirects) if the issue was
-   * [transferred](https://help.github.com/articles/transferring-an-issue-to-another-repository/) to another repository. If
-   * the issue was transferred to or deleted from a repository where the authenticated user lacks read access, the API
-   * returns a `404 Not Found` status. If the issue was deleted from a repository where the authenticated user has read
-   * access, the API returns a `410 Gone` status. To receive webhook events for transferred and deleted issues, subscribe
-   * to the [`issues`](https://developer.github.com/webhooks/event-payloads/#issues) webhook.
-   *
-   * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
-   * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
-   * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
-   * request id, use the "[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)" endpoint.
+   * <p>
+   * The API returns a <a href=
+   * "https://developer.github.com/v3/#http-redirects"><code>301 Moved Permanently</code>
+   * status</a> if the issue was <a href=
+   * "https://help.github.com/articles/transferring-an-issue-to-another-repository/">transferred</a>
+   * to another repository. If the issue was transferred to or deleted from a
+   * repository where the authenticated user lacks read access, the API returns a
+   * <code>404 Not Found</code> status. If the issue was deleted from a repository
+   * where the authenticated user has read access, the API returns a
+   * <code>410 Gone</code> status. To receive webhook events for transferred and
+   * deleted issues, subscribe to the <a href=
+   * "https://developer.github.com/webhooks/event-payloads/#issues"><code>issues</code></a>
+   * webhook.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: GitHub's REST API v3 considers every pull request an
+   * issue, but not every issue is a pull request. For this reason,
+   * &quot;Issues&quot; endpoints may return both issues and pull requests in the
+   * response. You can identify pull requests by the <code>pull_request</code>
+   * key. Be aware that the <code>id</code> of a pull request returned from
+   * &quot;Issues&quot; endpoints will be an <em>issue id</em>. To find out the
+   * pull request id, use the &quot;<a href=
+   * "https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a>&quot; endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}")
   @GET
@@ -3057,7 +4975,10 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber);
 
   /**
+   * <p>
    * Issue owners and users with push access can edit an issue.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}")
   @PATCH
@@ -3067,7 +4988,7 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/labels/{name}")
   @GET
@@ -3076,7 +4997,7 @@ public interface ReposResource {
       @PathParam("name") String name);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/labels/{name}")
   @DELETE
@@ -3084,7 +5005,7 @@ public interface ReposResource {
       @PathParam("name") String name);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/labels/{name}")
   @PATCH
@@ -3094,37 +5015,40 @@ public interface ReposResource {
       @PathParam("name") String name, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/labels")
   @GET
   @Produces("application/json")
-  Response issues_list_labels_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response issues_list_labels_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/labels")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response issues_create_label(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response issues_create_label(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/timeline")
   @GET
   @Produces("application/json")
-  Response issues_list_events_for_timeline(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("issue_number") Integer issueNumber,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response issues_list_events_for_timeline(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("issue_number") Integer issueNumber, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.
+   * <p>
+   * Lists the <a href=
+   * "https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/">available
+   * assignees</a> for issues in a repository.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/assignees")
   @GET
@@ -3133,17 +5057,20 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/labels")
   @GET
   @Produces("application/json")
-  Response issues_list_labels_on_issue(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("issue_number") Integer issueNumber,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response issues_list_labels_on_issue(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("issue_number") Integer issueNumber, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Removes any previous labels and sets the new labels for an issue.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/labels")
   @PUT
@@ -3153,7 +5080,7 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/labels")
   @POST
@@ -3163,7 +5090,7 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/labels")
   @DELETE
@@ -3171,7 +5098,7 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/events")
   @GET
@@ -3181,12 +5108,21 @@ public interface ReposResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * List issues in a repository.
-   *
-   * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
-   * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
-   * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
-   * request id, use the "[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)" endpoint.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: GitHub's REST API v3 considers every pull request an
+   * issue, but not every issue is a pull request. For this reason,
+   * &quot;Issues&quot; endpoints may return both issues and pull requests in the
+   * response. You can identify pull requests by the <code>pull_request</code>
+   * key. Be aware that the <code>id</code> of a pull request returned from
+   * &quot;Issues&quot; endpoints will be an <em>issue id</em>. To find out the
+   * pull request id, use the &quot;<a href=
+   * "https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a>&quot; endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues")
   @GET
@@ -3194,25 +5130,40 @@ public interface ReposResource {
   Response issues_list_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
       @QueryParam("milestone") String milestone, @QueryParam("state") String state,
       @QueryParam("assignee") String assignee, @QueryParam("creator") String creator,
-      @QueryParam("mentioned") String mentioned, @QueryParam("labels") String labels,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @QueryParam("mentioned") String mentioned, @QueryParam("labels") String labels, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("since") String since,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://help.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * Any user with pull access to a repository can create an issue. If
+   * <a href="https://help.github.com/articles/disabling-issues/">issues are
+   * disabled in the repository</a>, the API returns a <code>410 Gone</code>
+   * status.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response issues_create(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response issues_create(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
+   * <p>
    * Issue Comments are ordered by ascending ID.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/comments")
   @GET
@@ -3222,7 +5173,17 @@ public interface ReposResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/comments")
   @POST
@@ -3232,7 +5193,11 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
-   * Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.
+   * <p>
+   * Adds up to 10 assignees to an issue. Users already assigned to an issue are
+   * not replaced.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/assignees")
   @POST
@@ -3242,7 +5207,10 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
+   * <p>
    * Removes one or more assignees from an issue.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/{issue_number}/assignees")
   @DELETE
@@ -3252,39 +5220,45 @@ public interface ReposResource {
       @PathParam("issue_number") Integer issueNumber, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/events")
   @GET
   @Produces("application/json")
-  Response issues_list_events_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response issues_list_events_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Checks if a user has permission to be assigned to an issue in this repository.
-   *
-   * If the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.
-   *
-   * Otherwise a `404` status code is returned.
+   * <p>
+   * Checks if a user has permission to be assigned to an issue in this
+   * repository.
+   * </p>
+   * <p>
+   * If the <code>assignee</code> can be assigned to issues in the repository, a
+   * <code>204</code> header with no content is returned.
+   * </p>
+   * <p>
+   * Otherwise a <code>404</code> status code is returned.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/assignees/{assignee}")
   @GET
-  void issues_check_user_can_be_assigned(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("assignee") String assignee);
+  void issues_check_user_can_be_assigned(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("assignee") String assignee);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/milestones/{milestone_number}/labels")
   @GET
   @Produces("application/json")
-  Response issues_list_labels_for_milestone(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @PathParam("milestone_number") Integer milestoneNumber,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response issues_list_labels_for_milestone(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @PathParam("milestone_number") Integer milestoneNumber, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/issues/events/{event_id}")
   @GET
@@ -3293,31 +5267,47 @@ public interface ReposResource {
       @PathParam("event_id") Integer eventId);
 
   /**
+   * <p>
    * By default, Issue Comments are ordered by ascending ID.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/issues/comments")
   @GET
   @Produces("application/json")
-  Response issues_list_comments_for_repo(@PathParam("owner") String owner,
-      @PathParam("repo") String repo, @QueryParam("sort") String sort,
-      @QueryParam("direction") String direction, @QueryParam("since") String since,
+  Response issues_list_comments_for_repo(@PathParam("owner") String owner, @PathParam("repo") String repo,
+      @QueryParam("sort") String sort, @QueryParam("direction") String direction, @QueryParam("since") String since,
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Enables an authenticated GitHub App to find the repository's installation
+   * information. The installation's account type will be either an organization
+   * or a user account, depending which account the repository belongs to.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/installation")
   @GET
   @Produces("application/json")
-  Response apps_get_repo_installation(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  Response apps_get_repo_installation(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * Returns a single tree using the SHA1 value for that tree.
-   *
-   * If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+   * </p>
+   * <p>
+   * If <code>truncated</code> is <code>true</code> in the response then the
+   * number of items in the <code>tree</code> array exceeded our maximum limit. If
+   * you need to fetch more items, use the non-recursive method of fetching trees,
+   * and fetch one sub-tree at a time.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/trees/{tree_sha}")
   @GET
@@ -3326,31 +5316,52 @@ public interface ReposResource {
       @PathParam("tree_sha") String treeSha, @QueryParam("recursive") String recursive);
 
   /**
-   * Returns an array of references from your Git database that match the supplied name. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't exist in the repository, but existing refs start with `:ref`, they will be returned as an array.
-   *
-   * When you use this endpoint without providing a `:ref`, it will return an array of all the references from your Git database, including notes and stashes if they exist on the server. Anything in the namespace is returned, not just `heads` and `tags`.
-   *
-   * **Note:** You need to explicitly [request a pull request](https://developer.github.com/v3/pulls/#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests)".
-   *
-   * If you request matching references for a branch named `feature` but the branch `feature` doesn't exist, the response can still include other matching head refs that start with the word `feature`, such as `featureA` and `featureB`.
+   * <p>
+   * Returns an array of references from your Git database that match the supplied
+   * name. The <code>:ref</code> in the URL must be formatted as
+   * <code>heads/&lt;branch name&gt;</code> for branches and
+   * <code>tags/&lt;tag name&gt;</code> for tags. If the <code>:ref</code> doesn't
+   * exist in the repository, but existing refs start with <code>:ref</code>, they
+   * will be returned as an array.
+   * </p>
+   * <p>
+   * When you use this endpoint without providing a <code>:ref</code>, it will
+   * return an array of all the references from your Git database, including notes
+   * and stashes if they exist on the server. Anything in the namespace is
+   * returned, not just <code>heads</code> and <code>tags</code>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You need to explicitly
+   * <a href="https://developer.github.com/v3/pulls/#get-a-pull-request">request a
+   * pull request</a> to trigger a test merge commit, which checks the
+   * mergeability of pull requests. For more information, see &quot;<a href=
+   * "https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests">Checking
+   * mergeability of pull requests</a>&quot;.
+   * </p>
+   * <p>
+   * If you request matching references for a branch named <code>feature</code>
+   * but the branch <code>feature</code> doesn't exist, the response can still
+   * include other matching head refs that start with the word
+   * <code>feature</code>, such as <code>featureA</code> and
+   * <code>featureB</code>.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/matching-refs/{ref}")
   @GET
   @Produces("application/json")
   Response git_list_matching_refs(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("ref") String ref, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("ref") String ref, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/git/refs/{ref}")
   @DELETE
-  void git_delete_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("ref") String ref);
+  void git_delete_ref(@PathParam("owner") String owner, @PathParam("repo") String repo, @PathParam("ref") String ref);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/git/refs/{ref}")
   @PATCH
@@ -3360,63 +5371,98 @@ public interface ReposResource {
       @PathParam("ref") String ref, InputStream data);
 
   /**
-   * Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
-   *
+   * <p>
+   * Creates a new Git <a href=
+   * "https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects">commit
+   * object</a>.
+   * </p>
+   * <p>
    * In this example, the payload of the signature would be:
-   *
-   *
-   *
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * </p>
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/commits")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response git_create_commit(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response git_create_commit(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/tags/{tag_sha}")
   @GET
@@ -3425,84 +5471,138 @@ public interface ReposResource {
       @PathParam("tag_sha") String tagSha);
 
   /**
-   * The tree creation API accepts nested entries. If you specify both a tree and a nested path modifying that tree, this endpoint will overwrite the contents of the tree with the new path contents, and create a new tree structure.
-   *
-   * If you use this endpoint to add, delete, or modify the file contents in a tree, you will need to commit the tree and then update a branch to point to the commit. For more information see "[Create a commit](https://developer.github.com/v3/git/commits/#create-a-commit)" and "[Update a reference](https://developer.github.com/v3/git/refs/#update-a-reference)."
+   * <p>
+   * The tree creation API accepts nested entries. If you specify both a tree and
+   * a nested path modifying that tree, this endpoint will overwrite the contents
+   * of the tree with the new path contents, and create a new tree structure.
+   * </p>
+   * <p>
+   * If you use this endpoint to add, delete, or modify the file contents in a
+   * tree, you will need to commit the tree and then update a branch to point to
+   * the commit. For more information see &quot;<a href=
+   * "https://developer.github.com/v3/git/commits/#create-a-commit">Create a
+   * commit</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/git/refs/#update-a-reference">Update a
+   * reference</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/trees")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response git_create_tree(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response git_create_tree(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Creates a reference for your repository. You are unable to create new references for empty repositories, even if the commit SHA-1 hash used exists. Empty repositories are repositories without branches.
+   * <p>
+   * Creates a reference for your repository. You are unable to create new
+   * references for empty repositories, even if the commit SHA-1 hash used exists.
+   * Empty repositories are repositories without branches.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/refs")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response git_create_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response git_create_ref(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://developer.github.com/v3/git/refs/#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://developer.github.com/v3/git/refs/#create-a-reference) the tag reference - this call would be unnecessary.
-   *
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * <p>
+   * Note that creating a tag object does not create the reference that makes a
+   * tag in Git. If you want to create an annotated tag in Git, you have to do
+   * this call to create the tag object, and then <a href=
+   * "https://developer.github.com/v3/git/refs/#create-a-reference">create</a> the
+   * <code>refs/tags/[tag]</code> reference. If you want to create a lightweight
+   * tag, you only have to <a href=
+   * "https://developer.github.com/v3/git/refs/#create-a-reference">create</a> the
+   * tag reference - this call would be unnecessary.
+   * </p>
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/tags")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response git_create_tag(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response git_create_tag(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * Returns a single reference from your Git database. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't match an existing ref, a `404` is returned.
-   *
-   * **Note:** You need to explicitly [request a pull request](https://developer.github.com/v3/pulls/#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests)".
+   * <p>
+   * Returns a single reference from your Git database. The <code>:ref</code> in
+   * the URL must be formatted as <code>heads/&lt;branch name&gt;</code> for
+   * branches and <code>tags/&lt;tag name&gt;</code> for tags. If the
+   * <code>:ref</code> doesn't match an existing ref, a <code>404</code> is
+   * returned.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> You need to explicitly
+   * <a href="https://developer.github.com/v3/pulls/#get-a-pull-request">request a
+   * pull request</a> to trigger a test merge commit, which checks the
+   * mergeability of pull requests. For more information, see &quot;<a href=
+   * "https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests">Checking
+   * mergeability of pull requests</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/ref/{ref}")
   @GET
   @Produces("application/json")
-  Response git_get_ref(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      @PathParam("ref") String ref);
+  Response git_get_ref(@PathParam("owner") String owner, @PathParam("repo") String repo, @PathParam("ref") String ref);
 
   /**
-   *
+   * 
    */
   @Path("/{owner}/{repo}/git/blobs")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
-  Response git_create_blob(@PathParam("owner") String owner, @PathParam("repo") String repo,
-      InputStream data);
+  Response git_create_blob(@PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * The `content` in the response will always be Base64 encoded.
-   *
-   * _Note_: This API supports blobs up to 100 megabytes in size.
+   * <p>
+   * The <code>content</code> in the response will always be Base64 encoded.
+   * </p>
+   * <p>
+   * <em>Note</em>: This API supports blobs up to 100 megabytes in size.
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/blobs/{file_sha}")
   @GET
@@ -3511,29 +5611,49 @@ public interface ReposResource {
       @PathParam("file_sha") String fileSha);
 
   /**
-   * Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
-   *
-   * **Signature verification object**
-   *
-   * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
-   *
-   * These are the possible values for `reason` in the `verification` object:
-   *
-   * | Value                    | Description                                                                                                                       |
-   * | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-   * | `expired_key`            | The key that made the signature is expired.                                                                                       |
-   * | `not_signing_key`        | The "signing" flag is not among the usage flags in the GPG key that made the signature.                                           |
-   * | `gpgverify_error`        | There was an error communicating with the signature verification service.                                                         |
-   * | `gpgverify_unavailable`  | The signature verification service is currently unavailable.                                                                      |
-   * | `unsigned`               | The object does not include a signature.                                                                                          |
-   * | `unknown_signature_type` | A non-PGP signature was found in the commit.                                                                                      |
-   * | `no_user`                | No user was associated with the `committer` email address in the commit.                                                          |
-   * | `unverified_email`       | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
-   * | `bad_email`              | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature.             |
-   * | `unknown_key`            | The key that made the signature has not been registered with any user's account.                                                  |
-   * | `malformed_signature`    | There was an error parsing the signature.                                                                                         |
-   * | `invalid`                | The signature could not be cryptographically verified using the key whose key-id was found in the signature.                      |
-   * | `valid`                  | None of the above errors applied, so the signature is considered to be verified.                                                  |
+   * <p>
+   * Gets a Git <a href=
+   * "https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects">commit
+   * object</a>.
+   * </p>
+   * <p>
+   * <strong>Signature verification object</strong>
+   * </p>
+   * <p>
+   * The response will include a <code>verification</code> object that describes
+   * the result of verifying the commit's signature. The following fields are
+   * included in the <code>verification</code> object:
+   * </p>
+   * <p>
+   * These are the possible values for <code>reason</code> in the
+   * <code>verification</code> object:
+   * </p>
+   * <p>
+   * | Value | Description | | ------------------------ |
+   * ---------------------------------------------------------------------------------------------------------------------------------
+   * | | <code>expired_key</code> | The key that made the signature is expired. |
+   * | <code>not_signing_key</code> | The &quot;signing&quot; flag is not among
+   * the usage flags in the GPG key that made the signature. | |
+   * <code>gpgverify_error</code> | There was an error communicating with the
+   * signature verification service. | | <code>gpgverify_unavailable</code> | The
+   * signature verification service is currently unavailable. | |
+   * <code>unsigned</code> | The object does not include a signature. | |
+   * <code>unknown_signature_type</code> | A non-PGP signature was found in the
+   * commit. | | <code>no_user</code> | No user was associated with the
+   * <code>committer</code> email address in the commit. | |
+   * <code>unverified_email</code> | The <code>committer</code> email address in
+   * the commit was associated with a user, but the email address is not verified
+   * on her/his account. | | <code>bad_email</code> | The <code>committer</code>
+   * email address in the commit is not included in the identities of the PGP key
+   * that made the signature. | | <code>unknown_key</code> | The key that made the
+   * signature has not been registered with any user's account. | |
+   * <code>malformed_signature</code> | There was an error parsing the signature.
+   * | | <code>invalid</code> | The signature could not be cryptographically
+   * verified using the key whose key-id was found in the signature. | |
+   * <code>valid</code> | None of the above errors applied, so the signature is
+   * considered to be verified. |
+   * </p>
+   * 
    */
   @Path("/{owner}/{repo}/git/commits/{commit_sha}")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/RepositoriesResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/RepositoriesResource.java
@@ -7,17 +7,23 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/repositories")
 public interface RepositoriesResource {
   /**
+   * <p>
    * Lists all public repositories in the order that they were created.
-   *
-   * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of repositories.
+   * </p>
+   * <p>
+   * Note: Pagination is powered exclusively by the <code>since</code> parameter.
+   * Use the <a href="https://developer.github.com/v3/#link-header">Link
+   * header</a> to get the URL for the next page of repositories.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
-  Response repos_list_public(@QueryParam("per_page") Integer perPage,
-      @QueryParam("since") String since, @QueryParam("visibility") String visibility);
+  Response repos_list_public(@QueryParam("per_page") Integer perPage, @QueryParam("since") String since,
+      @QueryParam("visibility") String visibility);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/RootResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/RootResource.java
@@ -6,12 +6,15 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/")
 public interface RootResource {
   /**
+   * <p>
    * Get Hypermedia links to resources accessible in GitHub's REST API
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ScimResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ScimResource.java
@@ -14,12 +14,12 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/scim")
 public interface ScimResource {
   /**
-   *
+   * 
    */
   @Path("/v2/organizations/{org}/Users/{scim_user_id}")
   @GET
@@ -28,11 +28,24 @@ public interface ScimResource {
       @PathParam("scim_user_id") String scimUserId);
 
   /**
-   * Replaces an existing provisioned user's information. You must provide all the information required for the user as if you were provisioning them for the first time. Any existing user information that you don't provide will be removed. If you want to only update a specific attribute, use the [Update an attribute for a SCIM user](https://developer.github.com/v3/scim/#update-an-attribute-for-a-scim-user) endpoint instead.
-   *
-   * You must at least provide the required values for the user: `userName`, `name`, and `emails`.
-   *
-   * **Warning:** Setting `active: false` removes the user from the organization, deletes the external identity, and deletes the associated `{scim_user_id}`.
+   * <p>
+   * Replaces an existing provisioned user's information. You must provide all the
+   * information required for the user as if you were provisioning them for the
+   * first time. Any existing user information that you don't provide will be
+   * removed. If you want to only update a specific attribute, use the <a href=
+   * "https://developer.github.com/v3/scim/#update-an-attribute-for-a-scim-user">Update
+   * an attribute for a SCIM user</a> endpoint instead.
+   * </p>
+   * <p>
+   * You must at least provide the required values for the user:
+   * <code>userName</code>, <code>name</code>, and <code>emails</code>.
+   * </p>
+   * <p>
+   * <strong>Warning:</strong> Setting <code>active: false</code> removes the user
+   * from the organization, deletes the external identity, and deletes the
+   * associated <code>{scim_user_id}</code>.
+   * </p>
+   * 
    */
   @Path("/v2/organizations/{org}/Users/{scim_user_id}")
   @PUT
@@ -42,65 +55,129 @@ public interface ScimResource {
       @PathParam("scim_user_id") String scimUserId, InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/v2/organizations/{org}/Users/{scim_user_id}")
   @DELETE
-  void scim_delete_user_from_org(@PathParam("org") String org,
-      @PathParam("scim_user_id") String scimUserId);
+  void scim_delete_user_from_org(@PathParam("org") String org, @PathParam("scim_user_id") String scimUserId);
 
   /**
-   * Allows you to change a provisioned user's individual attributes. To change a user's values, you must provide a specific `Operations` JSON format that contains at least one of the `add`, `remove`, or `replace` operations. For examples and more information on the SCIM operations format, see the [SCIM specification](https://tools.ietf.org/html/rfc7644#section-3.5.2).
-   *
-   * **Note:** Complicated SCIM `path` selectors that include filters are not supported. For example, a `path` selector defined as `"path": "emails[type eq \"work\"]"` will not work.
-   *
-   * **Warning:** If you set `active:false` using the `replace` operation (as shown in the JSON example below), it removes the user from the organization, deletes the external identity, and deletes the associated `:scim_user_id`.
-   *
-   * ```
-   * {
-   *   "Operations":[{
-   *     "op":"replace",
-   *     "value":{
-   *       "active":false
-   *     }
-   *   }]
-   * }
-   * ```
+   * <p>
+   * Allows you to change a provisioned user's individual attributes. To change a
+   * user's values, you must provide a specific <code>Operations</code> JSON
+   * format that contains at least one of the <code>add</code>,
+   * <code>remove</code>, or <code>replace</code> operations. For examples and
+   * more information on the SCIM operations format, see the
+   * <a href="https://tools.ietf.org/html/rfc7644#section-3.5.2">SCIM
+   * specification</a>.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> Complicated SCIM <code>path</code> selectors that
+   * include filters are not supported. For example, a <code>path</code> selector
+   * defined as
+   * <code>&quot;path&quot;: &quot;emails[type eq \&quot;work\&quot;]&quot;</code>
+   * will not work.
+   * </p>
+   * <p>
+   * <strong>Warning:</strong> If you set <code>active:false</code> using the
+   * <code>replace</code> operation (as shown in the JSON example below), it
+   * removes the user from the organization, deletes the external identity, and
+   * deletes the associated <code>:scim_user_id</code>.
+   * </p>
+   * 
+   * <pre>
+   * <code>{
+    &quot;Operations&quot;:[{
+  &quot;op&quot;:&quot;replace&quot;,
+  &quot;value&quot;:{
+    &quot;active&quot;:false
+  }
+    }]
+  }
+  </code>
+   * </pre>
+   * 
    */
   @Path("/v2/organizations/{org}/Users/{scim_user_id}")
   @PATCH
   @Produces("application/scim+json")
   @Consumes("application/json")
-  Response scim_update_attribute_for_user(@PathParam("org") String org,
-      @PathParam("scim_user_id") String scimUserId, InputStream data);
+  Response scim_update_attribute_for_user(@PathParam("org") String org, @PathParam("scim_user_id") String scimUserId,
+      InputStream data);
 
   /**
-   * Retrieves a paginated list of all provisioned organization members, including pending invitations. If you provide the `filter` parameter, the resources for all matching provisions members are returned.
-   *
-   * When a user with a SAML-provisioned external identity leaves (or is removed from) an organization, the account's metadata is immediately removed. However, the returned list of user accounts might not always match the organization or enterprise member list you see on GitHub. This can happen in certain cases where an external identity associated with an organization will not match an organization member:
-   *   - When a user with a SCIM-provisioned external identity is removed from an organization, the account's metadata is preserved to allow the user to re-join the organization in the future.
-   *   - When inviting a user to join an organization, you can expect to see their external identity in the results before they accept the invitation, or if the invitation is cancelled (or never accepted).
-   *   - When a user is invited over SCIM, an external identity is created that matches with the invitee's email address. However, this identity is only linked to a user account when the user accepts the invitation by going through SAML SSO.
-   *
-   * The returned list of external identities can include an entry for a `null` user. These are unlinked SAML identities that are created when a user goes through the following Single Sign-On (SSO) process but does not sign in to their GitHub account after completing SSO:
-   *
-   * 1. The user is granted access by the IdP and is not a member of the GitHub organization.
-   *
-   * 1. The user attempts to access the GitHub organization and initiates the SAML SSO process, and is not currently signed in to their GitHub account.
-   *
-   * 1. After successfully authenticating with the SAML SSO IdP, the `null` external identity entry is created and the user is prompted to sign in to their GitHub account:
-   *    - If the user signs in, their GitHub account is linked to this entry.
-   *    - If the user does not sign in (or does not create a new account when prompted), they are not added to the GitHub organization, and the external identity `null` entry remains in place.
+   * <p>
+   * Retrieves a paginated list of all provisioned organization members, including
+   * pending invitations. If you provide the <code>filter</code> parameter, the
+   * resources for all matching provisions members are returned.
+   * </p>
+   * <p>
+   * When a user with a SAML-provisioned external identity leaves (or is removed
+   * from) an organization, the account's metadata is immediately removed.
+   * However, the returned list of user accounts might not always match the
+   * organization or enterprise member list you see on GitHub. This can happen in
+   * certain cases where an external identity associated with an organization will
+   * not match an organization member:
+   * </p>
+   * <ul>
+   * <li>When a user with a SCIM-provisioned external identity is removed from an
+   * organization, the account's metadata is preserved to allow the user to
+   * re-join the organization in the future.</li>
+   * <li>When inviting a user to join an organization, you can expect to see their
+   * external identity in the results before they accept the invitation, or if the
+   * invitation is cancelled (or never accepted).</li>
+   * <li>When a user is invited over SCIM, an external identity is created that
+   * matches with the invitee's email address. However, this identity is only
+   * linked to a user account when the user accepts the invitation by going
+   * through SAML SSO.</li>
+   * </ul>
+   * <p>
+   * The returned list of external identities can include an entry for a
+   * <code>null</code> user. These are unlinked SAML identities that are created
+   * when a user goes through the following Single Sign-On (SSO) process but does
+   * not sign in to their GitHub account after completing SSO:
+   * </p>
+   * <ol>
+   * <li>
+   * <p>
+   * The user is granted access by the IdP and is not a member of the GitHub
+   * organization.
+   * </p>
+   * </li>
+   * <li>
+   * <p>
+   * The user attempts to access the GitHub organization and initiates the SAML
+   * SSO process, and is not currently signed in to their GitHub account.
+   * </p>
+   * </li>
+   * <li>
+   * <p>
+   * After successfully authenticating with the SAML SSO IdP, the
+   * <code>null</code> external identity entry is created and the user is prompted
+   * to sign in to their GitHub account:
+   * </p>
+   * <ul>
+   * <li>If the user signs in, their GitHub account is linked to this entry.</li>
+   * <li>If the user does not sign in (or does not create a new account when
+   * prompted), they are not added to the GitHub organization, and the external
+   * identity <code>null</code> entry remains in place.</li>
+   * </ul>
+   * </li>
+   * </ol>
+   * 
    */
   @Path("/v2/organizations/{org}/Users")
   @GET
   @Produces("application/scim+json")
-  Response scim_list_provisioned_identities(@PathParam("org") String org,
-      @QueryParam("startIndex") Integer startIndex, @QueryParam("count") Integer count,
-      @QueryParam("filter") String filter);
+  Response scim_list_provisioned_identities(@PathParam("org") String org, @QueryParam("startIndex") Integer startIndex,
+      @QueryParam("count") Integer count, @QueryParam("filter") String filter);
 
   /**
-   * Provision organization membership for a user, and send an activation email to the email address.
+   * <p>
+   * Provision organization membership for a user, and send an activation email to
+   * the email address.
+   * </p>
+   * 
    */
   @Path("/v2/organizations/{org}/Users")
   @POST

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/SearchResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/SearchResource.java
@@ -7,141 +7,267 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/search")
 public interface SearchResource {
   /**
-   * Searches for query terms inside of a file. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).
-   *
-   * When searching for code, you can get text match metadata for the file **content** and file **path** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery) repository, your query would look something like this:
-   *
-   * `q=addClass+in:file+language:js+repo:jquery/jquery`
-   *
-   * This query searches for the keyword `addClass` within a file's contents. The query limits the search to files where the language is JavaScript in the `jquery/jquery` repository.
-   *
-   * #### Considerations for code search
-   *
-   * Due to the complexity of searching code, there are a few restrictions on how searches are performed:
-   *
-   * *   Only the _default branch_ is considered. In most cases, this will be the `master` branch.
-   * *   Only files smaller than 384 KB are searchable.
-   * *   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing
-   * language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.
+   * <p>
+   * Searches for query terms inside of a file. This method returns up to 100
+   * results <a href="https://developer.github.com/v3/#pagination">per page</a>.
+   * </p>
+   * <p>
+   * When searching for code, you can get text match metadata for the file
+   * <strong>content</strong> and file <strong>path</strong> fields when you pass
+   * the <code>text-match</code> media type. For more details about how to receive
+   * highlighted search results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you want to find the definition of the <code>addClass</code>
+   * function inside <a href="https://github.com/jquery/jquery">jQuery</a>
+   * repository, your query would look something like this:
+   * </p>
+   * <p>
+   * <code>q=addClass+in:file+language:js+repo:jquery/jquery</code>
+   * </p>
+   * <p>
+   * This query searches for the keyword <code>addClass</code> within a file's
+   * contents. The query limits the search to files where the language is
+   * JavaScript in the <code>jquery/jquery</code> repository.
+   * </p>
+   * <h4>Considerations for code search</h4>
+   * <p>
+   * Due to the complexity of searching code, there are a few restrictions on how
+   * searches are performed:
+   * </p>
+   * <ul>
+   * <li>Only the <em>default branch</em> is considered. In most cases, this will
+   * be the <code>master</code> branch.</li>
+   * <li>Only files smaller than 384 KB are searchable.</li>
+   * <li>You must always include at least one search term when searching source
+   * code. For example, searching for <a href=
+   * "https://github.com/search?utf8=%E2%9C%93&amp;q=language%3Ago&amp;type=Code"><code>language:go</code></a>
+   * is not valid, while <a href=
+   * "https://github.com/search?utf8=%E2%9C%93&amp;q=amazing+language%3Ago&amp;type=Code"><code>amazing language:go</code></a>
+   * is.</li>
+   * </ul>
+   * 
    */
   @Path("/code")
   @GET
   @Produces("application/json")
-  Response search_code(@QueryParam("q") String q, @QueryParam("sort") String sort,
-      @QueryParam("order") String order, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response search_code(@QueryParam("q") String q, @QueryParam("sort") String sort, @QueryParam("order") String order,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Find labels in a repository with names or descriptions that match search keywords. Returns up to 100 results [per page](https://developer.github.com/v3/#pagination).
-   *
-   * When searching for labels, you can get text match metadata for the label **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you want to find labels in the `linguist` repository that match `bug`, `defect`, or `enhancement`. Your query might look like this:
-   *
-   * `q=bug+defect+enhancement&repository_id=64778136`
-   *
+   * <p>
+   * Find labels in a repository with names or descriptions that match search
+   * keywords. Returns up to 100 results
+   * <a href="https://developer.github.com/v3/#pagination">per page</a>.
+   * </p>
+   * <p>
+   * When searching for labels, you can get text match metadata for the label
+   * <strong>name</strong> and <strong>description</strong> fields when you pass
+   * the <code>text-match</code> media type. For more details about how to receive
+   * highlighted search results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you want to find labels in the <code>linguist</code>
+   * repository that match <code>bug</code>, <code>defect</code>, or
+   * <code>enhancement</code>. Your query might look like this:
+   * </p>
+   * <p>
+   * <code>q=bug+defect+enhancement&amp;repository_id=64778136</code>
+   * </p>
+   * <p>
    * The labels that best match the query appear first in the search results.
+   * </p>
+   * 
    */
   @Path("/labels")
   @GET
   @Produces("application/json")
-  Response search_labels(@QueryParam("repository_id") Integer repositoryId,
-      @QueryParam("q") String q, @QueryParam("sort") String sort,
-      @QueryParam("order") String order);
+  Response search_labels(@QueryParam("repository_id") Integer repositoryId, @QueryParam("q") String q,
+      @QueryParam("sort") String sort, @QueryParam("order") String order);
 
   /**
-   * Find users via various criteria. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).
-   *
-   * When searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields when you pass the `text-match` media type. For more details about highlighting search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata). For more details about how to receive highlighted search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you're looking for a list of popular users, you might try this query:
-   *
-   * `q=tom+repos:%3E42+followers:%3E1000`
-   *
-   * This query searches for users with the name `tom`. The results are restricted to users with more than 42 repositories and over 1,000 followers.
+   * <p>
+   * Find users via various criteria. This method returns up to 100 results
+   * <a href="https://developer.github.com/v3/#pagination">per page</a>.
+   * </p>
+   * <p>
+   * When searching for users, you can get text match metadata for the issue
+   * <strong>login</strong>, <strong>email</strong>, and <strong>name</strong>
+   * fields when you pass the <code>text-match</code> media type. For more details
+   * about highlighting search results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>. For more details about how to receive highlighted search
+   * results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you're looking for a list of popular users, you might try
+   * this query:
+   * </p>
+   * <p>
+   * <code>q=tom+repos:%3E42+followers:%3E1000</code>
+   * </p>
+   * <p>
+   * This query searches for users with the name <code>tom</code>. The results are
+   * restricted to users with more than 42 repositories and over 1,000 followers.
+   * </p>
+   * 
    */
   @Path("/users")
   @GET
   @Produces("application/json")
-  Response search_users(@QueryParam("q") String q, @QueryParam("sort") String sort,
-      @QueryParam("order") String order, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response search_users(@QueryParam("q") String q, @QueryParam("sort") String sort, @QueryParam("order") String order,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Find commits via various criteria on the default branch (usually `master`). This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).
-   *
-   * When searching for commits, you can get text match metadata for the **message** field when you provide the `text-match` media type. For more details about how to receive highlighted search results, see [Text match
-   * metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:
-   *
-   * `q=repo:octocat/Spoon-Knife+css`
+   * <p>
+   * Find commits via various criteria on the default branch (usually
+   * <code>master</code>). This method returns up to 100 results
+   * <a href="https://developer.github.com/v3/#pagination">per page</a>.
+   * </p>
+   * <p>
+   * When searching for commits, you can get text match metadata for the
+   * <strong>message</strong> field when you provide the <code>text-match</code>
+   * media type. For more details about how to receive highlighted search results,
+   * see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you want to find commits related to CSS in the
+   * <a href="https://github.com/octocat/Spoon-Knife">octocat/Spoon-Knife</a>
+   * repository. Your query would look something like this:
+   * </p>
+   * <p>
+   * <code>q=repo:octocat/Spoon-Knife+css</code>
+   * </p>
+   * 
    */
   @Path("/commits")
   @GET
   @Produces("application/json")
-  Response search_commits(@QueryParam("q") String q, @QueryParam("sort") String sort,
-      @QueryParam("order") String order, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response search_commits(@QueryParam("q") String q, @QueryParam("sort") String sort, @QueryParam("order") String order,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Find issues by state and keyword. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).
-   *
-   * When searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields when you pass the `text-match` media type. For more details about how to receive highlighted
-   * search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.
-   *
-   * `q=windows+label:bug+language:python+state:open&sort=created&order=asc`
-   *
-   * This query searches for the keyword `windows`, within any open issue that is labeled as `bug`. The search runs across repositories whose primary language is Python. The results are sorted by creation date in ascending order, whick means the oldest issues appear first in the search results.
+   * <p>
+   * Find issues by state and keyword. This method returns up to 100 results
+   * <a href="https://developer.github.com/v3/#pagination">per page</a>.
+   * </p>
+   * <p>
+   * When searching for issues, you can get text match metadata for the issue
+   * <strong>title</strong>, issue <strong>body</strong>, and issue
+   * <strong>comment body</strong> fields when you pass the
+   * <code>text-match</code> media type. For more details about how to receive
+   * highlighted search results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you want to find the oldest unresolved Python bugs on
+   * Windows. Your query might look something like this.
+   * </p>
+   * <p>
+   * <code>q=windows+label:bug+language:python+state:open&amp;sort=created&amp;order=asc</code>
+   * </p>
+   * <p>
+   * This query searches for the keyword <code>windows</code>, within any open
+   * issue that is labeled as <code>bug</code>. The search runs across
+   * repositories whose primary language is Python. The results are sorted by
+   * creation date in ascending order, whick means the oldest issues appear first
+   * in the search results.
+   * </p>
+   * 
    */
   @Path("/issues")
   @GET
   @Produces("application/json")
-  Response search_issues_and_pull_requests(@QueryParam("q") String q,
-      @QueryParam("sort") String sort, @QueryParam("order") String order,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response search_issues_and_pull_requests(@QueryParam("q") String q, @QueryParam("sort") String sort,
+      @QueryParam("order") String order, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Find repositories via various criteria. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination).
-   *
-   * When searching for repositories, you can get text match metadata for the **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you want to search for popular Tetris repositories written in assembly code, your query might look like this:
-   *
-   * `q=tetris+language:assembly&sort=stars&order=desc`
-   *
-   * This query searches for repositories with the word `tetris` in the name, the description, or the README. The results are limited to repositories where the primary language is assembly. The results are sorted by stars in descending order, so that the most popular repositories appear first in the search results.
-   *
-   * When you include the `mercy` preview header, you can also search for multiple topics by adding more `topic:` instances. For example, your query might look like this:
-   *
-   * `q=topic:ruby+topic:rails`
+   * <p>
+   * Find repositories via various criteria. This method returns up to 100 results
+   * <a href="https://developer.github.com/v3/#pagination">per page</a>.
+   * </p>
+   * <p>
+   * When searching for repositories, you can get text match metadata for the
+   * <strong>name</strong> and <strong>description</strong> fields when you pass
+   * the <code>text-match</code> media type. For more details about how to receive
+   * highlighted search results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you want to search for popular Tetris repositories written in
+   * assembly code, your query might look like this:
+   * </p>
+   * <p>
+   * <code>q=tetris+language:assembly&amp;sort=stars&amp;order=desc</code>
+   * </p>
+   * <p>
+   * This query searches for repositories with the word <code>tetris</code> in the
+   * name, the description, or the README. The results are limited to repositories
+   * where the primary language is assembly. The results are sorted by stars in
+   * descending order, so that the most popular repositories appear first in the
+   * search results.
+   * </p>
+   * <p>
+   * When you include the <code>mercy</code> preview header, you can also search
+   * for multiple topics by adding more <code>topic:</code> instances. For
+   * example, your query might look like this:
+   * </p>
+   * <p>
+   * <code>q=topic:ruby+topic:rails</code>
+   * </p>
+   * 
    */
   @Path("/repositories")
   @GET
   @Produces("application/json")
-  Response search_repos(@QueryParam("q") String q, @QueryParam("sort") String sort,
-      @QueryParam("order") String order, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response search_repos(@QueryParam("q") String q, @QueryParam("sort") String sort, @QueryParam("order") String order,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Find topics via various criteria. Results are sorted by best match. This method returns up to 100 results [per page](https://developer.github.com/v3/#pagination). See "[Searching topics](https://help.github.com/articles/searching-topics/)" for a detailed list of qualifiers.
-   *
-   * When searching for topics, you can get text match metadata for the topic's **short\_description**, **description**, **name**, or **display\_name** field when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://developer.github.com/v3/search/#text-match-metadata).
-   *
-   * For example, if you want to search for topics related to Ruby that are featured on https://github.com/topics. Your query might look like this:
-   *
-   * `q=ruby+is:featured`
-   *
-   * This query searches for topics with the keyword `ruby` and limits the results to find only topics that are featured. The topics that are the best match for the query appear first in the search results.
+   * <p>
+   * Find topics via various criteria. Results are sorted by best match. This
+   * method returns up to 100 results
+   * <a href="https://developer.github.com/v3/#pagination">per page</a>. See
+   * &quot;<a href="https://help.github.com/articles/searching-topics/">Searching
+   * topics</a>&quot; for a detailed list of qualifiers.
+   * </p>
+   * <p>
+   * When searching for topics, you can get text match metadata for the topic's
+   * <strong>short_description</strong>, <strong>description</strong>,
+   * <strong>name</strong>, or <strong>display_name</strong> field when you pass
+   * the <code>text-match</code> media type. For more details about how to receive
+   * highlighted search results, see
+   * <a href="https://developer.github.com/v3/search/#text-match-metadata">Text
+   * match metadata</a>.
+   * </p>
+   * <p>
+   * For example, if you want to search for topics related to Ruby that are
+   * featured on https://github.com/topics. Your query might look like this:
+   * </p>
+   * <p>
+   * <code>q=ruby+is:featured</code>
+   * </p>
+   * <p>
+   * This query searches for topics with the keyword <code>ruby</code> and limits
+   * the results to find only topics that are featured. The topics that are the
+   * best match for the query appear first in the search results.
+   * </p>
+   * 
    */
   @Path("/topics")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/TeamsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/TeamsResource.java
@@ -14,53 +14,103 @@ import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/teams")
 public interface TeamsResource {
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List reactions for a team discussion comment`](https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-comment) endpoint.
-   *
-   * List the reactions to a [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/). OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion-comment"><code>List reactions for a team discussion comment</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * List the reactions to a
+   * <a href="https://developer.github.com/v3/teams/discussion_comments/">team
+   * discussion comment</a>. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions")
   @GET
   @Produces("application/json")
   Response reactions_list_for_team_discussion_comment_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber, @QueryParam("content") String content,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber,
+      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`Create reaction for a team discussion comment`](https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-comment) endpoint.
-   *
-   * Create a reaction to a [team discussion comment](https://developer.github.com/v3/teams/discussion_comments/). OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with a `Status: 200 OK` means that you already added the reaction type to this team discussion comment.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion-comment"><code>Create reaction for a team discussion comment</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * Create a reaction to a
+   * <a href="https://developer.github.com/v3/teams/discussion_comments/">team
+   * discussion comment</a>. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * A response with a <code>Status: 200 OK</code> means that you already added
+   * the reaction type to this team discussion comment.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions")
   @POST
   @Produces("application/json")
   @Consumes("application/json")
   Response reactions_create_for_team_discussion_comment_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber, InputStream data);
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber,
+      InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List reactions for a team discussion`](https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion) endpoint.
-   *
-   * List the reactions to a [team discussion](https://developer.github.com/v3/teams/discussions/). OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/reactions/#list-reactions-for-a-team-discussion"><code>List reactions for a team discussion</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * List the reactions to a
+   * <a href="https://developer.github.com/v3/teams/discussions/">team
+   * discussion</a>. OAuth access tokens require the <code>read:discussion</code>
+   * <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/reactions")
   @GET
   @Produces("application/json")
   Response reactions_list_for_team_discussion_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @QueryParam("content") String content, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("discussion_number") Integer discussionNumber, @QueryParam("content") String content,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`Create reaction for a team discussion`](https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion) endpoint.
-   *
-   * Create a reaction to a [team discussion](https://developer.github.com/v3/teams/discussions/). OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with a `Status: 200 OK` means that you already added the reaction type to this team discussion.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/reactions/#create-reaction-for-a-team-discussion"><code>Create reaction for a team discussion</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * Create a reaction to a
+   * <a href="https://developer.github.com/v3/teams/discussions/">team
+   * discussion</a>. OAuth access tokens require the <code>write:discussion</code>
+   * <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * A response with a <code>Status: 200 OK</code> means that you already added
+   * the reaction type to this team discussion.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/reactions")
   @POST
@@ -70,93 +120,191 @@ public interface TeamsResource {
       @PathParam("discussion_number") Integer discussionNumber, InputStream data);
 
   /**
-   * The "Get team member" endpoint (described below) is deprecated.
-   *
-   * We recommend using the [Get team membership for a user](https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user) endpoint instead. It allows you to get both active and pending memberships.
-   *
-   * To list members in a team, the team must be visible to the authenticated user.
+   * <p>
+   * The &quot;Get team member&quot; endpoint (described below) is deprecated.
+   * </p>
+   * <p>
+   * We recommend using the <a href=
+   * "https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user">Get
+   * team membership for a user</a> endpoint instead. It allows you to get both
+   * active and pending memberships.
+   * </p>
+   * <p>
+   * To list members in a team, the team must be visible to the authenticated
+   * user.
+   * </p>
+   * 
    */
   @Path("/{team_id}/members/{username}")
   @GET
-  void teams_get_member_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("username") String username);
+  void teams_get_member_legacy(@PathParam("team_id") Integer teamId, @PathParam("username") String username);
 
   /**
-   * The "Add team member" endpoint (described below) is deprecated.
-   *
-   * We recommend using the [Add or update team membership for a user](https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user) endpoint instead. It allows you to invite new organization members to your teams.
-   *
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * To add someone to a team, the authenticated user must be an organization owner or a team maintainer in the team they're changing. The person being added to the team must be a member of the team's organization.
-   *
-   * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
-   *
-   * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
+   * <p>
+   * The &quot;Add team member&quot; endpoint (described below) is deprecated.
+   * </p>
+   * <p>
+   * We recommend using the <a href=
+   * "https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user">Add
+   * or update team membership for a user</a> endpoint instead. It allows you to
+   * invite new organization members to your teams.
+   * </p>
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * To add someone to a team, the authenticated user must be an organization
+   * owner or a team maintainer in the team they're changing. The person being
+   * added to the team must be a member of the team's organization.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> When you have team synchronization set up for a team
+   * with your organization's identity provider (IdP), you will see an error if
+   * you attempt to use the API for making changes to the team's membership. If
+   * you have access to manage group membership in your IdP, you can manage GitHub
+   * team membership through your identity provider, which automatically adds and
+   * removes team members in an organization. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/">Synchronizing
+   * teams between your identity provider and GitHub</a>.&quot;
+   * </p>
+   * <p>
+   * Note that you'll need to set <code>Content-Length</code> to zero when calling
+   * out to this endpoint. For more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{team_id}/members/{username}")
   @PUT
-  void teams_add_member_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("username") String username);
+  void teams_add_member_legacy(@PathParam("team_id") Integer teamId, @PathParam("username") String username);
 
   /**
-   * The "Remove team member" endpoint (described below) is deprecated.
-   *
-   * We recommend using the [Remove team membership for a user](https://developer.github.com/v3/teams/members/#remove-team-membership-for-a-user) endpoint instead. It allows you to remove both active and pending memberships.
-   *
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * To remove a team member, the authenticated user must have 'admin' permissions to the team or be an owner of the org that the team is associated with. Removing a team member does not delete the user, it just removes them from the team.
-   *
-   * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+   * <p>
+   * The &quot;Remove team member&quot; endpoint (described below) is deprecated.
+   * </p>
+   * <p>
+   * We recommend using the <a href=
+   * "https://developer.github.com/v3/teams/members/#remove-team-membership-for-a-user">Remove
+   * team membership for a user</a> endpoint instead. It allows you to remove both
+   * active and pending memberships.
+   * </p>
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * To remove a team member, the authenticated user must have 'admin' permissions
+   * to the team or be an owner of the org that the team is associated with.
+   * Removing a team member does not delete the user, it just removes them from
+   * the team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> When you have team synchronization set up for a team
+   * with your organization's identity provider (IdP), you will see an error if
+   * you attempt to use the API for making changes to the team's membership. If
+   * you have access to manage group membership in your IdP, you can manage GitHub
+   * team membership through your identity provider, which automatically adds and
+   * removes team members in an organization. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/">Synchronizing
+   * teams between your identity provider and GitHub</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{team_id}/members/{username}")
   @DELETE
-  void teams_remove_member_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("username") String username);
+  void teams_remove_member_legacy(@PathParam("team_id") Integer teamId, @PathParam("username") String username);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Get a discussion comment](https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comment) endpoint.
-   *
-   * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussion_comments/#get-a-discussion-comment">Get
+   * a discussion comment</a> endpoint.
+   * </p>
+   * <p>
+   * Get a specific comment on a team discussion. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments/{comment_number}")
   @GET
   @Produces("application/json")
   Response teams_get_discussion_comment_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber);
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Delete a discussion comment](https://developer.github.com/v3/teams/discussion_comments/#delete-a-discussion-comment) endpoint.
-   *
-   * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussion_comments/#delete-a-discussion-comment">Delete
+   * a discussion comment</a> endpoint.
+   * </p>
+   * <p>
+   * Deletes a comment on a team discussion. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments/{comment_number}")
   @DELETE
   void teams_delete_discussion_comment_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber);
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Update a discussion comment](https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-comment) endpoint.
-   *
-   * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussion_comments/#update-a-discussion-comment">Update
+   * a discussion comment</a> endpoint.
+   * </p>
+   * <p>
+   * Edits the body text of a discussion comment. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments/{comment_number}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
   Response teams_update_discussion_comment_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @PathParam("comment_number") Integer commentNumber, InputStream data);
+      @PathParam("discussion_number") Integer discussionNumber, @PathParam("comment_number") Integer commentNumber,
+      InputStream data);
 
   /**
-   * **Note**: Repositories inherited through a parent team will also be checked.
-   *
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Check team permissions for a repository](https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository) endpoint.
-   *
-   * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:
+   * <p>
+   * <strong>Note</strong>: Repositories inherited through a parent team will also
+   * be checked.
+   * </p>
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#check-team-permissions-for-a-repository">Check
+   * team permissions for a repository</a> endpoint.
+   * </p>
+   * <p>
+   * You can also get information about the specified repository, including what
+   * permissions the team grants on it, by passing the following custom
+   * <a href="https://developer.github.com/v3/media/">media type</a> via the
+   * <code>Accept</code> header:
+   * </p>
+   * 
    */
   @Path("/{team_id}/repos/{owner}/{repo}")
   @GET
@@ -165,11 +313,29 @@ public interface TeamsResource {
       @PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Add or update team repository permissions](https://developer.github.com/v3/teams/#add-or-update-team-repository-permissions) endpoint.
-   *
-   * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization.
-   *
-   * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#add-or-update-team-repository-permissions">Add
+   * or update team repository permissions</a> endpoint.
+   * </p>
+   * <p>
+   * To add a repository to a team or update the team's permission on a
+   * repository, the authenticated user must have admin access to the repository,
+   * and must be able to see the team. The repository must be owned by the
+   * organization, or a direct fork of a repository owned by the organization. You
+   * will get a <code>422 Unprocessable Entity</code> status if you attempt to add
+   * a repository to a team that is not owned by the organization.
+   * </p>
+   * <p>
+   * Note that, if you choose not to pass any parameters, you'll need to set
+   * <code>Content-Length</code> to zero when calling out to this endpoint. For
+   * more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{team_id}/repos/{owner}/{repo}")
   @PUT
@@ -178,23 +344,50 @@ public interface TeamsResource {
       @PathParam("owner") String owner, @PathParam("repo") String repo, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Remove a repository from a team](https://developer.github.com/v3/teams/#remove-a-repository-from-a-team) endpoint.
-   *
-   * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. NOTE: This does not delete the repository, it just removes it from the team.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#remove-a-repository-from-a-team">Remove
+   * a repository from a team</a> endpoint.
+   * </p>
+   * <p>
+   * If the authenticated user is an organization owner or a team maintainer, they
+   * can remove any repositories from the team. To remove a repository from a team
+   * as an organization member, the authenticated user must have admin access to
+   * the repository and must be able to see the team. NOTE: This does not delete
+   * the repository, it just removes it from the team.
+   * </p>
+   * 
    */
   @Path("/{team_id}/repos/{owner}/{repo}")
   @DELETE
-  void teams_remove_repo_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("owner") String owner, @PathParam("repo") String repo);
+  void teams_remove_repo_legacy(@PathParam("team_id") Integer teamId, @PathParam("owner") String owner,
+      @PathParam("repo") String repo);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Get team membership for a user](https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user) endpoint.
-   *
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user">Get
+   * team membership for a user</a> endpoint.
+   * </p>
+   * <p>
    * Team members will include the members of child teams.
-   *
-   * To get a user's membership with a team, the team must be visible to the authenticated user.
-   *
-   * **Note:** The `role` for organization owners returns as `maintainer`. For more information about `maintainer` roles, see [Create a team](https://developer.github.com/v3/teams/#create-a-team).
+   * </p>
+   * <p>
+   * To get a user's membership with a team, the team must be visible to the
+   * authenticated user.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> The <code>role</code> for organization owners returns
+   * as <code>maintainer</code>. For more information about
+   * <code>maintainer</code> roles, see
+   * <a href="https://developer.github.com/v3/teams/#create-a-team">Create a
+   * team</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/memberships/{username}")
   @GET
@@ -203,17 +396,51 @@ public interface TeamsResource {
       @PathParam("username") String username);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Add or update team membership for a user](https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user) endpoint.
-   *
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * If the user is already a member of the team's organization, this endpoint will add the user to the team. To add a membership between an organization member and a team, the authenticated user must be an organization owner or a team maintainer.
-   *
-   * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
-   *
-   * If the user is unaffiliated with the team's organization, this endpoint will send an invitation to the user via email. This newly-created membership will be in the "pending" state until the user accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team. To add a membership between an unaffiliated user and a team, the authenticated user must be an organization owner.
-   *
-   * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/members/#add-or-update-team-membership-for-a-user">Add
+   * or update team membership for a user</a> endpoint.
+   * </p>
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * If the user is already a member of the team's organization, this endpoint
+   * will add the user to the team. To add a membership between an organization
+   * member and a team, the authenticated user must be an organization owner or a
+   * team maintainer.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> When you have team synchronization set up for a team
+   * with your organization's identity provider (IdP), you will see an error if
+   * you attempt to use the API for making changes to the team's membership. If
+   * you have access to manage group membership in your IdP, you can manage GitHub
+   * team membership through your identity provider, which automatically adds and
+   * removes team members in an organization. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/">Synchronizing
+   * teams between your identity provider and GitHub</a>.&quot;
+   * </p>
+   * <p>
+   * If the user is unaffiliated with the team's organization, this endpoint will
+   * send an invitation to the user via email. This newly-created membership will
+   * be in the &quot;pending&quot; state until the user accepts the invitation, at
+   * which point the membership will transition to the &quot;active&quot; state
+   * and the user will be added as a member of the team. To add a membership
+   * between an unaffiliated user and a team, the authenticated user must be an
+   * organization owner.
+   * </p>
+   * <p>
+   * If the user is already a member of the team, this endpoint will update the
+   * role of the team member's role. To update the membership of a team member,
+   * the authenticated user must be an organization owner or a team maintainer.
+   * </p>
+   * 
    */
   @Path("/{team_id}/memberships/{username}")
   @PUT
@@ -223,13 +450,37 @@ public interface TeamsResource {
       @PathParam("username") String username, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Remove team membership for a user](https://developer.github.com/v3/teams/members/#remove-team-membership-for-a-user) endpoint.
-   *
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
-   *
-   * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/members/#remove-team-membership-for-a-user">Remove
+   * team membership for a user</a> endpoint.
+   * </p>
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * To remove a membership between a user and a team, the authenticated user must
+   * have 'admin' permissions to the team or be an owner of the organization that
+   * the team is associated with. Removing team membership does not delete the
+   * user, it just removes their membership from the team.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> When you have team synchronization set up for a team
+   * with your organization's identity provider (IdP), you will see an error if
+   * you attempt to use the API for making changes to the team's membership. If
+   * you have access to manage group membership in your IdP, you can manage GitHub
+   * team membership through your identity provider, which automatically adds and
+   * removes team members in an organization. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/">Synchronizing
+   * teams between your identity provider and GitHub</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/{team_id}/memberships/{username}")
   @DELETE
@@ -237,9 +488,19 @@ public interface TeamsResource {
       @PathParam("username") String username);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Get a discussion](https://developer.github.com/v3/teams/discussions/#get-a-discussion) endpoint.
-   *
-   * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussions/#get-a-discussion">Get a
+   * discussion</a> endpoint.
+   * </p>
+   * <p>
+   * Get a specific discussion on a team's page. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}")
   @GET
@@ -248,9 +509,19 @@ public interface TeamsResource {
       @PathParam("discussion_number") Integer discussionNumber);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`Delete a discussion`](https://developer.github.com/v3/teams/discussions/#delete-a-discussion) endpoint.
-   *
-   * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussions/#delete-a-discussion"><code>Delete a discussion</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * Delete a discussion from a team's page. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}")
   @DELETE
@@ -258,9 +529,20 @@ public interface TeamsResource {
       @PathParam("discussion_number") Integer discussionNumber);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Update a discussion](https://developer.github.com/v3/teams/discussions/#update-a-discussion) endpoint.
-   *
-   * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussions/#update-a-discussion">Update
+   * a discussion</a> endpoint.
+   * </p>
+   * <p>
+   * Edits the title and body text of a discussion post. Only the parameters you
+   * provide are updated. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}")
   @PATCH
@@ -270,7 +552,14 @@ public interface TeamsResource {
       @PathParam("discussion_number") Integer discussionNumber, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the [Get a team by name](https://developer.github.com/v3/teams/#get-a-team-by-name) endpoint.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the
+   * <a href="https://developer.github.com/v3/teams/#get-a-team-by-name">Get a
+   * team by name</a> endpoint.
+   * </p>
+   * 
    */
   @Path("/{team_id}")
   @GET
@@ -278,22 +567,44 @@ public interface TeamsResource {
   Response teams_get_legacy(@PathParam("team_id") Integer teamId);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Delete a team](https://developer.github.com/v3/teams/#delete-a-team) endpoint.
-   *
-   * To delete a team, the authenticated user must be an organization owner or team maintainer.
-   *
-   * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new
+   * <a href="https://developer.github.com/v3/teams/#delete-a-team">Delete a
+   * team</a> endpoint.
+   * </p>
+   * <p>
+   * To delete a team, the authenticated user must be an organization owner or
+   * team maintainer.
+   * </p>
+   * <p>
+   * If you are an organization owner, deleting a parent team will delete all of
+   * its child teams as well.
+   * </p>
+   * 
    */
   @Path("/{team_id}")
   @DELETE
   void teams_delete_legacy(@PathParam("team_id") Integer teamId);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Update a team](https://developer.github.com/v3/teams/#update-a-team) endpoint.
-   *
-   * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
-   *
-   * **Note:** With nested teams, the `privacy` for parent teams cannot be `secret`.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new
+   * <a href="https://developer.github.com/v3/teams/#update-a-team">Update a
+   * team</a> endpoint.
+   * </p>
+   * <p>
+   * To edit a team, the authenticated user must either be an organization owner
+   * or a team maintainer.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> With nested teams, the <code>privacy</code> for parent
+   * teams cannot be <code>secret</code>.
+   * </p>
+   * 
    */
   @Path("/{team_id}")
   @PATCH
@@ -302,11 +613,23 @@ public interface TeamsResource {
   Response teams_update_legacy(@PathParam("team_id") Integer teamId, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List IdP groups for a team`](https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team) endpoint.
-   *
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/team_sync/#list-idp-groups-for-a-team"><code>List IdP groups for a team</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
    * List IdP groups connected to a team on GitHub.
+   * </p>
+   * 
    */
   @Path("/{team_id}/team-sync/group-mappings")
   @GET
@@ -314,23 +637,50 @@ public interface TeamsResource {
   Response teams_list_idp_groups_for_legacy(@PathParam("team_id") Integer teamId);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`Create or update IdP group connections`](https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections) endpoint.
-   *
-   * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
-   *
-   * Creates, updates, or removes a connection between a team and an IdP group. When adding groups to a team, you must include all new and existing groups to avoid replacing existing groups with the new ones. Specifying an empty `groups` array will remove all connections for a team.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/team_sync/#create-or-update-idp-group-connections"><code>Create or update IdP group connections</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * Team synchronization is available for organizations using GitHub Enterprise
+   * Cloud. For more information, see <a href=
+   * "https://help.github.com/github/getting-started-with-github/githubs-products">GitHub's
+   * products</a> in the GitHub Help documentation.
+   * </p>
+   * <p>
+   * Creates, updates, or removes a connection between a team and an IdP group.
+   * When adding groups to a team, you must include all new and existing groups to
+   * avoid replacing existing groups with the new ones. Specifying an empty
+   * <code>groups</code> array will remove all connections for a team.
+   * </p>
+   * 
    */
   @Path("/{team_id}/team-sync/group-mappings")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response teams_create_or_update_idp_group_connections_legacy(@PathParam("team_id") Integer teamId,
-      InputStream data);
+  Response teams_create_or_update_idp_group_connections_legacy(@PathParam("team_id") Integer teamId, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List pending team invitations`](https://developer.github.com/v3/teams/members/#list-pending-team-invitations) endpoint.
-   *
-   * The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/members/#list-pending-team-invitations"><code>List pending team invitations</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * The return hash contains a <code>role</code> field which refers to the
+   * Organization Invitation role and will be one of the following values:
+   * <code>direct_member</code>, <code>admin</code>, <code>billing_manager</code>,
+   * <code>hiring_manager</code>, or <code>reinstate</code>. If the invitee is not
+   * a GitHub member, the <code>login</code> field in the return hash will be
+   * <code>null</code>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/invitations")
   @GET
@@ -339,24 +689,51 @@ public interface TeamsResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [List discussion comments](https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comments) endpoint.
-   *
-   * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussion_comments/#list-discussion-comments">List
+   * discussion comments</a> endpoint.
+   * </p>
+   * <p>
+   * List all comments on a team discussion. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments")
   @GET
   @Produces("application/json")
   Response teams_list_discussion_comments_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("discussion_number") Integer discussionNumber,
-      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("discussion_number") Integer discussionNumber, @QueryParam("direction") String direction,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Create a discussion comment](https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-comment) endpoint.
-   *
-   * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussion_comments/#create-a-discussion-comment">Create
+   * a discussion comment</a> endpoint.
+   * </p>
+   * <p>
+   * Creates a new comment on a team discussion. OAuth access tokens require the
+   * <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions/{discussion_number}/comments")
   @POST
@@ -366,27 +743,51 @@ public interface TeamsResource {
       @PathParam("discussion_number") Integer discussionNumber, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [List team repositories](https://developer.github.com/v3/teams/#list-team-repositories) endpoint.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new
+   * <a href="https://developer.github.com/v3/teams/#list-team-repositories">List
+   * team repositories</a> endpoint.
+   * </p>
+   * 
    */
   @Path("/{team_id}/repos")
   @GET
   @Produces("application/json")
-  Response teams_list_repos_legacy(@PathParam("team_id") Integer teamId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response teams_list_repos_legacy(@PathParam("team_id") Integer teamId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List child teams`](https://developer.github.com/v3/teams/#list-child-teams) endpoint.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#list-child-teams"><code>List child teams</code></a>
+   * endpoint.
+   * </p>
+   * 
    */
   @Path("/{team_id}/teams")
   @GET
   @Produces("application/json")
-  Response teams_list_child_legacy(@PathParam("team_id") Integer teamId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response teams_list_child_legacy(@PathParam("team_id") Integer teamId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Check team permissions for a project](https://developer.github.com/v3/teams/#check-team-permissions-for-a-project) endpoint.
-   *
-   * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#check-team-permissions-for-a-project">Check
+   * team permissions for a project</a> endpoint.
+   * </p>
+   * <p>
+   * Checks whether a team has <code>read</code>, <code>write</code>, or
+   * <code>admin</code> permissions for an organization project. The response
+   * includes projects inherited from a parent team.
+   * </p>
+   * 
    */
   @Path("/{team_id}/projects/{project_id}")
   @GET
@@ -395,9 +796,20 @@ public interface TeamsResource {
       @PathParam("project_id") Integer projectId);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Add or update team project permissions](https://developer.github.com/v3/teams/#add-or-update-team-project-permissions) endpoint.
-   *
-   * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#add-or-update-team-project-permissions">Add
+   * or update team project permissions</a> endpoint.
+   * </p>
+   * <p>
+   * Adds an organization project to a team. To add a project to a team or update
+   * the team's permission on a project, the authenticated user must have
+   * <code>admin</code> permissions for the project. The project and team must be
+   * part of the same organization.
+   * </p>
+   * 
    */
   @Path("/{team_id}/projects/{project_id}")
   @PUT
@@ -406,30 +818,60 @@ public interface TeamsResource {
       @PathParam("project_id") Integer projectId, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [Remove a project from a team](https://developer.github.com/v3/teams/#remove-a-project-from-a-team) endpoint.
-   *
-   * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. **Note:** This endpoint removes the project from the team, but does not delete it.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#remove-a-project-from-a-team">Remove
+   * a project from a team</a> endpoint.
+   * </p>
+   * <p>
+   * Removes an organization project from a team. An organization owner or a team
+   * maintainer can remove any project from the team. To remove a project from a
+   * team as an organization member, the authenticated user must have
+   * <code>read</code> access to both the team and project, or <code>admin</code>
+   * access to the team or project. <strong>Note:</strong> This endpoint removes
+   * the project from the team, but does not delete it.
+   * </p>
+   * 
    */
   @Path("/{team_id}/projects/{project_id}")
   @DELETE
-  void teams_remove_project_legacy(@PathParam("team_id") Integer teamId,
-      @PathParam("project_id") Integer projectId);
+  void teams_remove_project_legacy(@PathParam("team_id") Integer teamId, @PathParam("project_id") Integer projectId);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List team projects`](https://developer.github.com/v3/teams/#list-team-projects) endpoint.
-   *
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/#list-team-projects"><code>List team projects</code></a>
+   * endpoint.
+   * </p>
+   * <p>
    * Lists the organization projects for a team.
+   * </p>
+   * 
    */
   @Path("/{team_id}/projects")
   @GET
   @Produces("application/json")
-  Response teams_list_projects_legacy(@PathParam("team_id") Integer teamId,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response teams_list_projects_legacy(@PathParam("team_id") Integer teamId, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List discussions`](https://developer.github.com/v3/teams/discussions/#list-discussions) endpoint.
-   *
-   * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussions/#list-discussions"><code>List discussions</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * List all discussions on a team's page. OAuth access tokens require the
+   * <code>read:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions")
   @GET
@@ -439,11 +881,29 @@ public interface TeamsResource {
       @QueryParam("page") Integer page);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`Create a discussion`](https://developer.github.com/v3/teams/discussions/#create-a-discussion) endpoint.
-   *
-   * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
-   *
-   * This endpoint triggers [notifications](https://help.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://developer.github.com/v3/#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits)" for details.
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/discussions/#create-a-discussion"><code>Create a discussion</code></a>
+   * endpoint.
+   * </p>
+   * <p>
+   * Creates a new discussion post on a team's page. OAuth access tokens require
+   * the <code>write:discussion</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * <p>
+   * This endpoint triggers <a href=
+   * "https://help.github.com/articles/about-notifications/">notifications</a>.
+   * Creating content too quickly using this endpoint may result in abuse rate
+   * limiting. See
+   * &quot;<a href="https://developer.github.com/v3/#abuse-rate-limits">Abuse rate
+   * limits</a>&quot; and &quot;<a href=
+   * "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+   * with abuse rate limits</a>&quot; for details.
+   * </p>
+   * 
    */
   @Path("/{team_id}/discussions")
   @POST
@@ -452,14 +912,21 @@ public interface TeamsResource {
   Response teams_create_discussion_legacy(@PathParam("team_id") Integer teamId, InputStream data);
 
   /**
-   * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Teams API. We recommend migrating your existing code to use the new [`List team members`](https://developer.github.com/v3/teams/members/#list-team-members) endpoint.
-   *
+   * <p>
+   * <strong>Deprecation Notice:</strong> This endpoint route is deprecated and
+   * will be removed from the Teams API. We recommend migrating your existing code
+   * to use the new <a href=
+   * "https://developer.github.com/v3/teams/members/#list-team-members"><code>List team members</code></a>
+   * endpoint.
+   * </p>
+   * <p>
    * Team members will include the members of child teams.
+   * </p>
+   * 
    */
   @Path("/{team_id}/members")
   @GET
   @Produces("application/json")
-  Response teams_list_members_legacy(@PathParam("team_id") Integer teamId,
-      @QueryParam("role") String role, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response teams_list_members_legacy(@PathParam("team_id") Integer teamId, @QueryParam("role") String role,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/UserResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/UserResource.java
@@ -15,12 +15,16 @@ import java.io.InputStream;
 import java.util.List;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/user")
 public interface UserResource {
   /**
-   * When authenticating as a user, this endpoint will list all currently open repository invitations for that user.
+   * <p>
+   * When authenticating as a user, this endpoint will list all currently open
+   * repository invitations for that user.
+   * </p>
+   * 
    */
   @Path("/repository_invitations")
   @GET
@@ -29,42 +33,57 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/repository_invitations/{invitation_id}")
   @DELETE
   void repos_decline_invitation(@PathParam("invitation_id") Integer invitationId);
 
   /**
-   *
+   * 
    */
   @Path("/repository_invitations/{invitation_id}")
   @PATCH
   void repos_accept_invitation(@PathParam("invitation_id") Integer invitationId);
 
   /**
-   * Lists repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
-   *
-   * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+   * <p>
+   * Lists repositories that the authenticated user has explicit permission
+   * (<code>:read</code>, <code>:write</code>, or <code>:admin</code>) to access.
+   * </p>
+   * <p>
+   * The authenticated user has explicit permission to access repositories they
+   * own, repositories where they are a collaborator, and repositories that they
+   * can access through an organization membership.
+   * </p>
+   * 
    */
   @Path("/repos")
   @GET
   @Produces("application/json")
   Response repos_list_for_authenticated_user(@QueryParam("visibility") String visibility,
-      @QueryParam("affiliation") String affiliation, @QueryParam("type") String type,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page,
-      @QueryParam("since") String since, @QueryParam("before") String before);
+      @QueryParam("affiliation") String affiliation, @QueryParam("type") String type, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page, @QueryParam("since") String since, @QueryParam("before") String before);
 
   /**
+   * <p>
    * Creates a new repository for the authenticated user.
-   *
-   * **OAuth scope requirements**
-   *
-   * When using [OAuth](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
-   *
-   * *   `public_repo` scope or `repo` scope to create a public repository
-   * *   `repo` scope to create a private repository
+   * </p>
+   * <p>
+   * <strong>OAuth scope requirements</strong>
+   * </p>
+   * <p>
+   * When using <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">OAuth</a>,
+   * authorizations must include:
+   * </p>
+   * <ul>
+   * <li><code>public_repo</code> scope or <code>repo</code> scope to create a
+   * public repository</li>
+   * <li><code>repo</code> scope to create a private repository</li>
+   * </ul>
+   * 
    */
   @Path("/repos")
   @POST
@@ -73,23 +92,40 @@ public interface UserResource {
   Response repos_create_for_authenticated_user(InputStream data);
 
   /**
-   * Fetches a single user migration. The response includes the `state` of the migration, which can be one of the following values:
-   *
-   * *   `pending` - the migration hasn't started yet.
-   * *   `exporting` - the migration is in progress.
-   * *   `exported` - the migration finished successfully.
-   * *   `failed` - the migration failed.
-   *
-   * Once the migration has been `exported` you can [download the migration archive](https://developer.github.com/v3/migrations/users/#download-a-user-migration-archive).
+   * <p>
+   * Fetches a single user migration. The response includes the <code>state</code>
+   * of the migration, which can be one of the following values:
+   * </p>
+   * <ul>
+   * <li><code>pending</code> - the migration hasn't started yet.</li>
+   * <li><code>exporting</code> - the migration is in progress.</li>
+   * <li><code>exported</code> - the migration finished successfully.</li>
+   * <li><code>failed</code> - the migration failed.</li>
+   * </ul>
+   * <p>
+   * Once the migration has been <code>exported</code> you can <a href=
+   * "https://developer.github.com/v3/migrations/users/#download-a-user-migration-archive">download
+   * the migration archive</a>.
+   * </p>
+   * 
    */
   @Path("/migrations/{migration_id}")
   @GET
   @Produces("application/json")
-  Response migrations_get_status_for_authenticated_user(
-      @PathParam("migration_id") Integer migrationId, @QueryParam("exclude") List<String> exclude);
+  Response migrations_get_status_for_authenticated_user(@PathParam("migration_id") Integer migrationId,
+      @QueryParam("exclude") List<String> exclude);
 
   /**
-   * Unlocks a repository. You can lock repositories when you [start a user migration](https://developer.github.com/v3/migrations/users/#start-a-user-migration). Once the migration is complete you can unlock each repository to begin using it again or [delete the repository](https://developer.github.com/v3/repos/#delete-a-repository) if you no longer need the source data. Returns a status of `404 Not Found` if the repository is not locked.
+   * <p>
+   * Unlocks a repository. You can lock repositories when you <a href=
+   * "https://developer.github.com/v3/migrations/users/#start-a-user-migration">start
+   * a user migration</a>. Once the migration is complete you can unlock each
+   * repository to begin using it again or
+   * <a href="https://developer.github.com/v3/repos/#delete-a-repository">delete
+   * the repository</a> if you no longer need the source data. Returns a status of
+   * <code>404 Not Found</code> if the repository is not locked.
+   * </p>
+   * 
    */
   @Path("/migrations/{migration_id}/repos/{repo_name}/lock")
   @DELETE
@@ -97,7 +133,10 @@ public interface UserResource {
       @PathParam("repo_name") String repoName);
 
   /**
+   * <p>
    * Lists all the repositories for this user migration.
+   * </p>
+   * 
    */
   @Path("/migrations/{migration_id}/repositories")
   @GET
@@ -106,7 +145,10 @@ public interface UserResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists all migrations a user has started.
+   * </p>
+   * 
    */
   @Path("/migrations")
   @GET
@@ -115,7 +157,10 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Initiates the generation of a user migration archive.
+   * </p>
+   * 
    */
   @Path("/migrations")
   @POST
@@ -124,43 +169,60 @@ public interface UserResource {
   Response migrations_start_for_authenticated_user(InputStream data);
 
   /**
-   * Fetches the URL to download the migration archive as a `tar.gz` file. Depending on the resources your repository uses, the migration archive can contain JSON files with data for these objects:
-   *
-   * *   attachments
-   * *   bases
-   * *   commit\_comments
-   * *   issue\_comments
-   * *   issue\_events
-   * *   issues
-   * *   milestones
-   * *   organizations
-   * *   projects
-   * *   protected\_branches
-   * *   pull\_request\_reviews
-   * *   pull\_requests
-   * *   releases
-   * *   repositories
-   * *   review\_comments
-   * *   schema
-   * *   users
-   *
-   * The archive will also contain an `attachments` directory that includes all attachment files uploaded to GitHub.com and a `repositories` directory that contains the repository's Git data.
+   * <p>
+   * Fetches the URL to download the migration archive as a <code>tar.gz</code>
+   * file. Depending on the resources your repository uses, the migration archive
+   * can contain JSON files with data for these objects:
+   * </p>
+   * <ul>
+   * <li>attachments</li>
+   * <li>bases</li>
+   * <li>commit_comments</li>
+   * <li>issue_comments</li>
+   * <li>issue_events</li>
+   * <li>issues</li>
+   * <li>milestones</li>
+   * <li>organizations</li>
+   * <li>projects</li>
+   * <li>protected_branches</li>
+   * <li>pull_request_reviews</li>
+   * <li>pull_requests</li>
+   * <li>releases</li>
+   * <li>repositories</li>
+   * <li>review_comments</li>
+   * <li>schema</li>
+   * <li>users</li>
+   * </ul>
+   * <p>
+   * The archive will also contain an <code>attachments</code> directory that
+   * includes all attachment files uploaded to GitHub.com and a
+   * <code>repositories</code> directory that contains the repository's Git data.
+   * </p>
+   * 
    */
   @Path("/migrations/{migration_id}/archive")
   @GET
-  void migrations_get_archive_for_authenticated_user(
-      @PathParam("migration_id") Integer migrationId);
+  void migrations_get_archive_for_authenticated_user(@PathParam("migration_id") Integer migrationId);
 
   /**
-   * Deletes a previous migration archive. Downloadable migration archives are automatically deleted after seven days. Migration metadata, which is returned in the [List user migrations](https://developer.github.com/v3/migrations/users/#list-user-migrations) and [Get a user migration status](https://developer.github.com/v3/migrations/users/#get-a-user-migration-status) endpoints, will continue to be available even after an archive is deleted.
+   * <p>
+   * Deletes a previous migration archive. Downloadable migration archives are
+   * automatically deleted after seven days. Migration metadata, which is returned
+   * in the <a href=
+   * "https://developer.github.com/v3/migrations/users/#list-user-migrations">List
+   * user migrations</a> and <a href=
+   * "https://developer.github.com/v3/migrations/users/#get-a-user-migration-status">Get
+   * a user migration status</a> endpoints, will continue to be available even
+   * after an archive is deleted.
+   * </p>
+   * 
    */
   @Path("/migrations/{migration_id}/archive")
   @DELETE
-  void migrations_delete_archive_for_authenticated_user(
-      @PathParam("migration_id") Integer migrationId);
+  void migrations_delete_archive_for_authenticated_user(@PathParam("migration_id") Integer migrationId);
 
   /**
-   *
+   * 
    */
   @Path("/starred/{owner}/{repo}")
   @GET
@@ -168,34 +230,47 @@ public interface UserResource {
       @PathParam("repo") String repo);
 
   /**
-   * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
+   * <p>
+   * Note that you'll need to set <code>Content-Length</code> to zero when calling
+   * out to this endpoint. For more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * 
    */
   @Path("/starred/{owner}/{repo}")
   @PUT
-  void activity_star_repo_for_authenticated_user(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void activity_star_repo_for_authenticated_user(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
-   *
+   * 
    */
   @Path("/starred/{owner}/{repo}")
   @DELETE
-  void activity_unstar_repo_for_authenticated_user(@PathParam("owner") String owner,
-      @PathParam("repo") String repo);
+  void activity_unstar_repo_for_authenticated_user(@PathParam("owner") String owner, @PathParam("repo") String repo);
 
   /**
+   * <p>
    * Lists repositories the authenticated user is watching.
+   * </p>
+   * 
    */
   @Path("/subscriptions")
   @GET
   @Produces("application/json")
-  Response activity_list_watched_repos_for_authenticated_user(
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response activity_list_watched_repos_for_authenticated_user(@QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists repositories the authenticated user has starred.
-   *
-   * You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:
+   * </p>
+   * <p>
+   * You can also find out <em>when</em> stars were created by passing the
+   * following custom <a href="https://developer.github.com/v3/media/">media
+   * type</a> via the <code>Accept</code> header:
+   * </p>
+   * 
    */
   @Path("/starred")
   @GET
@@ -205,7 +280,7 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/projects")
   @POST
@@ -214,7 +289,7 @@ public interface UserResource {
   Response projects_create_for_authenticated_user(InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/memberships/orgs")
   @GET
@@ -223,7 +298,7 @@ public interface UserResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/memberships/orgs/{org}")
   @GET
@@ -231,30 +306,41 @@ public interface UserResource {
   Response orgs_get_membership_for_authenticated_user(@PathParam("org") String org);
 
   /**
-   *
+   * 
    */
   @Path("/memberships/orgs/{org}")
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response orgs_update_membership_for_authenticated_user(@PathParam("org") String org,
-      InputStream data);
+  Response orgs_update_membership_for_authenticated_user(@PathParam("org") String org, InputStream data);
 
   /**
+   * <p>
    * List organizations for the authenticated user.
-   *
-   * **OAuth scope requirements**
-   *
-   * This only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.
+   * </p>
+   * <p>
+   * <strong>OAuth scope requirements</strong>
+   * </p>
+   * <p>
+   * This only lists organizations that your authorization allows you to operate
+   * on in some way (e.g., you can list teams with <code>read:org</code> scope,
+   * you can publicize your organization membership with <code>user</code> scope,
+   * etc.). Therefore, this API requires at least <code>user</code> or
+   * <code>read:org</code> scope. OAuth requests with insufficient scope receive a
+   * <code>403 Forbidden</code> response.
+   * </p>
+   * 
    */
   @Path("/orgs")
   @GET
   @Produces("application/json")
-  Response orgs_list_for_authenticated_user(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response orgs_list_for_authenticated_user(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists the people following the authenticated user.
+   * </p>
+   * 
    */
   @Path("/followers")
   @GET
@@ -263,7 +349,10 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists the people who the authenticated user follows.
+   * </p>
+   * 
    */
   @Path("/following")
   @GET
@@ -272,7 +361,12 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   * Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * Lists the current user's GPG keys. Requires that you are authenticated via
+   * Basic Auth or via OAuth with at least <code>read:gpg_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/gpg_keys")
   @GET
@@ -281,7 +375,13 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   * Adds a GPG key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * Adds a GPG key to the authenticated user's GitHub account. Requires that you
+   * are authenticated via Basic Auth, or OAuth with at least
+   * <code>write:gpg_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/gpg_keys")
   @POST
@@ -290,7 +390,13 @@ public interface UserResource {
   Response users_create_gpg_key_for_authenticated(InputStream data);
 
   /**
-   * View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * View extended details for a single public SSH key. Requires that you are
+   * authenticated via Basic Auth or via OAuth with at least
+   * <code>read:public_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/keys/{key_id}")
   @GET
@@ -298,14 +404,26 @@ public interface UserResource {
   Response users_get_public_ssh_key_for_authenticated(@PathParam("key_id") Integer keyId);
 
   /**
-   * Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * Removes a public SSH key from the authenticated user's GitHub account.
+   * Requires that you are authenticated via Basic Auth or via OAuth with at least
+   * <code>admin:public_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/keys/{key_id}")
   @DELETE
   void users_delete_public_ssh_key_for_authenticated(@PathParam("key_id") Integer keyId);
 
   /**
-   * View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * View extended details for a single GPG key. Requires that you are
+   * authenticated via Basic Auth or via OAuth with at least
+   * <code>read:gpg_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/gpg_keys/{gpg_key_id}")
   @GET
@@ -313,14 +431,24 @@ public interface UserResource {
   Response users_get_gpg_key_for_authenticated(@PathParam("gpg_key_id") Integer gpgKeyId);
 
   /**
-   * Removes a GPG key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * Removes a GPG key from the authenticated user's GitHub account. Requires that
+   * you are authenticated via Basic Auth or via OAuth with at least
+   * <code>admin:gpg_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/gpg_keys/{gpg_key_id}")
   @DELETE
   void users_delete_gpg_key_for_authenticated(@PathParam("gpg_key_id") Integer gpgKeyId);
 
   /**
-   * Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.
+   * <p>
+   * Lists all of your email addresses, and specifies which one is visible to the
+   * public. This endpoint is accessible with the <code>user:email</code> scope.
+   * </p>
+   * 
    */
   @Path("/emails")
   @GET
@@ -329,7 +457,10 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   * This endpoint is accessible with the `user` scope.
+   * <p>
+   * This endpoint is accessible with the <code>user</code> scope.
+   * </p>
+   * 
    */
   @Path("/emails")
   @POST
@@ -338,7 +469,10 @@ public interface UserResource {
   Response users_add_email_for_authenticated(InputStream data);
 
   /**
-   * This endpoint is accessible with the `user` scope.
+   * <p>
+   * This endpoint is accessible with the <code>user</code> scope.
+   * </p>
+   * 
    */
   @Path("/emails")
   @DELETE
@@ -346,53 +480,76 @@ public interface UserResource {
   void users_delete_email_for_authenticated(InputStream data);
 
   /**
-   *
+   * 
    */
   @Path("/following/{username}")
   @GET
   void users_check_person_is_followed_by_authenticated(@PathParam("username") String username);
 
   /**
-   * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://developer.github.com/v3/#http-verbs)."
-   *
-   * Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+   * <p>
+   * Note that you'll need to set <code>Content-Length</code> to zero when calling
+   * out to this endpoint. For more information, see
+   * &quot;<a href="https://developer.github.com/v3/#http-verbs">HTTP
+   * verbs</a>.&quot;
+   * </p>
+   * <p>
+   * Following a user requires the user to be logged in and authenticated with
+   * basic auth or OAuth with the <code>user:follow</code> scope.
+   * </p>
+   * 
    */
   @Path("/following/{username}")
   @PUT
   void users_follow(@PathParam("username") String username);
 
   /**
-   * Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+   * <p>
+   * Unfollowing a user requires the user to be logged in and authenticated with
+   * basic auth or OAuth with the <code>user:follow</code> scope.
+   * </p>
+   * 
    */
   @Path("/following/{username}")
   @DELETE
   void users_unfollow(@PathParam("username") String username);
 
   /**
+   * <p>
    * If the user is blocked:
-   *
+   * </p>
+   * <p>
    * If the user is not blocked:
+   * </p>
+   * 
    */
   @Path("/blocks/{username}")
   @GET
   void users_check_blocked(@PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/blocks/{username}")
   @PUT
   void users_block(@PathParam("username") String username);
 
   /**
-   *
+   * 
    */
   @Path("/blocks/{username}")
   @DELETE
   void users_unblock(@PathParam("username") String username);
 
   /**
-   * Lists your publicly visible email address, which you can set with the [Set primary email visibility for the authenticated user](https://developer.github.com/v3/users/emails/#set-primary-email-visibility-for-the-authenticated-user) endpoint. This endpoint is accessible with the `user:email` scope.
+   * <p>
+   * Lists your publicly visible email address, which you can set with the
+   * <a href=
+   * "https://developer.github.com/v3/users/emails/#set-primary-email-visibility-for-the-authenticated-user">Set
+   * primary email visibility for the authenticated user</a> endpoint. This
+   * endpoint is accessible with the <code>user:email</code> scope.
+   * </p>
+   * 
    */
   @Path("/public_emails")
   @GET
@@ -401,7 +558,10 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * List the users you've blocked on your personal account.
+   * </p>
+   * 
    */
   @Path("/blocks")
   @GET
@@ -409,7 +569,13 @@ public interface UserResource {
   Response users_list_blocked_by_authenticated();
 
   /**
-   * Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * Lists the public SSH keys for the authenticated user's GitHub account.
+   * Requires that you are authenticated via Basic Auth or via OAuth with at least
+   * <code>read:public_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/keys")
   @GET
@@ -418,7 +584,13 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   * Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+   * <p>
+   * Adds a public SSH key to the authenticated user's GitHub account. Requires
+   * that you are authenticated via Basic Auth, or OAuth with at least
+   * <code>write:public_key</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>.
+   * </p>
+   * 
    */
   @Path("/keys")
   @POST
@@ -427,16 +599,30 @@ public interface UserResource {
   Response users_create_public_ssh_key_for_authenticated(InputStream data);
 
   /**
-   * If the authenticated user is authenticated through basic authentication or OAuth with the `user` scope, then the response lists public and private profile information.
-   *
-   * If the authenticated user is authenticated through OAuth without the `user` scope, then the response lists only public profile information.
+   * <p>
+   * If the authenticated user is authenticated through basic authentication or
+   * OAuth with the <code>user</code> scope, then the response lists public and
+   * private profile information.
+   * </p>
+   * <p>
+   * If the authenticated user is authenticated through OAuth without the
+   * <code>user</code> scope, then the response lists only public profile
+   * information.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   Response users_get_authenticated();
 
   /**
-   * **Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.
+   * <p>
+   * <strong>Note:</strong> If your email is set to private and you send an
+   * <code>email</code> parameter as part of this request to update your profile,
+   * your privacy settings are still enforced: the email address will not be
+   * displayed on your public profile or via the API.
+   * </p>
+   * 
    */
   @PATCH
   @Produces("application/json")
@@ -444,7 +630,10 @@ public interface UserResource {
   Response users_update_authenticated(InputStream data);
 
   /**
+   * <p>
    * Sets the visibility for your primary email addresses.
+   * </p>
+   * 
    */
   @Path("/email/visibility")
   @PATCH
@@ -453,39 +642,68 @@ public interface UserResource {
   Response users_set_primary_email_visibility_for_authenticated(InputStream data);
 
   /**
-   * List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://developer.github.com/apps/building-oauth-apps/).
+   * <p>
+   * List all of the teams across all of the organizations to which the
+   * authenticated user belongs. This method requires <code>user</code>,
+   * <code>repo</code>, or <code>read:org</code> <a href=
+   * "https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/">scope</a>
+   * when authenticating via
+   * <a href="https://developer.github.com/apps/building-oauth-apps/">OAuth</a>.
+   * </p>
+   * 
    */
   @Path("/teams")
   @GET
   @Produces("application/json")
-  Response teams_list_for_authenticated_user(@QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response teams_list_for_authenticated_user(@QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * List issues across owned and member repositories assigned to the authenticated user.
-   *
-   * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
-   * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
-   * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
-   * request id, use the "[List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)" endpoint.
+   * <p>
+   * List issues across owned and member repositories assigned to the
+   * authenticated user.
+   * </p>
+   * <p>
+   * <strong>Note</strong>: GitHub's REST API v3 considers every pull request an
+   * issue, but not every issue is a pull request. For this reason,
+   * &quot;Issues&quot; endpoints may return both issues and pull requests in the
+   * response. You can identify pull requests by the <code>pull_request</code>
+   * key. Be aware that the <code>id</code> of a pull request returned from
+   * &quot;Issues&quot; endpoints will be an <em>issue id</em>. To find out the
+   * pull request id, use the &quot;<a href=
+   * "https://developer.github.com/v3/pulls/#list-pull-requests">List pull
+   * requests</a>&quot; endpoint.
+   * </p>
+   * 
    */
   @Path("/issues")
   @GET
   @Produces("application/json")
-  Response issues_list_for_authenticated_user(@QueryParam("filter") String filter,
-      @QueryParam("state") String state, @QueryParam("labels") String labels,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response issues_list_for_authenticated_user(@QueryParam("filter") String filter, @QueryParam("state") String state,
+      @QueryParam("labels") String labels, @QueryParam("sort") String sort, @QueryParam("direction") String direction,
+      @QueryParam("since") String since, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
-   *
-   * You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
-   *
-   * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
-   *
-   * You can find the permissions for the installation under the `permissions` key.
+   * <p>
+   * Lists installations of your GitHub App that the authenticated user has
+   * explicit permission (<code>:read</code>, <code>:write</code>, or
+   * <code>:admin</code>) to access.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site">user-to-server
+   * OAuth access token</a>, created for a user who has authorized your GitHub
+   * App, to access this endpoint.
+   * </p>
+   * <p>
+   * The authenticated user has explicit permission to access repositories they
+   * own, repositories where they are a collaborator, and repositories that they
+   * can access through an organization membership.
+   * </p>
+   * <p>
+   * You can find the permissions for the installation under the
+   * <code>permissions</code> key.
+   * </p>
+   * 
    */
   @Path("/installations")
   @GET
@@ -494,23 +712,46 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
-   *
-   * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
-   *
-   * You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
-   *
-   * The access the user has to each repository is included in the hash under the `permissions` key.
+   * <p>
+   * List repositories that the authenticated user has explicit permission
+   * (<code>:read</code>, <code>:write</code>, or <code>:admin</code>) to access
+   * for an installation.
+   * </p>
+   * <p>
+   * The authenticated user has explicit permission to access repositories they
+   * own, repositories where they are a collaborator, and repositories that they
+   * can access through an organization membership.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site">user-to-server
+   * OAuth access token</a>, created for a user who has authorized your GitHub
+   * App, to access this endpoint.
+   * </p>
+   * <p>
+   * The access the user has to each repository is included in the hash under the
+   * <code>permissions</code> key.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}/repositories")
   @GET
   @Produces("application/json")
-  Response apps_list_installation_repos_for_authenticated_user(
-      @PathParam("installation_id") Integer installationId, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response apps_list_installation_repos_for_authenticated_user(@PathParam("installation_id") Integer installationId,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Lists the active subscriptions for the authenticated user. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).
+   * <p>
+   * Lists the active subscriptions for the authenticated user. You must use a
+   * <a href=
+   * "https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site">user-to-server
+   * OAuth access token</a>, created for a user who has authorized your GitHub
+   * App, to access this endpoint. . OAuth Apps must authenticate using an
+   * <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/">OAuth
+   * token</a>.
+   * </p>
+   * 
    */
   @Path("/marketplace_purchases")
   @GET
@@ -519,9 +760,20 @@ public interface UserResource {
       @QueryParam("page") Integer page);
 
   /**
-   * Add a single repository to an installation. The authenticated user must have admin access to the repository.
-   *
-   * You must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](https://developer.github.com/v3/auth/#basic-authentication) to access this endpoint.
+   * <p>
+   * Add a single repository to an installation. The authenticated user must have
+   * admin access to the repository.
+   * </p>
+   * <p>
+   * You must use a personal access token (which you can create via the <a href=
+   * "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/">command
+   * line</a> or the <a href=
+   * "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">OAuth
+   * Authorizations API</a>) or
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">Basic
+   * Authentication</a> to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}/repositories/{repository_id}")
   @PUT
@@ -529,9 +781,20 @@ public interface UserResource {
       @PathParam("repository_id") Integer repositoryId);
 
   /**
-   * Remove a single repository from an installation. The authenticated user must have admin access to the repository.
-   *
-   * You must use a personal access token (which you can create via the [command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or the [OAuth Authorizations API](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization)) or [Basic Authentication](https://developer.github.com/v3/auth/#basic-authentication) to access this endpoint.
+   * <p>
+   * Remove a single repository from an installation. The authenticated user must
+   * have admin access to the repository.
+   * </p>
+   * <p>
+   * You must use a personal access token (which you can create via the <a href=
+   * "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/">command
+   * line</a> or the <a href=
+   * "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization">OAuth
+   * Authorizations API</a>) or
+   * <a href="https://developer.github.com/v3/auth/#basic-authentication">Basic
+   * Authentication</a> to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/installations/{installation_id}/repositories/{repository_id}")
   @DELETE
@@ -539,11 +802,21 @@ public interface UserResource {
       @PathParam("repository_id") Integer repositoryId);
 
   /**
-   * Lists the active subscriptions for the authenticated user. You must use a [user-to-server OAuth access token](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint. . OAuth Apps must authenticate using an [OAuth token](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/).
+   * <p>
+   * Lists the active subscriptions for the authenticated user. You must use a
+   * <a href=
+   * "https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site">user-to-server
+   * OAuth access token</a>, created for a user who has authorized your GitHub
+   * App, to access this endpoint. . OAuth Apps must authenticate using an
+   * <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/">OAuth
+   * token</a>.
+   * </p>
+   * 
    */
   @Path("/marketplace_purchases/stubbed")
   @GET
   @Produces("application/json")
-  Response apps_list_subscriptions_for_authenticated_user_stubbed(
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response apps_list_subscriptions_for_authenticated_user_stubbed(@QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 }

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/UsersResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/UsersResource.java
@@ -8,23 +8,25 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/users")
 public interface UsersResource {
   /**
+   * <p>
    * Lists public repositories for the specified user.
+   * </p>
+   * 
    */
   @Path("/{username}/repos")
   @GET
   @Produces("application/json")
-  Response repos_list_for_user(@PathParam("username") String username,
-      @QueryParam("type") String type, @QueryParam("sort") String sort,
-      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response repos_list_for_user(@PathParam("username") String username, @QueryParam("type") String type,
+      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{username}/events/public")
   @GET
@@ -33,17 +35,25 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * This is the user's organization dashboard. You must be authenticated as the user to view this.
+   * <p>
+   * This is the user's organization dashboard. You must be authenticated as the
+   * user to view this.
+   * </p>
+   * 
    */
   @Path("/{username}/events/orgs/{org}")
   @GET
   @Produces("application/json")
   Response activity_list_org_events_for_authenticated_user(@PathParam("username") String username,
-      @PathParam("org") String org, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+      @PathParam("org") String org, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.
+   * <p>
+   * These are events that you've received by watching repos and following users.
+   * If you are authenticated as the given user, you will see private events.
+   * Otherwise, you'll only see public events.
+   * </p>
+   * 
    */
   @Path("/{username}/received_events")
   @GET
@@ -52,19 +62,28 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists repositories a user has starred.
-   *
-   * You can also find out _when_ stars were created by passing the following custom [media type](https://developer.github.com/v3/media/) via the `Accept` header:
+   * </p>
+   * <p>
+   * You can also find out <em>when</em> stars were created by passing the
+   * following custom <a href="https://developer.github.com/v3/media/">media
+   * type</a> via the <code>Accept</code> header:
+   * </p>
+   * 
    */
   @Path("/{username}/starred")
   @GET
   @Produces({"application/json", "application/vnd.github.v3.star+json"})
-  Response activity_list_repos_starred_by_user(@PathParam("username") String username,
-      @QueryParam("sort") String sort, @QueryParam("direction") String direction,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response activity_list_repos_starred_by_user(@PathParam("username") String username, @QueryParam("sort") String sort,
+      @QueryParam("direction") String direction, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists repositories a user is watching.
+   * </p>
+   * 
    */
   @Path("/{username}/subscriptions")
   @GET
@@ -73,7 +92,11 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+   * <p>
+   * If you are authenticated as the given user, you will see your private events.
+   * Otherwise, you'll only see public events.
+   * </p>
+   * 
    */
   @Path("/{username}/events")
   @GET
@@ -82,7 +105,7 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{username}/received_events/public")
   @GET
@@ -91,28 +114,40 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{username}/projects")
   @GET
   @Produces("application/json")
-  Response projects_list_for_user(@PathParam("username") String username,
-      @QueryParam("state") String state, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response projects_list_for_user(@PathParam("username") String username, @QueryParam("state") String state,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.
-   *
-   * This method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List organizations for the authenticated user](https://developer.github.com/v3/orgs/#list-organizations-for-the-authenticated-user) API instead.
+   * <p>
+   * List <a href=
+   * "https://help.github.com/articles/publicizing-or-concealing-organization-membership">public
+   * organization memberships</a> for the specified user.
+   * </p>
+   * <p>
+   * This method only lists <em>public</em> memberships, regardless of
+   * authentication. If you need to fetch all of the organization memberships
+   * (public and private) for the authenticated user, use the <a href=
+   * "https://developer.github.com/v3/orgs/#list-organizations-for-the-authenticated-user">List
+   * organizations for the authenticated user</a> API instead.
+   * </p>
+   * 
    */
   @Path("/{username}/orgs")
   @GET
   @Produces("application/json")
-  Response orgs_list_for_user(@PathParam("username") String username,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response orgs_list_for_user(@PathParam("username") String username, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists the people who the specified user follows.
+   * </p>
+   * 
    */
   @Path("/{username}/following")
   @GET
@@ -121,13 +156,37 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Provides publicly available information about someone with a GitHub account.
-   *
-   * GitHub Apps with the `Plan` user permission can use this endpoint to retrieve information about a user's GitHub plan. The GitHub App must be authenticated as a user. See "[Identifying and authorizing users for GitHub Apps](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)" for details about authentication. For an example response, see "[Response with GitHub plan information](https://developer.github.com/v3/users/#response-with-github-plan-information)."
-   *
-   * The `email` key in the following response is the publicly visible email address from your GitHub [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub. For more information, see [Authentication](https://developer.github.com/v3/#authentication).
-   *
-   * The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "[Emails API](https://developer.github.com/v3/users/emails/)".
+   * </p>
+   * <p>
+   * GitHub Apps with the <code>Plan</code> user permission can use this endpoint
+   * to retrieve information about a user's GitHub plan. The GitHub App must be
+   * authenticated as a user. See &quot;<a href=
+   * "https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/">Identifying
+   * and authorizing users for GitHub Apps</a>&quot; for details about
+   * authentication. For an example response, see &quot;<a href=
+   * "https://developer.github.com/v3/users/#response-with-github-plan-information">Response
+   * with GitHub plan information</a>.&quot;
+   * </p>
+   * <p>
+   * The <code>email</code> key in the following response is the publicly visible
+   * email address from your GitHub
+   * <a href="https://github.com/settings/profile">profile page</a>. When setting
+   * up your profile, you can select a primary email address to be “public” which
+   * provides an email entry for this endpoint. If you do not set a public email
+   * address for <code>email</code>, then it will have a value of
+   * <code>null</code>. You only see publicly visible email addresses when
+   * authenticated with GitHub. For more information, see
+   * <a href="https://developer.github.com/v3/#authentication">Authentication</a>.
+   * </p>
+   * <p>
+   * The Emails API enables you to list all of your email addresses, and toggle a
+   * primary email to be visible publicly. For more information, see
+   * &quot;<a href="https://developer.github.com/v3/users/emails/">Emails
+   * API</a>&quot;.
+   * </p>
+   * 
    */
   @Path("/{username}")
   @GET
@@ -135,16 +194,19 @@ public interface UsersResource {
   Response users_get_by_username(@PathParam("username") String username);
 
   /**
+   * <p>
    * Lists the GPG keys for a user. This information is accessible by anyone.
+   * </p>
+   * 
    */
   @Path("/{username}/gpg_keys")
   @GET
   @Produces("application/json")
-  Response users_list_gpg_keys_for_user(@PathParam("username") String username,
-      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
+  Response users_list_gpg_keys_for_user(@PathParam("username") String username, @QueryParam("per_page") Integer perPage,
+      @QueryParam("page") Integer page);
 
   /**
-   *
+   * 
    */
   @Path("/{username}/following/{target_user}")
   @GET
@@ -152,23 +214,41 @@ public interface UsersResource {
       @PathParam("target_user") String targetUser);
 
   /**
-   * Lists all users, in the order that they signed up on GitHub. This list includes personal user accounts and organization accounts.
-   *
-   * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://developer.github.com/v3/#link-header) to get the URL for the next page of users.
+   * <p>
+   * Lists all users, in the order that they signed up on GitHub. This list
+   * includes personal user accounts and organization accounts.
+   * </p>
+   * <p>
+   * Note: Pagination is powered exclusively by the <code>since</code> parameter.
+   * Use the <a href="https://developer.github.com/v3/#link-header">Link
+   * header</a> to get the URL for the next page of users.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   Response users_list(@QueryParam("since") String since, @QueryParam("per_page") Integer perPage);
 
   /**
-   * Provides hovercard information when authenticated through basic auth or OAuth with the `repo` scope. You can find out more about someone in relation to their pull requests, issues, repositories, and organizations.
-   *
-   * The `subject_type` and `subject_id` parameters provide context for the person's hovercard, which returns more information than without the parameters. For example, if you wanted to find out more about `octocat` who owns the `Spoon-Knife` repository via cURL, it would look like this:
-   *
-   * ```shell
-   *  curl -u username:token
-   *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
-   * ```
+   * <p>
+   * Provides hovercard information when authenticated through basic auth or OAuth
+   * with the <code>repo</code> scope. You can find out more about someone in
+   * relation to their pull requests, issues, repositories, and organizations.
+   * </p>
+   * <p>
+   * The <code>subject_type</code> and <code>subject_id</code> parameters provide
+   * context for the person's hovercard, which returns more information than
+   * without the parameters. For example, if you wanted to find out more about
+   * <code>octocat</code> who owns the <code>Spoon-Knife</code> repository via
+   * cURL, it would look like this:
+   * </p>
+   * 
+   * <pre>
+   * <code class="language-shell"> curl -u username:token
+    https://api.github.com/users/octocat/hovercard?subject_type=repository&amp;subject_id=1300192
+  </code>
+   * </pre>
+   * 
    */
   @Path("/{username}/hovercard")
   @GET
@@ -177,7 +257,11 @@ public interface UsersResource {
       @QueryParam("subject_type") String subjectType, @QueryParam("subject_id") String subjectId);
 
   /**
-   * Lists the _verified_ public SSH keys for a user. This is accessible by anyone.
+   * <p>
+   * Lists the <em>verified</em> public SSH keys for a user. This is accessible by
+   * anyone.
+   * </p>
+   * 
    */
   @Path("/{username}/keys")
   @GET
@@ -186,7 +270,10 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
+   * <p>
    * Lists the people following the specified user.
+   * </p>
+   * 
    */
   @Path("/{username}/followers")
   @GET
@@ -195,9 +282,16 @@ public interface UsersResource {
       @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * Enables an authenticated GitHub App to find the user’s installation information.
-   *
-   * You must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+   * <p>
+   * Enables an authenticated GitHub App to find the user’s installation
+   * information.
+   * </p>
+   * <p>
+   * You must use a <a href=
+   * "https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">JWT</a>
+   * to access this endpoint.
+   * </p>
+   * 
    */
   @Path("/{username}/installation")
   @GET
@@ -205,23 +299,36 @@ public interface UsersResource {
   Response apps_get_user_installation(@PathParam("username") String username);
 
   /**
+   * <p>
    * Lists public gists for the specified user:
+   * </p>
+   * 
    */
   @Path("/{username}/gists")
   @GET
   @Produces("application/json")
-  Response gists_list_for_user(@PathParam("username") String username,
-      @QueryParam("since") String since, @QueryParam("per_page") Integer perPage,
-      @QueryParam("page") Integer page);
+  Response gists_list_for_user(@PathParam("username") String username, @QueryParam("since") String since,
+      @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
-   * Gets the estimated paid and estimated total storage used for GitHub Actions and Github Packages.
-   *
-   * Paid minutes only apply to packages stored for private repositories. For more information, see "[Managing billing for GitHub Packages](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages)."
-   *
-   * Access tokens must have the `user` scope.
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
+   * Gets the estimated paid and estimated total storage used for GitHub Actions
+   * and Github Packages.
+   * </p>
+   * <p>
+   * Paid minutes only apply to packages stored for private repositories. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages">Managing
+   * billing for GitHub Packages</a>.&quot;
+   * </p>
+   * <p>
+   * Access tokens must have the <code>user</code> scope.
+   * </p>
+   * 
    */
   @Path("/{username}/settings/billing/shared-storage")
   @GET
@@ -229,13 +336,23 @@ public interface UsersResource {
   Response billing_get_shared_storage_billing_user(@PathParam("username") String username);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
    * Gets the free and paid storage used for GitHub Packages in gigabytes.
-   *
-   * Paid minutes only apply to packages stored for private repositories. For more information, see "[Managing billing for GitHub Packages](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages)."
-   *
-   * Access tokens must have the `user` scope.
+   * </p>
+   * <p>
+   * Paid minutes only apply to packages stored for private repositories. For more
+   * information, see &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-packages">Managing
+   * billing for GitHub Packages</a>.&quot;
+   * </p>
+   * <p>
+   * Access tokens must have the <code>user</code> scope.
+   * </p>
+   * 
    */
   @Path("/{username}/settings/billing/packages")
   @GET
@@ -243,13 +360,27 @@ public interface UsersResource {
   Response billing_get_github_packages_billing_user(@PathParam("username") String username);
 
   /**
-   * **Warning:** The Billing API is currently in public beta and subject to change.
-   *
+   * <p>
+   * <strong>Warning:</strong> The Billing API is currently in public beta and
+   * subject to change.
+   * </p>
+   * <p>
    * Gets the summary of the free and paid GitHub Actions minutes used.
-   *
-   * Paid minutes only apply to workflows in private repositories that use GitHub-hosted runners. Minutes used is listed for each GitHub-hosted runner operating system. Any job re-runs are also included in the usage. The usage does not include the multiplier for macOS and Windows runners and is not rounded up to the nearest whole minute. For more information, see "[Managing billing for GitHub Actions](https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions)".
-   *
-   * Access tokens must have the `user` scope.
+   * </p>
+   * <p>
+   * Paid minutes only apply to workflows in private repositories that use
+   * GitHub-hosted runners. Minutes used is listed for each GitHub-hosted runner
+   * operating system. Any job re-runs are also included in the usage. The usage
+   * does not include the multiplier for macOS and Windows runners and is not
+   * rounded up to the nearest whole minute. For more information, see
+   * &quot;<a href=
+   * "https://help.github.com/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions">Managing
+   * billing for GitHub Actions</a>&quot;.
+   * </p>
+   * <p>
+   * Access tokens must have the <code>user</code> scope.
+   * </p>
+   * 
    */
   @Path("/{username}/settings/billing/actions")
   @GET

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ZenResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/ZenResource.java
@@ -5,12 +5,15 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/zen")
 public interface ZenResource {
   /**
+   * <p>
    * Get a random sentence from the Zen of GitHub
+   * </p>
+   * 
    */
   @GET
   @Produces("text/plain")

--- a/core/src/test/resources/OpenApi2ThorntailTest/_expected-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2ThorntailTest/_expected-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -12,12 +12,15 @@ import javax.ws.rs.Produces;
 import org.example.api.beans.Beer;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/beers")
 public interface BeersResource {
   /**
+   * <p>
    * Returns full information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @GET
@@ -25,7 +28,10 @@ public interface BeersResource {
   Beer getBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Updates information about a single beer.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @PUT
@@ -33,21 +39,30 @@ public interface BeersResource {
   void updateBeer(@PathParam("beerId") int beerId, Beer data);
 
   /**
+   * <p>
    * Removes a single beer from the data set.
+   * </p>
+   * 
    */
   @Path("/{beerId}")
   @DELETE
   void deleteBeer(@PathParam("beerId") int beerId);
 
   /**
+   * <p>
    * Returns all of the beers in the database.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Beer> listAllBeers();
 
   /**
+   * <p>
    * Adds a single beer to the dataset.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")

--- a/core/src/test/resources/OpenApi2ThorntailTest/_expected-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2ThorntailTest/_expected-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -13,26 +13,35 @@ import org.example.api.beans.Beer;
 import org.example.api.beans.Brewery;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/breweries")
 public interface BreweriesResource {
   /**
+   * <p>
    * Returns a list of all the breweries.
+   * </p>
+   * 
    */
   @GET
   @Produces("application/json")
   List<Brewery> listAllBreweries();
 
   /**
+   * <p>
    * Adds a single brewery to the data set.
+   * </p>
+   * 
    */
   @POST
   @Consumes("application/json")
   void addBrewery(Brewery data);
 
   /**
+   * <p>
    * Returns full information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @GET
@@ -40,7 +49,10 @@ public interface BreweriesResource {
   Brewery getBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Updates information about a single brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @PUT
@@ -48,14 +60,20 @@ public interface BreweriesResource {
   void updateBrewery(@PathParam("breweryId") int breweryId, Brewery data);
 
   /**
+   * <p>
    * Removes a single brewery from the data set.
+   * </p>
+   * 
    */
   @Path("/{breweryId}")
   @DELETE
   void deleteBrewery(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Returns all of the beers made by the brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @GET
@@ -63,7 +81,10 @@ public interface BreweriesResource {
   List<Beer> listBreweryBeers(@PathParam("breweryId") int breweryId);
 
   /**
+   * <p>
    * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
    */
   @Path("/{breweryId}/beers")
   @POST

--- a/core/src/test/resources/OpenApi2ThorntailTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ApisResource.java
+++ b/core/src/test/resources/OpenApi2ThorntailTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ApisResource.java
@@ -5,12 +5,15 @@ import javax.ws.rs.Path;
 import org.example.api.beans.API;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/apis")
 public interface ApisResource {
   /**
+   * <p>
    * Publish an API and make it immediately available on the gateway.
+   * </p>
+   * 
    */
   @PUT
   void publishAnAPI(API body);

--- a/core/src/test/resources/OpenApi2ThorntailTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ClientsResource.java
+++ b/core/src/test/resources/OpenApi2ThorntailTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/ClientsResource.java
@@ -5,12 +5,15 @@ import javax.ws.rs.Path;
 import org.example.api.beans.Client;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/clients")
 public interface ClientsResource {
   /**
+   * <p>
    * Register a Client and make it immediately available on the gateway.
+   * </p>
+   * 
    */
   @PUT
   void registerAClient(Client body);

--- a/core/src/test/resources/OpenApi2ThorntailTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/SystemResource.java
+++ b/core/src/test/resources/OpenApi2ThorntailTest/_expected-gatewayApi-full/generated-api/src/main/java/org/example/api/SystemResource.java
@@ -5,12 +5,18 @@ import javax.ws.rs.Path;
 import org.example.api.beans.SystemStatus;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/system")
 public interface SystemResource {
   /**
-   * Get current gateway status. Useful for determining whether a given gateway is responding correctly (routing, finished booting, error, etc) and verifying that provided auth credentials are correct, and/or the auth server is reachable (if applicable).
+   * <p>
+   * Get current gateway status. Useful for determining whether a given gateway is
+   * responding correctly (routing, finished booting, error, etc) and verifying
+   * that provided auth credentials are correct, and/or the auth server is
+   * reachable (if applicable).
+   * </p>
+   * 
    */
   @Path("/status")
   @GET

--- a/core/src/test/resources/OpenApi2ThorntailTest/_expected-rda/src/main/java/org/example/api/V1Resource.java
+++ b/core/src/test/resources/OpenApi2ThorntailTest/_expected-rda/src/main/java/org/example/api/V1Resource.java
@@ -12,7 +12,7 @@ import javax.ws.rs.QueryParam;
 import org.example.api.beans.TemplateMetadata;
 
 /**
- * A JAX-RS interface.  An implementation of this interface must be provided.
+ * A JAX-RS interface. An implementation of this interface must be provided.
  */
 @Path("/v1")
 public interface V1Resource {
@@ -22,7 +22,10 @@ public interface V1Resource {
   List<TemplateMetadata> generatedMethod1();
 
   /**
+   * <p>
    * Publish a new metadata document for a template
+   * </p>
+   * 
    */
   @Path("templates/metadata")
   @POST
@@ -30,17 +33,22 @@ public interface V1Resource {
   void generatedMethod2(TemplateMetadata data);
 
   /**
+   * <p>
    * Search template metadata and return a list of matching template metadata
+   * </p>
+   * 
    */
   @Path("templates/metadata/search")
   @GET
   @Produces("application/json")
   List<TemplateMetadata> thisIsTheSearchEndpointUseAGETRequestAlongWithParametersToSearchForMetadataOnTemplates(
-      @QueryParam("tag") String tag, @QueryParam("free-text") String freeText,
-      @QueryParam("author") String author);
+      @QueryParam("tag") String tag, @QueryParam("free-text") String freeText, @QueryParam("author") String author);
 
   /**
+   * <p>
    * Get the metadata for a single template by id
+   * </p>
+   * 
    */
   @Path("templates/metadata/{id}")
   @GET
@@ -48,7 +56,10 @@ public interface V1Resource {
   TemplateMetadata generatedMethod3();
 
   /**
+   * <p>
    * Update the metadata for a single template by id
+   * </p>
+   * 
    */
   @Path("templates/metadata/{id}")
   @PUT
@@ -56,7 +67,10 @@ public interface V1Resource {
   void generatedMethod4(TemplateMetadata data);
 
   /**
+   * <p>
    * Delete the metadata for a single template by id
+   * </p>
+   * 
    */
   @Path("templates/metadata/{id}")
   @DELETE

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 
         <!-- Plugin versions -->
         <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
+        <version.maven-surefire-plugin>3.0.0</version.maven-surefire-plugin>
         <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
         <version.maven-javadoc-plugin>3.5.0</version.maven-javadoc-plugin>
         <version.maven-source-plugin>3.2.1</version.maven-source-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,12 @@
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.commons-codec>1.15</version.commons-codec>
         <version.commons-io>2.11.0</version.commons-io>
-        <version.org.apache.commons.commons-pool2>2.11.1
-        </version.org.apache.commons.commons-pool2>
+        <version.org.apache.commons.commons-pool2>2.11.1</version.org.apache.commons.commons-pool2>
         <version.com.fasterxml.jackson>2.15.0</version.com.fasterxml.jackson>
         <version.org.json>20230227</version.org.json>
         <!-- TODO: re-upgrade to 1.1.2 after fixing Quarkus CLI build -->
         <version.org.jsonschema2pojo>1.2.1</version.org.jsonschema2pojo>
-        <version.com.squareup.javapoet>1.13.0</version.com.squareup.javapoet>
+        <version.roaster>2.28.0.Final</version.roaster>
         <version.com.sun.codemodel>2.6</version.com.sun.codemodel>
 
         <!-- Plugin versions -->


### PR DESCRIPTION
Migrate from javapoet to Roaster for JAX-RS interface generation. Also includes functionality to parse OpenAPI operation descriptions as Markdown and render in JavaDocs as HTML to preserve formatting information.