### PR TITLE
Add option to wrap return type in a generic class

### DIFF
--- a/core/src/main/java/io/apicurio/hub/api/codegen/JaxRsProjectSettings.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/JaxRsProjectSettings.java
@@ -33,6 +33,7 @@ public class JaxRsProjectSettings {
     public String javaPackage = "org.example.api";
     public String classNamePrefix = "";
     public String classNameSuffix = "";
+    public String genericReturnType = null;
 
     /**
      * Constructor.
@@ -166,5 +167,13 @@ public class JaxRsProjectSettings {
 
     public void setClassNameSuffix(String classNameSuffix) {
         this.classNameSuffix = classNameSuffix;
+    }
+
+    public String getGenericReturnType() {
+        return genericReturnType;
+    }
+
+    public void setGenericReturnType(String genericReturnType) {
+        this.genericReturnType = genericReturnType;
     }
 }

--- a/core/src/main/java/io/apicurio/hub/api/codegen/OpenApi2JaxRs.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/OpenApi2JaxRs.java
@@ -24,7 +24,6 @@ import java.io.PrintWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -552,16 +551,19 @@ public class OpenApi2JaxRs {
                 reactive = Boolean.TRUE.equals(methodInfo.getAsync());
             }
 
+            final String genericReturnType = getSettings().genericReturnType;
+
             Optional.ofNullable(methodInfo.getReturn())
                 .map(rt -> generateTypeName(
                         rt,
                         true,
                         String.format("%s.ws.rs.core.Response", topLevelPackage)))
+                .map(rt -> generateGenericReturnType(rt, genericReturnType))
                 .map(rt -> reactive ? generateReactiveTypeName(rt) : rt)
                 .map(Object::toString)
                 .ifPresentOrElse(
                         operationMethod::setReturnType,
-                        () -> setVoidReturnType(operationMethod, reactive));
+                        () -> setVoidReturnType(operationMethod, reactive, genericReturnType));
 
             Optional.ofNullable(methodInfo.getArguments())
                 .map(Collection::stream)
@@ -751,12 +753,17 @@ public class OpenApi2JaxRs {
         return parseType(defaultType);
     }
 
-    protected void setVoidReturnType(MethodSource<JavaInterfaceSource> operationMethod, boolean reactive) {
-        if (reactive) {
-            operationMethod.setReturnType(generateReactiveTypeName(VOID));
-        } else {
-            operationMethod.setReturnTypeVoid();
-        }
+    protected void setVoidReturnType(MethodSource<JavaInterfaceSource> operationMethod, boolean reactive, String genericReturnType) {
+        Optional.of(VOID)
+            .map(type -> generateGenericReturnType(type, genericReturnType))
+            .map(type -> reactive ? generateReactiveTypeName(type) : type)
+            .ifPresent(type -> {
+                if (type != VOID) {
+                    operationMethod.setReturnType(type);
+                } else {
+                    operationMethod.setReturnTypeVoid();
+                }
+            });
     }
 
     /**
@@ -767,6 +774,19 @@ public class OpenApi2JaxRs {
      */
     protected Type<?> generateReactiveTypeName(Type<?> coreType) {
         return parseType(String.format("java.util.concurrent.CompletionStage<%s>", coreType.toString()));
+    }
+
+    /**
+     * Generates the generic type wrapping response type.
+     *
+     * @param coreType
+     * @param genericReturnType
+     */
+    private Type<?> generateGenericReturnType(Type<?> coreType, String genericReturnType) {
+        if (genericReturnType == null) {
+            return coreType;
+        }
+        return parseType(String.format("%s<%s>", genericReturnType, coreType.toString()));
     }
 
     /**

--- a/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2JaxRsTest.java
+++ b/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2JaxRsTest.java
@@ -37,7 +37,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, "_expected-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no,  null, "_expected-full/generated-api", false);
     }
 
     /**
@@ -45,7 +45,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFullPrefixed() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, false,
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no,  null, false,
                 "_expected-full-prefixed/generated-api", "Test", "", false);
     }
 
@@ -54,7 +54,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFullSuffixed() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, false,
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no,  null, false,
                 "_expected-full-suffixed/generated-api", "", "Test", false);
     }
 
@@ -63,7 +63,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_GatewayApi() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/gateway-api.json", UpdateOnly.no, Reactive.no, "_expected-gatewayApi-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/gateway-api.json", UpdateOnly.no, Reactive.no, null, "_expected-gatewayApi-full/generated-api", false);
     }
 
     /**
@@ -71,7 +71,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_RegistryApi() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/registry-api.json", UpdateOnly.no, Reactive.no, "_expected-registryApi-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/registry-api.json", UpdateOnly.no, Reactive.no, null, "_expected-registryApi-full/generated-api", false);
     }
 
     /**
@@ -79,7 +79,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_RegistryApiV2() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/registry-api-v2.json", UpdateOnly.yes, Reactive.no, "_expected-registry-api-v2/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/registry-api-v2.json", UpdateOnly.yes, Reactive.no, null, "_expected-registry-api-v2/generated-api", false);
     }
 
     /**
@@ -87,7 +87,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateUpdateOnly() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.yes, Reactive.no, "_expected-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.yes, Reactive.no, null, "_expected-full/generated-api", false);
     }
 
     /**
@@ -95,7 +95,23 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFullReactive() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.yes, "_expected-reactive-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.yes, null, "_expected-reactive-full/generated-api", false);
+    }
+
+    /**
+     * Test method for {@link io.apicurio.hub.api.codegen.OpenApi2JaxRs#generate()}.
+     */
+    @Test
+    public void testGenerateFullGenericReturnType() throws IOException {
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, "org.jboss.resteasy.reactive.RestResponse", "_expected-genericReturnType-full/generated-api", false);
+    }
+
+    /**
+     * Test method for {@link io.apicurio.hub.api.codegen.OpenApi2JaxRs#generate()}.
+     */
+    @Test
+    public void testGenerateFullGenericReturnTypeReactive() throws IOException {
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.yes, "org.jboss.resteasy.reactive.RestResponse", "_expected-genericReturnTypeReactive-full/generated-api", false);
     }
 
     /**
@@ -103,7 +119,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateWithCLIGenCI() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, true,
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, null, true,
                 "_expected-full-with-ci/generated-api", "", "", false);
     }
 
@@ -113,7 +129,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
     @Test
     public void testGenerateFull_Issue885Api() throws IOException {
         // Note: I can't seem to get this working in the maven build, but it works in Eclipse.
-        doFullTest("OpenApi2JaxRsTest/issue-885-api.json", UpdateOnly.no, Reactive.no, "_expected-issue885Api-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/issue-885-api.json", UpdateOnly.no, Reactive.no, null, "_expected-issue885Api-full/generated-api", false);
     }
 
     /**
@@ -121,7 +137,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_MultipleMediaTypes() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/mmt-api.json", UpdateOnly.no, Reactive.no, "_expected-mmt-full/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/mmt-api.json", UpdateOnly.no, Reactive.no, null, "_expected-mmt-full/generated-api", false);
     }
 
     /**
@@ -129,7 +145,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_ContextRoot() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/context-root.json", UpdateOnly.no, Reactive.no, "_expected-context-root/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/context-root.json", UpdateOnly.no, Reactive.no, null, "_expected-context-root/generated-api", false);
     }
 
     /**
@@ -137,7 +153,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_SimpleType() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/simple-type.json", UpdateOnly.no, Reactive.no, "_expected-simple-type/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/simple-type.json", UpdateOnly.no, Reactive.no, null, "_expected-simple-type/generated-api", false);
     }
 
     /**
@@ -145,7 +161,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_BeanAnnotations() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/bean-annotations.json", UpdateOnly.no, Reactive.no, "_expected-bean-annotations/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/bean-annotations.json", UpdateOnly.no, Reactive.no, null, "_expected-bean-annotations/generated-api", false);
     }
 
     /**
@@ -153,7 +169,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_Inheritance() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/inheritance.json", UpdateOnly.yes, Reactive.no, "_expected-inheritance/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/inheritance.json", UpdateOnly.yes, Reactive.no, null, "_expected-inheritance/generated-api", false);
     }
 
     /**
@@ -161,7 +177,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_NZDAX() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/nzdax.json", UpdateOnly.yes, Reactive.no, "_expected-nzdax/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/nzdax.json", UpdateOnly.yes, Reactive.no, null, "_expected-nzdax/generated-api", false);
     }
 
     /**
@@ -169,7 +185,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testGenerateFull_CustomResponseType() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/custom-response-type.json", UpdateOnly.yes, Reactive.no, "_expected-custom-response-type/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/custom-response-type.json", UpdateOnly.yes, Reactive.no, null, "_expected-custom-response-type/generated-api", false);
     }
 
     /**
@@ -177,7 +193,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testSchemaExtends() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/schema-extends.json", UpdateOnly.yes, Reactive.no, "_expected-schema-extends/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/schema-extends.json", UpdateOnly.yes, Reactive.no, null, "_expected-schema-extends/generated-api", false);
     }
 
     /**
@@ -185,7 +201,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testMasStudio() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/mas-studio.json", UpdateOnly.no, Reactive.no, "_expected-mas-studio/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/mas-studio.json", UpdateOnly.no, Reactive.no, null, "_expected-mas-studio/generated-api", false);
     }
 
     /**
@@ -193,7 +209,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testPetStore() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/petstore-openapi.json", UpdateOnly.no, Reactive.no, "_expected-petstore/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/petstore-openapi.json", UpdateOnly.no, Reactive.no, null, "_expected-petstore/generated-api", false);
     }
 
     /**
@@ -201,7 +217,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      */
     @Test
     public void testConstraintParameters() throws IOException {
-        doFullTest("OpenApi2JaxRsTest/constrained-parameters.json", UpdateOnly.no, Reactive.no, "_expected-constrained-parameters/generated-api", false);
+        doFullTest("OpenApi2JaxRsTest/constrained-parameters.json", UpdateOnly.no, Reactive.no, null, "_expected-constrained-parameters/generated-api", false);
     }
 
     /**
@@ -209,19 +225,22 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      * @param apiDef
      * @param updateOnly
      * @param reactive
+     * @param genericReturnType
      * @param expectedFilesPath
      * @param debug
      * @throws IOException
      */
