### PR TITLE
Upgraded codegen to work against OpenAPI 3.1

### DIFF
--- a/core/src/main/java/io/apicurio/hub/api/codegen/OpenApi2JaxRs.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/OpenApi2JaxRs.java
@@ -78,7 +78,6 @@ import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.ModelType;
 import io.apicurio.datamodels.models.openapi.OpenApiDocument;
-import io.apicurio.datamodels.util.ModelTypeUtil;
 import io.apicurio.hub.api.codegen.beans.CodegenBeanAnnotationDirective;
 import io.apicurio.hub.api.codegen.beans.CodegenInfo;
 import io.apicurio.hub.api.codegen.beans.CodegenJavaBean;
@@ -327,10 +326,8 @@ public class OpenApi2JaxRs {
     protected CodegenInfo getInfoFromApiDoc() throws IOException {
         document = Library.readDocumentFromJSONString(openApiDoc);
 
-        // If the document is OpenAPI 2.0, upgrade/transform it to 3.0
-        if (ModelTypeUtil.isOpenApi2Model(document)) {
-            document = Library.transformDocument(document, ModelType.OPENAPI30);
-        }
+        // If the document is OpenAPI 2.0 or 3.0, upgrade/transform it to 3.1
+        document = Library.transformDocument(document, ModelType.OPENAPI31);
 
         // Pre-process the document
         document = preProcess(document);

--- a/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/InterfacesVisitor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/InterfacesVisitor.java
@@ -29,7 +29,7 @@ import io.apicurio.datamodels.util.NodeUtil;
  * Visitor used to organize all of the paths into a set of interface names.
  * @author eric.wittmann@gmail.com
  */
-public class InterfacesVisitor extends TraversingOpenApi30VisitorAdapter {
+public class InterfacesVisitor extends TraversingOpenApi31VisitorAdapter {
 
     private Map<String, InterfaceInfo> interfaces = new HashMap<>();
 

--- a/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/OpenApi2CodegenVisitor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/OpenApi2CodegenVisitor.java
@@ -47,10 +47,10 @@ import io.apicurio.datamodels.models.openapi.OpenApiPathItem;
 import io.apicurio.datamodels.models.openapi.OpenApiRequestBody;
 import io.apicurio.datamodels.models.openapi.OpenApiResponse;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30MediaType;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Response;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31MediaType;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Response;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.util.NodeUtil;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
 import io.apicurio.hub.api.codegen.beans.CodegenBeanAnnotationDirective;
@@ -67,7 +67,7 @@ import io.apicurio.hub.api.codegen.util.SchemaSigner;
  * Visitor used to create a Codegen Info object from a OpenAPI document.
  * @author eric.wittmann@gmail.com
  */
-public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApi2CodegenVisitor extends TraversingOpenApi31VisitorAdapter {
 
     private ObjectMapper mapper = new ObjectMapper();
 
@@ -116,14 +116,14 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
      * are the same.
      * @param node
      */
-    private static String createSignature(OpenApi30Schema node) {
+    private static String createSignature(OpenApi31Schema node) {
         SchemaSigner signer = new SchemaSigner();
         Library.visitNode(node, signer);
         return signer.getSignature();
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitDocument(io.apicurio.datamodels.core.models.Document)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitDocument(io.apicurio.datamodels.models.Document)
      */
     @Override
     public void visitDocument(Document node) {
@@ -139,7 +139,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitInfo(io.apicurio.datamodels.core.models.common.Info)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitInfo(io.apicurio.datamodels.models.Info)
      */
     @Override
     public void visitInfo(Info node) {
@@ -151,7 +151,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitPathItem(io.apicurio.datamodels.openapi.models.OpenApiPathItem)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitPathItem(io.apicurio.datamodels.models.openapi.OpenApiPathItem)
      */
     @Override
     public void visitPathItem(OpenApiPathItem node) {
@@ -161,7 +161,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitOperation(io.apicurio.datamodels.core.models.common.Operation)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitOperation(io.apicurio.datamodels.models.Operation)
      */
     @Override
     public void visitOperation(Operation node) {
@@ -198,7 +198,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitParameter(io.apicurio.datamodels.models.Parameter)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitParameter(io.apicurio.datamodels.models.Parameter)
      */
     @Override
     public void visitParameter(Parameter node) {
@@ -212,7 +212,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
             return;
         }
 
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
+        OpenApi31Parameter param = (OpenApi31Parameter) node;
 
         CodegenJavaArgument cgArgument = new CodegenJavaArgument();
         cgArgument.setName(param.getName());
@@ -226,30 +226,30 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
 
         this._currentMethods.forEach(method -> method.getArguments().add(cgArgument));
 
-        Map<String,OpenApi30MediaType> content = param.getContent();
+        Map<String,OpenApi31MediaType> content = param.getContent();
         if (content != null && !content.isEmpty()) {
-            Collection<OpenApi30MediaType> mediaTypes = content.values();
-            OpenApi30MediaType mediaType = mediaTypes.iterator().next();
-            CodegenJavaReturn cgReturn = this.returnFromSchema((OpenApi30Schema) mediaType.getSchema());
+            Collection<OpenApi31MediaType> mediaTypes = content.values();
+            OpenApi31MediaType mediaType = mediaTypes.iterator().next();
+            CodegenJavaReturn cgReturn = this.returnFromSchema((OpenApi31Schema) mediaType.getSchema());
             if (cgReturn != null) {
                 if (cgReturn.getCollection() != null) { this._currentArgument.setCollection(cgReturn.getCollection()); }
                 if (cgReturn.getType() != null) { this._currentArgument.setType(cgReturn.getType()); }
                 if (cgReturn.getFormat() != null) { this._currentArgument.setFormat(cgReturn.getFormat()); }
-                this._currentArgument.setTypeSignature(createSignature((OpenApi30Schema) mediaType.getSchema()));
+                this._currentArgument.setTypeSignature(createSignature((OpenApi31Schema) mediaType.getSchema()));
             }
         } else if (node.getSchema() != null) {
-            CodegenJavaReturn cgReturn = this.returnFromSchema((OpenApi30Schema) node.getSchema());
+            CodegenJavaReturn cgReturn = this.returnFromSchema((OpenApi31Schema) node.getSchema());
             if (cgReturn != null) {
                 if (cgReturn.getCollection() != null) { this._currentArgument.setCollection(cgReturn.getCollection()); }
                 if (cgReturn.getType() != null) { this._currentArgument.setType(cgReturn.getType()); }
                 if (cgReturn.getFormat() != null) { this._currentArgument.setFormat(cgReturn.getFormat()); }
-                this._currentArgument.setTypeSignature(createSignature((OpenApi30Schema) node.getSchema()));
+                this._currentArgument.setTypeSignature(createSignature((OpenApi31Schema) node.getSchema()));
             }
         }
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitRequestBody(io.apicurio.datamodels.models.openapi.OpenApiRequestBody)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitRequestBody(io.apicurio.datamodels.models.openapi.OpenApiRequestBody)
      */
     @Override
     public void visitRequestBody(OpenApiRequestBody node) {
@@ -268,7 +268,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
             content.entrySet().forEach(entry -> {
                 String name = entry.getKey();
                 OpenApiMediaType mediaType = entry.getValue();
-                CodegenJavaReturn cgReturn = this.returnFromSchema((OpenApi30Schema) mediaType.getSchema());
+                CodegenJavaReturn cgReturn = this.returnFromSchema((OpenApi31Schema) mediaType.getSchema());
                 if (cgReturn == null) {
                     cgReturn = new CodegenJavaReturn();
                 }
@@ -313,7 +313,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
     }
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitResponse(io.apicurio.datamodels.openapi.models.OpenApiResponse)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitResponse(io.apicurio.datamodels.models.openapi.OpenApiResponse)
      */
     @Override
     public void visitResponse(OpenApiResponse node) {
@@ -326,16 +326,16 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
         // Note: if there are multiple 2xx responses, only the first one will
         // become the method return value.
         if (statusCode != null && statusCode.indexOf("2") == 0 && this._currentMethods.get(0).getReturn() == null) {
-            OpenApi30Response response = (OpenApi30Response) node;
-            Map<String, OpenApi30MediaType> content = response.getContent();
+            OpenApi31Response response = (OpenApi31Response) node;
+            Map<String, OpenApi31MediaType> content = response.getContent();
             if (content == null) {
                 content = new HashMap<>();
             }
 
             // TODO if there are multiple response media types, handle it somehow - probably by returning a JAX-RS Response object
             if (!content.isEmpty()) {
-                Entry<String, OpenApi30MediaType> firstContent = content.entrySet().iterator().next();
-                OpenApi30MediaType mediaType = firstContent.getValue();
+                Entry<String, OpenApi31MediaType> firstContent = content.entrySet().iterator().next();
+                OpenApi31MediaType mediaType = firstContent.getValue();
 
                 JsonNode returnTypeExt = CodegenUtil.getExtension(mediaType, CodegenExtensions.RETURN_TYPE);
                 CodegenJavaReturn cgReturn = null;
@@ -345,7 +345,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
                     customReturn.setType(returnType);
                     cgReturn = customReturn;
                 } else {
-                    cgReturn = this.returnFromSchema((OpenApi30Schema) mediaType.getSchema());
+                    cgReturn = this.returnFromSchema((OpenApi31Schema) mediaType.getSchema());
                 }
 
                 // If no return was created, it was because we couldn't figure it out from the
@@ -367,6 +367,9 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
         }
     }
 
+    /**
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
+     */
     @Override
     public void visitSchema(Schema node) {
         if (NodeUtil.isDefinition(node)) {
@@ -377,7 +380,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
             bean.setName(name);
             bean.setPackage(CodegenUtil.schemaToPackageName(schema, this.packageName + ".beans"));
             bean.set$schema(Library.writeNode(schema));
-            bean.setSignature(createSignature((OpenApi30Schema) schema));
+            bean.setSignature(createSignature((OpenApi31Schema) schema));
             bean.setAnnotations(annotations(CodegenUtil.getExtension((Extensible) schema, CodegenExtensions.ANNOTATIONS)));
 
             this.codegenInfo.getBeans().add(bean);
@@ -501,7 +504,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
         return path;
     }
 
-    private CodegenJavaReturn returnFromSchema(OpenApi30Schema schema) {
+    private CodegenJavaReturn returnFromSchema(OpenApi31Schema schema) {
         if (schema == null) {
             return null;
         }
@@ -513,7 +516,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi30VisitorAdapter {
         } else if ("array".equals(schema.getType())) {
             cgReturn.setCollection("list");
             OpenApiSchema items = schema.getItems();
-            CodegenJavaReturn subReturn = this.returnFromSchema((OpenApi30Schema) items);
+            CodegenJavaReturn subReturn = this.returnFromSchema((OpenApi31Schema) items);
             if (subReturn != null && subReturn.getType() != null) {
                 cgReturn.setType(subReturn.getType());
             }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/PathItemDetectionVisitor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/PathItemDetectionVisitor.java
@@ -21,7 +21,7 @@ import io.apicurio.datamodels.models.openapi.OpenApiPathItem;
 /**
  * @author eric.wittmann@gmail.com
  */
-public class PathItemDetectionVisitor extends TraversingOpenApi30VisitorAdapter {
+public class PathItemDetectionVisitor extends TraversingOpenApi31VisitorAdapter {
 
     public boolean isPathItem = false;
 

--- a/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/TraversingOpenApi31VisitorAdapter.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/TraversingOpenApi31VisitorAdapter.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.Operation;
 import io.apicurio.datamodels.models.openapi.OpenApiPathItem;
-import io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter;
+import io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter;
 import io.apicurio.datamodels.models.visitors.TraversalContext;
 import io.apicurio.datamodels.models.visitors.TraversingVisitor;
 import io.apicurio.datamodels.util.NodeUtil;
 
-public abstract class TraversingOpenApi30VisitorAdapter extends OpenApi30VisitorAdapter implements TraversingVisitor {
+public abstract class TraversingOpenApi31VisitorAdapter extends OpenApi31VisitorAdapter implements TraversingVisitor {
 
     protected static final JsonNodeFactory factory = JsonNodeFactory.instance;
 

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/DocumentPreProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/DocumentPreProcessor.java
@@ -19,7 +19,7 @@ package io.apicurio.hub.api.codegen.pre;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.TraverserDirection;
 import io.apicurio.datamodels.models.Document;
-import io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30Visitor;
+import io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31Visitor;
 
 /**
  * Used to preprocess an OpenAPI document in a variety of ways with the intent of making the
@@ -28,7 +28,7 @@ import io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30Visitor;
  */
 public class DocumentPreProcessor {
 
-    private static OpenApi30Visitor [] processors = {
+    private static OpenApi31Visitor [] processors = {
             new OpenApiLongSimpleTypeProcessor(),
             new OpenApiDateTimeSimpleTypeProcessor(),
             new OpenApiByteSimpleTypeProcessor(),
@@ -47,7 +47,7 @@ public class DocumentPreProcessor {
      * @param document
      */
     public void process(Document document) {
-        for (OpenApi30Visitor proc : processors) {
+        for (OpenApi31Visitor proc : processors) {
             Library.visitTree(document, proc, TraverserDirection.down);
         }
     }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiAllOfProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiAllOfProcessor.java
@@ -23,28 +23,28 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.refs.LocalReferenceResolver;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiAllOfProcessor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiAllOfProcessor extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
      */
     @Override
     public void visitSchema(Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
         if (schema.getAllOf() != null) {
             List<String> required = new ArrayList<>();
             schema.getAllOf().forEach(allOfSchema -> {
-                OpenApi30Schema allOf = (OpenApi30Schema) allOfSchema;
+                OpenApi31Schema allOf = (OpenApi31Schema) allOfSchema;
                 if (allOf.get$ref() != null) {
                     LocalReferenceResolver resolver = new LocalReferenceResolver();
-                    allOf = (OpenApi30Schema) resolver.resolveRef(allOf.get$ref(), allOf);
+                    allOf = (OpenApi31Schema) resolver.resolveRef(allOf.get$ref(), allOf);
                 }
                 if (allOf != null) {
                     if (allOf.getRequired() != null) {

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiBeanClassExtendsProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiBeanClassExtendsProcessor.java
@@ -19,25 +19,25 @@ package io.apicurio.hub.api.codegen.pre;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.util.NodeUtil;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 import io.apicurio.hub.api.codegen.util.CodegenUtil;
 
 /**
  * Pre processes the OpenAPI document to handle the x-codegen-extendsClass extension.
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiBeanClassExtendsProcessor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiBeanClassExtendsProcessor extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
      */
     @Override
     public void visitSchema(Schema node) {
         if (NodeUtil.isDefinition(node)) {
-            OpenApi30Schema schema = (OpenApi30Schema) node;
+            OpenApi31Schema schema = (OpenApi31Schema) node;
             JsonNode extension = CodegenUtil.getExtension(schema, CodegenExtensions.EXTENDS_CLASS);
             if (extension != null && !extension.isNull() && extension.isTextual()) {
                 schema.removeExtension(CodegenExtensions.EXTENDS_CLASS);

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiByteSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiByteSimpleTypeProcessor.java
@@ -16,20 +16,20 @@
 
 package io.apicurio.hub.api.codegen.pre;
 
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiByteSimpleTypeProcessor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiByteSimpleTypeProcessor extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
      */
     @Override
     public void visitSchema(io.apicurio.datamodels.models.Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
         if ("string".equals(schema.getType()) && "byte".equals(schema.getFormat())) {
             schema.setType("object");
             // workaround for a jsonschema2pojo limitation

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiDateTimeSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiDateTimeSimpleTypeProcessor.java
@@ -19,19 +19,19 @@ package io.apicurio.hub.api.codegen.pre;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 import io.apicurio.hub.api.codegen.util.CodegenUtil;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiDateTimeSimpleTypeProcessor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiDateTimeSimpleTypeProcessor extends TraversingOpenApi31VisitorAdapter {
 
     @Override
     public void visitSchema(Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
         // Switch from int64 format to utc-millisec so that jsonschema2pojo will generate a Long instead of an Integer
         if ("string".equals(schema.getType()) && "date-time".equals(schema.getFormat())) {
             String formatPattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiInlinedParameterRemover.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiInlinedParameterRemover.java
@@ -23,32 +23,32 @@ import io.apicurio.datamodels.TraverserDirection;
 import io.apicurio.datamodels.models.Components;
 import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.Parameter;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
 import io.apicurio.datamodels.models.visitors.CombinedVisitorAdapter;
 import io.apicurio.datamodels.util.NodeUtil;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 import io.apicurio.hub.api.codegen.util.CodegenUtil;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiInlinedParameterRemover extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiInlinedParameterRemover extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitParameter(io.apicurio.datamodels.models.Parameter)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitParameter(io.apicurio.datamodels.models.Parameter)
      */
     @Override
     public void visitParameter(Parameter node) {
         if (NodeUtil.isDefinition(node)) {
-            OpenApi30Parameter param = (OpenApi30Parameter) node;
+            OpenApi31Parameter param = (OpenApi31Parameter) node;
             if (wasInlined(param)) {
                 final String definitionName = getMappedNodeName(node);
                 Library.visitTree(param.root(), new CombinedVisitorAdapter() {
                     @Override
                     public void visitComponents(Components node) {
-                        OpenApi30Components components = (OpenApi30Components) node;
+                        OpenApi31Components components = (OpenApi31Components) node;
                         components.getParameters().remove(definitionName);
                     }
                 }, TraverserDirection.down);

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiInlinedSchemaRemover.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiInlinedSchemaRemover.java
@@ -23,29 +23,29 @@ import io.apicurio.datamodels.TraverserDirection;
 import io.apicurio.datamodels.models.Components;
 import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Components;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Components;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.models.visitors.CombinedVisitorAdapter;
 import io.apicurio.datamodels.util.NodeUtil;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 import io.apicurio.hub.api.codegen.util.CodegenUtil;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiInlinedSchemaRemover extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiInlinedSchemaRemover extends TraversingOpenApi31VisitorAdapter {
 
     @Override
     public void visitSchema(Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
         if (NodeUtil.isDefinition(schema)) {
             if (wasInlined(schema)) {
                 String definitionName = getMappedNodeName(schema);
                 Library.visitTree(schema.root(), new CombinedVisitorAdapter() {
                     @Override
                     public void visitComponents(Components node) {
-                        OpenApi30Components components = (OpenApi30Components) node;
+                        OpenApi31Components components = (OpenApi31Components) node;
                         components.getSchemas().remove(definitionName);
                     }
                 }, TraverserDirection.down);

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiLongSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiLongSimpleTypeProcessor.java
@@ -17,20 +17,20 @@
 package io.apicurio.hub.api.codegen.pre;
 
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiLongSimpleTypeProcessor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiLongSimpleTypeProcessor extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
      */
     @Override
     public void visitSchema(Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
         // Switch from int64 format to utc-millisec so that jsonschema2pojo will generate a Long instead of an Integer
         if ("integer".equals(schema.getType()) && "int64".equals(schema.getFormat())) {
             schema.setFormat("utc-millisec");

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiMapDataTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiMapDataTypeProcessor.java
@@ -19,24 +19,24 @@ package io.apicurio.hub.api.codegen.pre;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.util.NodeUtil;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 import io.apicurio.hub.api.codegen.util.CodegenUtil;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiMapDataTypeProcessor extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiMapDataTypeProcessor extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitSchema(io.apicurio.datamodels.models.Schema)
      */
     @Override
     public void visitSchema(Schema node) {
         if (NodeUtil.isDefinition(node)) {
-            OpenApi30Schema schema = (OpenApi30Schema) node;
+            OpenApi31Schema schema = (OpenApi31Schema) node;
             if (isMapType(schema)) {
                 schema.setAdditionalProperties(null);
                 schema.addExtraProperty("existingJavaType", factory.textNode("java.util.Map<String,String>"));
@@ -44,7 +44,7 @@ public class OpenApiMapDataTypeProcessor extends TraversingOpenApi30VisitorAdapt
         }
     }
 
-    private boolean isMapType(OpenApi30Schema schema) {
+    private boolean isMapType(OpenApi31Schema schema) {
         JsonNode extension = CodegenUtil.getExtension(schema, CodegenExtensions.TYPE);
         if (extension == null || !extension.isTextual()) {
             return false;

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiParameterInliner.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiParameterInliner.java
@@ -22,22 +22,22 @@ import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.Parameter;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Parameter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Parameter;
 import io.apicurio.datamodels.refs.LocalReferenceResolver;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiParameterInliner extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiParameterInliner extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitParameter(io.apicurio.datamodels.models.Parameter)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitParameter(io.apicurio.datamodels.models.Parameter)
      */
     @Override
     public void visitParameter(Parameter node) {
-        OpenApi30Parameter param = (OpenApi30Parameter) node;
+        OpenApi31Parameter param = (OpenApi31Parameter) node;
 
         LocalReferenceResolver resolver = new LocalReferenceResolver();
         if (param.get$ref() != null) {
@@ -54,7 +54,7 @@ public class OpenApiParameterInliner extends TraversingOpenApi30VisitorAdapter {
      * @param param
      * @param paramDef
      */
-    private void inlineParameter(OpenApi30Parameter param, Node paramDef) {
+    private void inlineParameter(OpenApi31Parameter param, Node paramDef) {
         param.set$ref(null);
 
         // Copy everything from schemaDef into schema by serializing the former into a JSON

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiResponseInliner.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiResponseInliner.java
@@ -21,21 +21,21 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.openapi.OpenApiResponse;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Response;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Response;
 import io.apicurio.datamodels.refs.LocalReferenceResolver;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiResponseInliner extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiResponseInliner extends TraversingOpenApi31VisitorAdapter {
 
     /**
-     * @see io.apicurio.datamodels.models.openapi.v30.visitors.OpenApi30VisitorAdapter#visitResponse(io.apicurio.datamodels.models.openapi.OpenApiResponse)
+     * @see io.apicurio.datamodels.models.openapi.v31.visitors.OpenApi31VisitorAdapter#visitResponse(io.apicurio.datamodels.models.openapi.OpenApiResponse)
      */
     @Override
     public void visitResponse(OpenApiResponse node) {
-        OpenApi30Response response = (OpenApi30Response) node;
+        OpenApi31Response response = (OpenApi31Response) node;
         LocalReferenceResolver resolver = new LocalReferenceResolver();
         if (response.get$ref() != null) {
             Node referencedResponseDefNode = resolver.resolveRef(response.get$ref(), response);
@@ -50,7 +50,7 @@ public class OpenApiResponseInliner extends TraversingOpenApi30VisitorAdapter {
      * @param response
      * @param responseDef
      */
-    private void inlineResponse(OpenApi30Response response, Node responseDef) {
+    private void inlineResponse(OpenApi31Response response, Node responseDef) {
         response.set$ref(null);
 
         // Copy everything from schemaDef into schema by serializing the former into a JSON

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiTypeInliner.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiTypeInliner.java
@@ -23,26 +23,26 @@ import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.Node;
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.datamodels.refs.LocalReferenceResolver;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 import io.apicurio.hub.api.codegen.util.CodegenUtil;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class OpenApiTypeInliner extends TraversingOpenApi30VisitorAdapter {
+public class OpenApiTypeInliner extends TraversingOpenApi31VisitorAdapter {
 
     @Override
     public void visitSchema(Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
 
         LocalReferenceResolver resolver = new LocalReferenceResolver();
         if (schema.get$ref() != null) {
             Node referencedSchemaDefNode = resolver.resolveRef(schema.get$ref(), schema);
             if (referencedSchemaDefNode != null) {
-                OpenApi30Schema referencedSchema = (OpenApi30Schema) referencedSchemaDefNode;
+                OpenApi31Schema referencedSchema = (OpenApi31Schema) referencedSchemaDefNode;
                 if (isSimpleType(referencedSchema)) {
                     inlineSchema(schema, referencedSchema);
                     markForRemoval(referencedSchema);
@@ -50,7 +50,7 @@ public class OpenApiTypeInliner extends TraversingOpenApi30VisitorAdapter {
                     inlineSchema(schema, referencedSchema);
                     markForRemoval(referencedSchema);
                 } else if (isInlineSchema((Extensible) referencedSchemaDefNode)) {
-                    inlineSchema(schema, (OpenApi30Schema) referencedSchemaDefNode);
+                    inlineSchema(schema, (OpenApi31Schema) referencedSchemaDefNode);
                     markForRemoval((Extensible) referencedSchemaDefNode);
                 }
             }
@@ -62,7 +62,7 @@ public class OpenApiTypeInliner extends TraversingOpenApi30VisitorAdapter {
      * or is a primitive type that should be inlined
      * @param schema
      */
-    private boolean isSimpleType(OpenApi30Schema schema) {
+    private boolean isSimpleType(OpenApi31Schema schema) {
         if ("string".equals(schema.getType())) {
             return schema.getEnum() == null;
         } else {
@@ -75,7 +75,7 @@ public class OpenApiTypeInliner extends TraversingOpenApi30VisitorAdapter {
      * Returns true if the given schema is an array type.
      * @param schema
      */
-    private boolean isArrayType(OpenApi30Schema schema) {
+    private boolean isArrayType(OpenApi31Schema schema) {
         return "array".equals(schema.getType());
     }
 
@@ -84,7 +84,7 @@ public class OpenApiTypeInliner extends TraversingOpenApi30VisitorAdapter {
      * @param schema
      * @param schemaDef
      */
-    private void inlineSchema(OpenApi30Schema schema, OpenApi30Schema schemaDef) {
+    private void inlineSchema(OpenApi31Schema schema, OpenApi31Schema schemaDef) {
         schema.set$ref(null);
 
         // Copy everything from schemaDef into schema by serializing the former into a JSON

--- a/core/src/main/java/io/apicurio/hub/api/codegen/util/CodegenUtil.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/util/CodegenUtil.java
@@ -23,10 +23,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.apicurio.datamodels.models.Document;
 import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
-import io.apicurio.datamodels.models.openapi.v20.OpenApi20Document;
-import io.apicurio.datamodels.models.openapi.v20.OpenApi20Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Document;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
 
 public final class CodegenUtil {
@@ -50,19 +48,11 @@ public final class CodegenUtil {
     public static final String schemaRefToFQCN(Document document, String schemaRef, String defaultPackage) {
         String cname = "GeneratedClass_" + System.currentTimeMillis();
         String pname = defaultPackage;
-        if (schemaRef.startsWith("#/definitions/")) {
-            cname = schemaRef.substring(14);
-            OpenApi20Document doc20 = (OpenApi20Document) document;
-            if (doc20.getDefinitions() != null) {
-                OpenApi20Schema definition = doc20.getDefinitions().getItem(cname);
-                pname = CodegenUtil.schemaToPackageName(definition, pname);
-            }
-        }
         if (schemaRef.startsWith("#/components/schemas/")) {
             cname = schemaRef.substring(21);
-            OpenApi30Document doc30 = (OpenApi30Document) document;
-            if (doc30.getComponents() != null) {
-                OpenApi30Schema definition = (OpenApi30Schema) doc30.getComponents().getSchemas().get(cname);
+            OpenApi31Document doc31 = (OpenApi31Document) document;
+            if (doc31.getComponents() != null) {
+                OpenApi31Schema definition = (OpenApi31Schema) doc31.getComponents().getSchemas().get(cname);
                 pname = CodegenUtil.schemaToPackageName(definition, pname);
             }
         }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/util/SchemaSigner.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/util/SchemaSigner.java
@@ -21,13 +21,13 @@ import java.util.Arrays;
 import org.apache.commons.codec.digest.DigestUtils;
 
 import io.apicurio.datamodels.models.Schema;
-import io.apicurio.datamodels.models.openapi.v30.OpenApi30Schema;
-import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi30VisitorAdapter;
+import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
+import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
  * @author eric.wittmann@gmail.com
  */
-public class SchemaSigner extends TraversingOpenApi30VisitorAdapter {
+public class SchemaSigner extends TraversingOpenApi31VisitorAdapter {
 
     private StringBuilder sigSource = new StringBuilder();
 
@@ -49,7 +49,7 @@ public class SchemaSigner extends TraversingOpenApi30VisitorAdapter {
      */
     @Override
     public void visitSchema(Schema node) {
-        OpenApi30Schema schema = (OpenApi30Schema) node;
+        OpenApi31Schema schema = (OpenApi31Schema) node;
         // Right now we only support simple types.
         if (schema.getType() != null && !schema.getType().equals("object") && !schema.getType().equals("array") && schema.get$ref() == null) {
             // Type


### PR DESCRIPTION
This library now supports all versions of OpenAPI.  All visitors were upgraded to OpenAPI 3.1, and the analysis now transforms any input file from whatever version it is (2.0, 3.0.x) to 3.1.