### PR TITLE
Bump apicurio-data-models from 2.0.0.RC3 to 2.0.2

### DIFF
--- a/core/src/main/java/io/apicurio/hub/api/codegen/beans/CodegenJavaSchema.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/beans/CodegenJavaSchema.java
@@ -1,17 +1,20 @@
 package io.apicurio.hub.api.codegen.beans;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class CodegenJavaSchema {
 
     private String collection;
-    private String type;
+    private List<String> type;
     private String format;
     private String constant;
     private Number maximum;
-    private Boolean exclusiveMaximum;
+    private boolean exclusiveMaximum;
     private Number minimum;
-    private Boolean exclusiveMinimum;
+    private boolean exclusiveMinimum;
     private Long maxLength;
     private Long minLength;
     private String pattern;
@@ -20,13 +23,20 @@ public class CodegenJavaSchema {
     private Boolean uniqueItems;
     private Long maxProperties;
     private Long minProperties;
-    private Boolean nullable;
     private String defaultValue;
+
+    public void setType(String type) {
+        this.type = Collections.singletonList(type);
+    }
+
+    public boolean isNullable() {
+        return Optional.ofNullable(type).map(t -> t.contains("null")).orElse(false);
+    }
 
     @Override
     public int hashCode() {
         return Objects.hash(collection, constant, defaultValue, exclusiveMaximum, exclusiveMinimum, format, maxItems,
-                maxLength, maxProperties, maximum, minItems, minLength, minProperties, minimum, nullable, pattern, type,
+                maxLength, maxProperties, maximum, minItems, minLength, minProperties, minimum, pattern, type,
                 uniqueItems);
     }
 
@@ -47,7 +57,6 @@ public class CodegenJavaSchema {
                 && Objects.equals(maxProperties, other.maxProperties) && Objects.equals(maximum, other.maximum)
                 && Objects.equals(minItems, other.minItems) && Objects.equals(minLength, other.minLength)
                 && Objects.equals(minProperties, other.minProperties) && Objects.equals(minimum, other.minimum)
-                && Objects.equals(nullable, other.nullable) && Objects.equals(pattern, other.pattern)
                 && Objects.equals(type, other.type) && Objects.equals(uniqueItems, other.uniqueItems);
     }
 
@@ -68,14 +77,14 @@ public class CodegenJavaSchema {
     /**
      * @return the type
      */
-    public String getType() {
+    public List<String> getType() {
         return type;
     }
 
     /**
      * @param type the type to set
      */
-    public void setType(String type) {
+    public void setType(List<String> type) {
         this.type = type;
     }
 
@@ -124,14 +133,14 @@ public class CodegenJavaSchema {
     /**
      * @return the exclusiveMaximum
      */
-    public Boolean getExclusiveMaximum() {
+    public boolean isExclusiveMaximum() {
         return exclusiveMaximum;
     }
 
     /**
      * @param exclusiveMaximum the exclusiveMaximum to set
      */
-    public void setExclusiveMaximum(Boolean exclusiveMaximum) {
+    public void setExclusiveMaximum(boolean exclusiveMaximum) {
         this.exclusiveMaximum = exclusiveMaximum;
     }
 
@@ -152,14 +161,14 @@ public class CodegenJavaSchema {
     /**
      * @return the exclusiveMinimum
      */
-    public Boolean getExclusiveMinimum() {
+    public boolean isExclusiveMinimum() {
         return exclusiveMinimum;
     }
 
     /**
      * @param exclusiveMinimum the exclusiveMinimum to set
      */
-    public void setExclusiveMinimum(Boolean exclusiveMinimum) {
+    public void setExclusiveMinimum(boolean exclusiveMinimum) {
         this.exclusiveMinimum = exclusiveMinimum;
     }
 
@@ -275,19 +284,6 @@ public class CodegenJavaSchema {
         this.minProperties = minProperties;
     }
 
-    /**
-     * @return the nullable
-     */
-    public Boolean getNullable() {
-        return nullable;
-    }
-
-    /**
-     * @param nullable the nullable to set
-     */
-    public void setNullable(Boolean nullable) {
-        this.nullable = nullable;
-    }
 
     /**
      * @return the defaultValue

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiByteSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiByteSimpleTypeProcessor.java
@@ -16,7 +16,10 @@
 
 package io.apicurio.hub.api.codegen.pre;
 
+import static io.apicurio.hub.api.codegen.util.CodegenUtil.containsValue;
+
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
+import io.apicurio.datamodels.models.union.StringUnionValueImpl;
 import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
 
 /**
@@ -30,8 +33,8 @@ public class OpenApiByteSimpleTypeProcessor extends TraversingOpenApi31VisitorAd
     @Override
     public void visitSchema(io.apicurio.datamodels.models.Schema node) {
         OpenApi31Schema schema = (OpenApi31Schema) node;
-        if ("string".equals(schema.getType()) && "byte".equals(schema.getFormat())) {
-            schema.setType("object");
+        if (containsValue(schema.getType(), "string") && "byte".equals(schema.getFormat())) {
+            schema.setType(new StringUnionValueImpl("object"));
             // workaround for a jsonschema2pojo limitation
             schema.addExtraProperty("existingJavaType", factory.textNode("APICURIO_CODEGEN_BYTE_ARRAY_REPRESENTATION"));
         }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiDateTimeSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiDateTimeSimpleTypeProcessor.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.hub.api.codegen.pre;
 
+import static io.apicurio.hub.api.codegen.util.CodegenUtil.containsValue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.apicurio.datamodels.models.Schema;
@@ -33,7 +35,7 @@ public class OpenApiDateTimeSimpleTypeProcessor extends TraversingOpenApi31Visit
     public void visitSchema(Schema node) {
         OpenApi31Schema schema = (OpenApi31Schema) node;
         // Switch from int64 format to utc-millisec so that jsonschema2pojo will generate a Long instead of an Integer
-        if ("string".equals(schema.getType()) && "date-time".equals(schema.getFormat())) {
+        if (containsValue(schema.getType(), "string") && "date-time".equals(schema.getFormat())) {
             String formatPattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
             JsonNode ext = CodegenUtil.getExtension(schema, CodegenExtensions.FORMAT_PATTERN);
             if (ext != null && !ext.isNull() && ext.isTextual()) {

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiLongSimpleTypeProcessor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiLongSimpleTypeProcessor.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.hub.api.codegen.pre;
 
+import static io.apicurio.hub.api.codegen.util.CodegenUtil.containsValue;
+
 import io.apicurio.datamodels.models.Schema;
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
 import io.apicurio.hub.api.codegen.jaxrs.TraversingOpenApi31VisitorAdapter;
@@ -32,7 +34,7 @@ public class OpenApiLongSimpleTypeProcessor extends TraversingOpenApi31VisitorAd
     public void visitSchema(Schema node) {
         OpenApi31Schema schema = (OpenApi31Schema) node;
         // Switch from int64 format to utc-millisec so that jsonschema2pojo will generate a Long instead of an Integer
-        if ("integer".equals(schema.getType()) && "int64".equals(schema.getFormat())) {
+        if (containsValue(schema.getType(), "integer") && "int64".equals(schema.getFormat())) {
             schema.setFormat("utc-millisec");
         }
     }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiTypeInliner.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/pre/OpenApiTypeInliner.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.hub.api.codegen.pre;
 
+import static io.apicurio.hub.api.codegen.util.CodegenUtil.containsValue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -63,11 +65,10 @@ public class OpenApiTypeInliner extends TraversingOpenApi31VisitorAdapter {
      * @param schema
      */
     private boolean isSimpleType(OpenApi31Schema schema) {
-        if ("string".equals(schema.getType())) {
+        if (containsValue(schema.getType(), "string")) {
             return schema.getEnum() == null;
         } else {
-            return "integer".equals(schema.getType()) || "number".equals(schema.getType()) ||
-                    "boolean".equals(schema.getType());
+            return containsValue(schema.getType(), "boolean", "integer", "number");
         }
     }
 
@@ -76,7 +77,7 @@ public class OpenApiTypeInliner extends TraversingOpenApi31VisitorAdapter {
      * @param schema
      */
     private boolean isArrayType(OpenApi31Schema schema) {
-        return "array".equals(schema.getType());
+        return containsValue(schema.getType(), "array");
     }
 
     /**

--- a/core/src/main/java/io/apicurio/hub/api/codegen/util/CodegenUtil.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/util/CodegenUtil.java
@@ -16,6 +16,12 @@
 
 package io.apicurio.hub.api.codegen.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -25,6 +31,7 @@ import io.apicurio.datamodels.models.Extensible;
 import io.apicurio.datamodels.models.openapi.OpenApiSchema;
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Document;
 import io.apicurio.datamodels.models.openapi.v31.OpenApi31Schema;
+import io.apicurio.datamodels.models.union.StringStringListUnion;
 import io.apicurio.hub.api.codegen.CodegenExtensions;
 
 public final class CodegenUtil {
@@ -66,4 +73,22 @@ public final class CodegenUtil {
         return null;
     }
 
+    public static List<String> toStringList(StringStringListUnion union) {
+        return Optional.ofNullable(union)
+            .filter(u -> Objects.nonNull(u.unionValue()))
+            .map(u -> u.isStringList() ? u.asStringList() : new ArrayList<>(List.of(u.asString())))
+            .orElse(null);
+    }
+
+    public static boolean containsValue(StringStringListUnion union, String... values) {
+        if (union == null) {
+            return false;
+        }
+
+        if (union.isStringList()) {
+            return union.asStringList().stream().anyMatch(Arrays.asList(values)::contains);
+        }
+
+        return Arrays.asList(values).contains(union.asString());
+    }
 }

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-constrained-parameters/generated-api/src/main/java/org/example/api/WidgetResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-constrained-parameters/generated-api/src/main/java/org/example/api/WidgetResource.java
@@ -20,8 +20,8 @@ public interface WidgetResource {
   @GET
   @Produces("application/json")
   List<String> getWidgetNames(
-      @QueryParam("ownerId") @DecimalMax(value = "1000000000", inclusive = false) @DecimalMin(value = "1.0", inclusive = true) @DefaultValue("100") Integer ownerId,
-      @QueryParam("userId") @DecimalMax(value = "999999999", inclusive = true) @DecimalMin(value = "0.0", inclusive = false) Integer userId,
+      @QueryParam("ownerId") @DecimalMax(value = "1000000000", inclusive = false) @DecimalMin(value = "1", inclusive = true) @DefaultValue("100") Integer ownerId,
+      @QueryParam("userId") @DecimalMax(value = "999999999", inclusive = true) @DecimalMin(value = "0", inclusive = false) Integer userId,
       @QueryParam("nameFilter") @Size(max = 10) @Size(min = 1) List<String> nameFilter,
       @CookieParam("sessionToken") @Size(max = 20) @Size(min = 1) @Pattern(regexp = "\\S") String sessionToken,
       @CookieParam("sessionInfo") Object sessionInfo);

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-mmt-full/generated-api/src/main/java/org/example/api/WidgetsResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-mmt-full/generated-api/src/main/java/org/example/api/WidgetsResource.java
@@ -38,8 +38,8 @@ public interface WidgetsResource {
    * 
    */
   @POST
-  @Consumes("application/json+v2")
-  void createWidget(@NotNull Widgetv2 data);
+  @Consumes("application/json+v1")
+  void createWidget(@NotNull Widgetv1 data);
 
   /**
    * <p>
@@ -48,8 +48,8 @@ public interface WidgetsResource {
    * 
    */
   @POST
-  @Consumes("application/json+v1")
-  void createWidget(@NotNull Widgetv1 data);
+  @Consumes("application/json+v2")
+  void createWidget(@NotNull Widgetv2 data);
 
   /**
    * <p>
@@ -70,8 +70,8 @@ public interface WidgetsResource {
    */
   @Path("/{widgetId}")
   @PUT
-  @Consumes("application/json")
-  void updateWidget(@PathParam("widgetId") String widgetId, @NotNull Widget data);
+  @Consumes("*/*")
+  void updateWidget(@PathParam("widgetId") String widgetId, @NotNull InputStream data);
 
   /**
    * <p>
@@ -81,8 +81,8 @@ public interface WidgetsResource {
    */
   @Path("/{widgetId}")
   @PUT
-  @Consumes("*/*")
-  void updateWidget(@PathParam("widgetId") String widgetId, @NotNull InputStream data);
+  @Consumes("application/json")
+  void updateWidget(@PathParam("widgetId") String widgetId, @NotNull Widget data);
 
   /**
    * <p>

--- a/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/GistsResource.java
+++ b/core/src/test/resources/OpenApi2QuarkusTest/_expected-github/generated-api/src/main/java/org/example/api/GistsResource.java
@@ -129,7 +129,7 @@ public interface GistsResource {
   @PATCH
   @Produces("application/json")
   @Consumes("application/json")
-  Response gists_update(@PathParam("gist_id") String gistId, @NotNull InputStream data);
+  Response gists_update(@PathParam("gist_id") String gistId, InputStream data);
 
   /**
    * 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.2.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
         <version.junit>4.13.2</version.junit>
         <version.org.slf4j>2.0.7</version.org.slf4j>
-        <version.apicurio-data-models>2.0.0.RC3</version.apicurio-data-models>
+        <version.apicurio-data-models>2.0.2</version.apicurio-data-models>
         <version.commons-lang>2.6</version.commons-lang>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.commons-codec>1.15</version.commons-codec>


### PR DESCRIPTION
Supersedes #158 

Includes adjustments to account for breaking changes in the API:
- make schema type is a list
- account for inclusive min/max change from bool to number
- attempt to stabilize method order when there are multiple request body mime types (see changes in `WidgetsResource`)