-    private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, String expectedFilesPath, boolean debug) throws IOException {
-        doFullTest(apiDef, updateOnly, reactive, false, expectedFilesPath, "", "", debug);
+    private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, String genericReturnType, String expectedFilesPath, boolean debug) throws IOException {
+        doFullTest(apiDef, updateOnly, reactive, genericReturnType, false, expectedFilesPath, "", "", debug);
     }
 
     /**
      * Shared test method.
+     *
      * @param apiDef
      * @param updateOnly
      * @param reactive
+     * @param genericReturnType
      * @param generateCLiGenCI
      * @param expectedFilesPath
      * @param namePrefix
@@ -229,8 +248,8 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
      * @param debug
      * @throws IOException
      */
-    private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, boolean generateCLiGenCI,
-            String expectedFilesPath, String namePrefix, String nameSuffix, boolean debug) throws IOException {
+    private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, String genericReturnType, boolean generateCLiGenCI,
+                            String expectedFilesPath, String namePrefix, String nameSuffix, boolean debug) throws IOException {
         JaxRsProjectSettings settings = new JaxRsProjectSettings();
         settings.codeOnly = false;
         settings.reactive = reactive == Reactive.yes;
@@ -240,6 +259,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
         settings.javaPackage = "org.example.api";
         settings.classNamePrefix = namePrefix;
         settings.classNameSuffix = nameSuffix;
+        settings.genericReturnType = genericReturnType;
 
         OpenApi2JaxRs generator = new OpenApi2JaxRs();
         generator.setSettings(settings);

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/pom.xml
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.example.api</groupId>
+    <artifactId>generated-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Beer API</name>
+    <description>The official Beer API!  Search for both beers and breweries.</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.jakarta.ws.rs-jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-jakarta.ws.rs-api>
+        <version.jakarta.validation-jakarta.validation-api>3.0.2</version.jakarta.validation-jakarta.validation-api>
+        <version.jakarta.enterprise-jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise-jakarta.enterprise.cdi-api>
+        <version.com.fasterxml.jackson>2.15.1</version.com.fasterxml.jackson>
+    </properties>
+
+    <dependencies>
+        <!-- Third Party Dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${version.com.fasterxml.jackson}</version>
+        </dependency>
+        <!-- Specification Dependencies -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${version.jakarta.ws.rs-jakarta.ws.rs-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${version.jakarta.enterprise-jakarta.enterprise.cdi-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${version.jakarta.validation-jakarta.validation-api}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -1,0 +1,76 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import org.example.api.beans.Beer;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/beers")
+public interface BeersResource {
+  /**
+   * <p>
+   * Returns full information about a single beer.
+   * </p>
+   *
+   */
+  @Path("/{beerId}")
+  @GET
+  @Produces("application/json")
+  RestResponse<Beer> getBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Updates information about a single beer.
+   * </p>
+   *
+   */
+  @Path("/{beerId}")
+  @PUT
+  @Consumes("application/json")
+  RestResponse<Void> updateBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId, @NotNull Beer data);
+
+  /**
+   * <p>
+   * Removes a single beer from the data set.
+   * </p>
+   *
+   */
+  @Path("/{beerId}")
+  @DELETE
+  RestResponse<Void> deleteBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Returns all of the beers in the database.
+   * </p>
+   *
+   */
+  @GET
+  @Produces("application/json")
+  RestResponse<List<Beer>> listAllBeers();
+
+  /**
+   * <p>
+   * Adds a single beer to the dataset.
+   * </p>
+   *
+   */
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBeer(@NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -1,0 +1,96 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import java.util.Set;
+import org.example.api.beans.Beer;
+import org.example.api.beans.Brewery;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/breweries")
+public interface BreweriesResource {
+  /**
+   * <p>
+   * Returns a list of all the breweries.
+   * </p>
+   *
+   */
+  @GET
+  @Produces("application/json")
+  RestResponse<Set<Brewery>> listAllBreweries();
+
+  /**
+   * <p>
+   * Adds a single brewery to the data set.
+   * </p>
+   *
+   */
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBrewery(@NotNull Brewery data);
+
+  /**
+   * <p>
+   * Returns full information about a single brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}")
+  @GET
+  @Produces("application/json")
+  RestResponse<Brewery> getBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Updates information about a single brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}")
+  @PUT
+  @Consumes("application/json")
+  RestResponse<Void> updateBrewery(@PathParam("breweryId") int breweryId, @NotNull Brewery data);
+
+  /**
+   * <p>
+   * Removes a single brewery from the data set.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}")
+  @DELETE
+  RestResponse<Void> deleteBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Returns all of the beers made by the brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}/beers")
+  @GET
+  @Produces("application/json")
+  RestResponse<List<Beer>> listBreweryBeers(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Adds a single beer to the data set for this brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}/beers")
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBeerToBrewery(@PathParam("breweryId") int breweryId, @NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
@@ -1,0 +1,13 @@
+package org.example.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * The JAX-RS application.
+ */
+@ApplicationScoped
+@ApplicationPath("/")
+public class JaxRsApplication extends Application {
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Beer.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Beer.java
@@ -1,0 +1,204 @@
+
+package org.example.api.beans;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Beer
+ * <p>
+ * The root of the Beer type's schema.
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "abv",
+    "ibu",
+    "name",
+    "style",
+    "breweryId",
+    "ounces"
+})
+@Generated("jsonschema2pojo")
+public class Beer {
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("id")
+    private Integer id;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("abv")
+    private Double abv;
+    @JsonProperty("ibu")
+    private Double ibu;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("name")
+    private String name;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("style")
+    private String style;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("breweryId")
+    private Integer breweryId;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("ounces")
+    private Double ounces;
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("abv")
+    public Double getAbv() {
+        return abv;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("abv")
+    public void setAbv(Double abv) {
+        this.abv = abv;
+    }
+
+    @JsonProperty("ibu")
+    public Double getIbu() {
+        return ibu;
+    }
+
+    @JsonProperty("ibu")
+    public void setIbu(Double ibu) {
+        this.ibu = ibu;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("style")
+    public String getStyle() {
+        return style;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("style")
+    public void setStyle(String style) {
+        this.style = style;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("breweryId")
+    public Integer getBreweryId() {
+        return breweryId;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("breweryId")
+    public void setBreweryId(Integer breweryId) {
+        this.breweryId = breweryId;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("ounces")
+    public Double getOunces() {
+        return ounces;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("ounces")
+    public void setOunces(Double ounces) {
+        this.ounces = ounces;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
@@ -1,0 +1,101 @@
+
+package org.example.api.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Brewery
+ * <p>
+ * The root of the Brewery type's schema.
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "name",
+    "city",
+    "state",
+    "sampleBeers"
+})
+@Generated("jsonschema2pojo")
+public class Brewery {
+
+    @JsonProperty("id")
+    private Integer id;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("city")
+    private String city;
+    @JsonProperty("state")
+    private String state;
+    /**
+     *
+     */
+    @JsonProperty("sampleBeers")
+    @JsonPropertyDescription("")
+    private List<Beer> sampleBeers = new ArrayList<Beer>();
+
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("city")
+    public String getCity() {
+        return city;
+    }
+
+    @JsonProperty("city")
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    @JsonProperty("state")
+    public String getState() {
+        return state;
+    }
+
+    @JsonProperty("state")
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
+     *
+     */
+    @JsonProperty("sampleBeers")
+    public List<Beer> getSampleBeers() {
+        return sampleBeers;
+    }
+
+    /**
+     *
+     */
+    @JsonProperty("sampleBeers")
+    public void setSampleBeers(List<Beer> sampleBeers) {
+        this.sampleBeers = sampleBeers;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/resources/META-INF/openapi.json
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/resources/META-INF/openapi.json
@@ -1,0 +1,381 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Beer API",
+        "version": "1.0.0",
+        "description": "The official Beer API!  Search for both beers and breweries.",
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    },
+    "paths": {
+        "/beers/{beerId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Beer"
+                                }
+                            }
+                        },
+                        "description": "A single beer."
+                    }
+                },
+                "operationId": "getBeer",
+                "summary": "Get Info About a Beer",
+                "description": "Returns full information about a single beer."
+            },
+            "put": {
+                "requestBody": {
+                    "description": "Updated beer information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "The beer was updated."
+                    }
+                },
+                "operationId": "updateBeer",
+                "summary": "Update a Beer",
+                "description": "Updates information about a single beer."
+            },
+            "delete": {
+                "responses": {
+                    "204": {
+                        "description": "The beer was deleted."
+                    }
+                },
+                "operationId": "deleteBeer",
+                "summary": "Delete a Beer",
+                "description": "Removes a single beer from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "beerId",
+                    "description": "Unique ID of a beer.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true,
+                    "x-codegen-annotations": [
+                        "@jakarta.validation.constraints.Positive(message = \"The beerId must be a natural number!\")"
+                    ]
+                }
+            ]
+        },
+        "/breweries": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Brewery"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Returns all breweries."
+                    }
+                },
+                "operationId": "listAllBreweries",
+                "summary": "Get All Breweries",
+                "description": "Returns a list of all the breweries."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "New brewery information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Brewery successfully added."
+                    }
+                },
+                "operationId": "addBrewery",
+                "summary": "Add a Brewery",
+                "description": "Adds a single brewery to the data set."
+            }
+        },
+        "/breweries/{breweryId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brewery"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "getBrewery",
+                "summary": "Gets Info About a Brewery",
+                "description": "Returns full information about a single brewery."
+            },
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {}
+                },
+                "operationId": "updateBrewery",
+                "summary": "Update a Brewery",
+                "description": "Updates information about a single brewery."
+            },
+            "delete": {
+                "responses": {
+                    "204": {}
+                },
+                "operationId": "deleteBrewery",
+                "summary": "Delete a Brewery",
+                "description": "Removes a single brewery from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "description": "Unique ID of a brewery.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/breweries/{breweryId}/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "listBreweryBeers",
+                "summary": "Gets Beers From a Brewery",
+                "description": "Returns all of the beers made by the brewery."
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {}
+                },
+                "operationId": "addBeerToBrewery",
+                "summary": "Adds a Beer to the Brewery",
+                "description": "Adds a single beer to the data set for this brewery.",
+                "x-codegen-async": false
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "All the beers!"
+                    }
+                },
+                "operationId": "listAllBeers",
+                "summary": "Get All Beers",
+                "description": "Returns all of the beers in the database."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "The beer to add to the data set.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "The beer was added."
+                    }
+                },
+                "operationId": "addBeer",
+                "summary": "Add a Beer",
+                "description": "Adds a single beer to the dataset."
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Beer": {
+                "title": "Root Type for Beer",
+                "description": "The root of the Beer type's schema.",
+                "required": [
+                    "abv",
+                    "id",
+                    "name",
+                    "style",
+                    "breweryId",
+                    "ounces"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "abv": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "ibu": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "style": {
+                        "type": "string"
+                    },
+                    "breweryId": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "ounces": {
+                        "format": "double",
+                        "type": "number"
+                    }
+                }
+            },
+            "Brewery": {
+                "title": "Root Type for Brewery",
+                "description": "The root of the Brewery type's schema.",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "city": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "sampleBeers": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Beer"
+                        }
+                    }
+                },
+                "example": {
+                    "id": 92,
+                    "name": "some text",
+                    "city": "some text",
+                    "state": "some text",
+                    "sampleBeers": [
+                        {
+                            "id": 16,
+                            "abv": 47.81,
+                            "ibu": 57.48,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 44,
+                            "ounces": 72.8
+                        },
+                        {
+                            "id": 72,
+                            "abv": 59.7,
+                            "ibu": 47.07,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 99,
+                            "ounces": 34.92
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "beer",
+            "description": ""
+        },
+        {
+            "name": "brewery",
+            "description": ""
+        }
+    ]
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/pom.xml
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.example.api</groupId>
+    <artifactId>generated-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Beer API</name>
+    <description>The official Beer API!  Search for both beers and breweries.</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.jakarta.ws.rs-jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-jakarta.ws.rs-api>
+        <version.jakarta.validation-jakarta.validation-api>3.0.2</version.jakarta.validation-jakarta.validation-api>
+        <version.jakarta.enterprise-jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise-jakarta.enterprise.cdi-api>
+        <version.com.fasterxml.jackson>2.15.1</version.com.fasterxml.jackson>
+    </properties>
+
+    <dependencies>
+        <!-- Third Party Dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${version.com.fasterxml.jackson}</version>
+        </dependency>
+        <!-- Specification Dependencies -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${version.jakarta.ws.rs-jakarta.ws.rs-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${version.jakarta.enterprise-jakarta.enterprise.cdi-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${version.jakarta.validation-jakarta.validation-api}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -1,0 +1,77 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.example.api.beans.Beer;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/beers")
+public interface BeersResource {
+  /**
+   * <p>
+   * Returns full information about a single beer.
+   * </p>
+   *
+   */
+  @Path("/{beerId}")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<Beer>> getBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Updates information about a single beer.
+   * </p>
+   *
+   */
+  @Path("/{beerId}")
+  @PUT
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> updateBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId, @NotNull Beer data);
+
+  /**
+   * <p>
+   * Removes a single beer from the data set.
+   * </p>
+   *
+   */
+  @Path("/{beerId}")
+  @DELETE
+  CompletionStage<RestResponse<Void>> deleteBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Returns all of the beers in the database.
+   * </p>
+   *
+   */
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<List<Beer>>> listAllBeers();
+
+  /**
+   * <p>
+   * Adds a single beer to the dataset.
+   * </p>
+   *
+   */
+  @POST
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> addBeer(@NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -1,0 +1,97 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import org.example.api.beans.Beer;
+import org.example.api.beans.Brewery;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/breweries")
+public interface BreweriesResource {
+  /**
+   * <p>
+   * Returns a list of all the breweries.
+   * </p>
+   *
+   */
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<Set<Brewery>>> listAllBreweries();
+
+  /**
+   * <p>
+   * Adds a single brewery to the data set.
+   * </p>
+   *
+   */
+  @POST
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> addBrewery(@NotNull Brewery data);
+
+  /**
+   * <p>
+   * Returns full information about a single brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<Brewery>> getBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Updates information about a single brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}")
+  @PUT
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> updateBrewery(@PathParam("breweryId") int breweryId, @NotNull Brewery data);
+
+  /**
+   * <p>
+   * Removes a single brewery from the data set.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}")
+  @DELETE
+  CompletionStage<RestResponse<Void>> deleteBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Returns all of the beers made by the brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}/beers")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<List<Beer>>> listBreweryBeers(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Adds a single beer to the data set for this brewery.
+   * </p>
+   *
+   */
+  @Path("/{breweryId}/beers")
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBeerToBrewery(@PathParam("breweryId") int breweryId, @NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
@@ -1,0 +1,13 @@
+package org.example.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * The JAX-RS application.
+ */
+@ApplicationScoped
+@ApplicationPath("/")
+public class JaxRsApplication extends Application {
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Beer.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Beer.java
@@ -1,0 +1,204 @@
+
+package org.example.api.beans;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Beer
+ * <p>
+ * The root of the Beer type's schema.
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "abv",
+    "ibu",
+    "name",
+    "style",
+    "breweryId",
+    "ounces"
+})
+@Generated("jsonschema2pojo")
+public class Beer {
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("id")
+    private Integer id;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("abv")
+    private Double abv;
+    @JsonProperty("ibu")
+    private Double ibu;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("name")
+    private String name;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("style")
+    private String style;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("breweryId")
+    private Integer breweryId;
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("ounces")
+    private Double ounces;
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("abv")
+    public Double getAbv() {
+        return abv;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("abv")
+    public void setAbv(Double abv) {
+        this.abv = abv;
+    }
+
+    @JsonProperty("ibu")
+    public Double getIbu() {
+        return ibu;
+    }
+
+    @JsonProperty("ibu")
+    public void setIbu(Double ibu) {
+        this.ibu = ibu;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("style")
+    public String getStyle() {
+        return style;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("style")
+    public void setStyle(String style) {
+        this.style = style;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("breweryId")
+    public Integer getBreweryId() {
+        return breweryId;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("breweryId")
+    public void setBreweryId(Integer breweryId) {
+        this.breweryId = breweryId;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("ounces")
+    public Double getOunces() {
+        return ounces;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("ounces")
+    public void setOunces(Double ounces) {
+        this.ounces = ounces;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
@@ -1,0 +1,101 @@
+
+package org.example.api.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Brewery
+ * <p>
+ * The root of the Brewery type's schema.
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "name",
+    "city",
+    "state",
+    "sampleBeers"
+})
+@Generated("jsonschema2pojo")
+public class Brewery {
+
+    @JsonProperty("id")
+    private Integer id;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("city")
+    private String city;
+    @JsonProperty("state")
+    private String state;
+    /**
+     *
+     */
+    @JsonProperty("sampleBeers")
+    @JsonPropertyDescription("")
+    private List<Beer> sampleBeers = new ArrayList<Beer>();
+
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("city")
+    public String getCity() {
+        return city;
+    }
+
+    @JsonProperty("city")
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    @JsonProperty("state")
+    public String getState() {
+        return state;
+    }
+
+    @JsonProperty("state")
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
+     *
+     */
+    @JsonProperty("sampleBeers")
+    public List<Beer> getSampleBeers() {
+        return sampleBeers;
+    }
+
+    /**
+     *
+     */
+    @JsonProperty("sampleBeers")
+    public void setSampleBeers(List<Beer> sampleBeers) {
+        this.sampleBeers = sampleBeers;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/resources/META-INF/openapi.json
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/resources/META-INF/openapi.json
@@ -1,0 +1,381 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Beer API",
+        "version": "1.0.0",
+        "description": "The official Beer API!  Search for both beers and breweries.",
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    },
+    "paths": {
+        "/beers/{beerId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Beer"
+                                }
+                            }
+                        },
+                        "description": "A single beer."
+                    }
+                },
+                "operationId": "getBeer",
+                "summary": "Get Info About a Beer",
+                "description": "Returns full information about a single beer."
+            },
+            "put": {
+                "requestBody": {
+                    "description": "Updated beer information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "The beer was updated."
+                    }
+                },
+                "operationId": "updateBeer",
+                "summary": "Update a Beer",
+                "description": "Updates information about a single beer."
+            },
+            "delete": {
+                "responses": {
+                    "204": {
+                        "description": "The beer was deleted."
+                    }
+                },
+                "operationId": "deleteBeer",
+                "summary": "Delete a Beer",
+                "description": "Removes a single beer from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "beerId",
+                    "description": "Unique ID of a beer.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true,
+                    "x-codegen-annotations": [
+                        "@jakarta.validation.constraints.Positive(message = \"The beerId must be a natural number!\")"
+                    ]
+                }
+            ]
+        },
+        "/breweries": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Brewery"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Returns all breweries."
+                    }
+                },
+                "operationId": "listAllBreweries",
+                "summary": "Get All Breweries",
+                "description": "Returns a list of all the breweries."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "New brewery information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Brewery successfully added."
+                    }
+                },
+                "operationId": "addBrewery",
+                "summary": "Add a Brewery",
+                "description": "Adds a single brewery to the data set."
+            }
+        },
+        "/breweries/{breweryId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brewery"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "getBrewery",
+                "summary": "Gets Info About a Brewery",
+                "description": "Returns full information about a single brewery."
+            },
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {}
+                },
+                "operationId": "updateBrewery",
+                "summary": "Update a Brewery",
+                "description": "Updates information about a single brewery."
+            },
+            "delete": {
+                "responses": {
+                    "204": {}
+                },
+                "operationId": "deleteBrewery",
+                "summary": "Delete a Brewery",
+                "description": "Removes a single brewery from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "description": "Unique ID of a brewery.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/breweries/{breweryId}/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "listBreweryBeers",
+                "summary": "Gets Beers From a Brewery",
+                "description": "Returns all of the beers made by the brewery."
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {}
+                },
+                "operationId": "addBeerToBrewery",
+                "summary": "Adds a Beer to the Brewery",
+                "description": "Adds a single beer to the data set for this brewery.",
+                "x-codegen-async": false
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "All the beers!"
+                    }
+                },
+                "operationId": "listAllBeers",
+                "summary": "Get All Beers",
+                "description": "Returns all of the beers in the database."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "The beer to add to the data set.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "The beer was added."
+                    }
+                },
+                "operationId": "addBeer",
+                "summary": "Add a Beer",
+                "description": "Adds a single beer to the dataset."
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Beer": {
+                "title": "Root Type for Beer",
+                "description": "The root of the Beer type's schema.",
+                "required": [
+                    "abv",
+                    "id",
+                    "name",
+                    "style",
+                    "breweryId",
+                    "ounces"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "abv": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "ibu": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "style": {
+                        "type": "string"
+                    },
+                    "breweryId": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "ounces": {
+                        "format": "double",
+                        "type": "number"
+                    }
+                }
+            },
+            "Brewery": {
+                "title": "Root Type for Brewery",
+                "description": "The root of the Brewery type's schema.",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "city": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "sampleBeers": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Beer"
+                        }
+                    }
+                },
+                "example": {
+                    "id": 92,
+                    "name": "some text",
+                    "city": "some text",
+                    "state": "some text",
+                    "sampleBeers": [
+                        {
+                            "id": 16,
+                            "abv": 47.81,
+                            "ibu": 57.48,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 44,
+                            "ounces": 72.8
+                        },
+                        {
+                            "id": 72,
+                            "abv": 59.7,
+                            "ibu": 47.07,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 99,
+                            "ounces": 34.92
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "beer",
+            "description": ""
+        },
+        {
+            "name": "brewery",
+            "description": ""
+        }
+    ]
+}


### PR DESCRIPTION
JAX RS code generator actully doesn't take into consideration response status. The problem is that if the methods of API's interface return POJO, the assumed response code is 200. To define alternative status, either all the methods would have to return `jakarta.ws.rs.Response` which is not very useful or the impelemntation of JAX RS has a generic class which represents response with option to specify status or headers. In RestEasy such class is `org.jboss.resteasy.reactive.RestResponse`.

This PR is adding configuration to define such generic class name to use it instead of model class directly.