### PR TITLE
Upgrade apicurio-data-models to version 2.2.1

### DIFF
--- a/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/OpenApi2CodegenVisitor.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/jaxrs/OpenApi2CodegenVisitor.java
@@ -243,7 +243,7 @@ public class OpenApi2CodegenVisitor extends TraversingOpenApi31VisitorAdapter {
             .flatMap(Stream::findFirst)
             .map(OpenApi31MediaType::getSchema)
             .map(OpenApi31Schema.class::cast)
-            .or(() -> Optional.ofNullable((OpenApi31Schema) node.getSchema()))
+            .or(() -> Optional.ofNullable((OpenApi31Schema) ((OpenApi31Parameter) node).getSchema()))
             .ifPresent(schema -> {
                 setSchemaProperties(cgArgument, schema);
                 cgArgument.setTypeSignature(createSignature(schema));

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.jakarta.ws.rs-jakarta.ws.rs-api>4.0.0</version.jakarta.ws.rs-jakarta.ws.rs-api>
         <version.junit>4.13.2</version.junit>
         <version.org.slf4j>2.0.13</version.org.slf4j>
-        <version.apicurio-data-models>2.0.4</version.apicurio-data-models>
+        <version.apicurio-data-models>2.2.1</version.apicurio-data-models>
         <version.commons-lang>2.6</version.commons-lang>
         <version.commons-lang3>3.14.0</version.commons-lang3>
         <version.commons-codec>1.17.0</version.commons-codec>


### PR DESCRIPTION
Replaces https://github.com/Apicurio/apicurio-codegen/pull/313