### PR TITLE
Sanitize bean name

### DIFF
--- a/core/src/main/java/io/apicurio/hub/api/codegen/util/CodegenUtil.java
+++ b/core/src/main/java/io/apicurio/hub/api/codegen/util/CodegenUtil.java
@@ -37,7 +37,7 @@ import io.apicurio.hub.api.codegen.JaxRsProjectSettings;
 
 public final class CodegenUtil {
 
-    public static final String schemaToPackageName(OpenApiSchema schema, String defaultPackage) {
+    public static String schemaToPackageName(OpenApiSchema schema, String defaultPackage) {
         String pname = defaultPackage;
 
         if (schema != null) {
@@ -53,8 +53,8 @@ public final class CodegenUtil {
         return pname;
     }
 
-    public static final String schemaRefToFQCN(JaxRsProjectSettings settings, Document document,
-            String schemaRef, String defaultPackage) {
+    public static String schemaRefToFQCN(JaxRsProjectSettings settings, Document document, String schemaRef,
+          String defaultPackage) {
         String cname = "GeneratedClass_" + System.currentTimeMillis();
         String pname = defaultPackage;
         if (schemaRef.startsWith("#/components/schemas/")) {
@@ -69,8 +69,12 @@ public final class CodegenUtil {
         return pname + "." + StringUtils.capitalize(cname);
     }
 
-    public static final String toClassName(JaxRsProjectSettings settings, String name) {
-        return settings.getClassNamePrefix() + StringUtils.capitalize(name) + settings.getClassNameSuffix();
+    public static String toClassName(JaxRsProjectSettings settings, String name) {
+        return settings.getClassNamePrefix() + StringUtils.capitalize(sanitizeClassName(name)) + settings.getClassNameSuffix();
+    }
+
+    public static String sanitizeClassName(final String name) {
+        return name.replaceAll("[^a-zA-Z0-9]", "");
     }
 
     public static JsonNode getExtension(Extensible node, String name) {

--- a/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2JaxRsTest.java
+++ b/core/src/test/java/io/apicurio/hub/api/codegen/OpenApi2JaxRsTest.java
@@ -204,6 +204,11 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
         doFullTest("OpenApi2JaxRsTest/constrained-parameters.json", UpdateOnly.no, Reactive.no, "_expected-constrained-parameters/generated-api", false);
     }
 
+        @Test
+    public void testSchemaWithDash() throws IOException {
+        doFullTest("OpenApi2JaxRsTest/schema-with-dash.json", UpdateOnly.no, Reactive.no, "_expected-schema-with-dash/generated-api", false);
+    }
+
     /**
      * Shared test method.
      * @param apiDef

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/pom.xml
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.example.api</groupId>
+    <artifactId>generated-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Example API</name>
+    <description>A generated project with JAX-RS and Microprofile OpenAPI features enabled.</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.jakarta.ws.rs-jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-jakarta.ws.rs-api>
+        <version.jakarta.validation-jakarta.validation-api>3.0.2</version.jakarta.validation-jakarta.validation-api>
+        <version.jakarta.enterprise-jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise-jakarta.enterprise.cdi-api>
+        <version.com.fasterxml.jackson>2.15.1</version.com.fasterxml.jackson>
+    </properties>
+
+    <dependencies>
+        <!-- Third Party Dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${version.com.fasterxml.jackson}</version>
+        </dependency>
+        <!-- Specification Dependencies -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${version.jakarta.ws.rs-jakarta.ws.rs-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${version.jakarta.enterprise-jakarta.enterprise.cdi-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${version.jakarta.validation-jakarta.validation-api}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/JaxRsApplication.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/JaxRsApplication.java
@@ -1,0 +1,13 @@
+package org.example.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * The JAX-RS application.
+ */
+@ApplicationScoped
+@ApplicationPath("/")
+public class JaxRsApplication extends Application {
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/UserResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/UserResource.java
@@ -1,0 +1,46 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.example.api.beans.User;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/user")
+public interface UserResource {
+  /**
+   * 
+   */
+  @Path("/{username}")
+  @GET
+  @Produces({"application/xml", "application/json"})
+  User getUserByName(@PathParam("username") String username);
+
+  /**
+   * <p>
+   * This can only be done by the logged in user.
+   * </p>
+   * 
+   */
+  @Path("/{username}")
+  @PUT
+  @Consumes({"application/xml", "application/json", "application/x-www-form-urlencoded"})
+  void updateUser(@PathParam("username") String username, @NotNull User data);
+
+  /**
+   * <p>
+   * This can only be done by the logged in user.
+   * </p>
+   * 
+   */
+  @Path("/{username}")
+  @DELETE
+  void deleteUser(@PathParam("username") String username);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/beans/SomeObject.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/beans/SomeObject.java
@@ -1,0 +1,31 @@
+
+package org.example.api.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "someList"
+})
+@Generated("jsonschema2pojo")
+public class SomeObject {
+
+    @JsonProperty("someList")
+    private List<SomeOtherObject> someList = new ArrayList<SomeOtherObject>();
+
+    @JsonProperty("someList")
+    public List<SomeOtherObject> getSomeList() {
+        return someList;
+    }
+
+    @JsonProperty("someList")
+    public void setSomeList(List<SomeOtherObject> someList) {
+        this.someList = someList;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/beans/SomeOtherObject.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/java/org/example/api/beans/SomeOtherObject.java
@@ -1,0 +1,29 @@
+
+package org.example.api.beans;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "exampleProperty"
+})
+@Generated("jsonschema2pojo")
+public class SomeOtherObject {
+
+    @JsonProperty("exampleProperty")
+    private String exampleProperty;
+
+    @JsonProperty("exampleProperty")
+    public String getExampleProperty() {
+        return exampleProperty;
+    }
+
+    @JsonProperty("exampleProperty")
+    public void setExampleProperty(String exampleProperty) {
+        this.exampleProperty = exampleProperty;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/resources/META-INF/openapi.json
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-schema-with-dash/generated-api/src/main/resources/META-INF/openapi.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Example API",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeObject": {
+        "type": "object",
+        "properties": {
+          "someList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Some-Other-Object"
+            }
+          }
+        }
+      },
+      "Some-Other-Object": {
+        "type": "object",
+        "properties": {
+          "exampleProperty": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/schema-with-dash.json
+++ b/core/src/test/resources/OpenApi2JaxRsTest/schema-with-dash.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Example API",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeObject": {
+        "type": "object",
+        "properties": {
+          "someList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Some-Other-Object"
+            }
+          }
+        }
+      },
+      "Some-Other-Object": {
+        "type": "object",
+        "properties": {
+          "exampleProperty": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Context

Actually when the schema has a with hyphen by example:

```json
{
  "openapi": "3.0.3",
  "info": {
    "title": "Example API",
    "version": "1.0.0"
  },
  "paths": {},
  "components": {
    "schemas": {
      "SomeObject": {
        "type": "object",
        "properties": {
          "someList": {
            "type": "array",
            "items": {
              "$ref": "#/components/schemas/Some-Other-Object"
            }
          }
        }
      },
      "Some-Other-Object": {
        "type": "object",
        "properties": {
          "exampleProperty": {
            "type": "string"
          }
        }
      }
    }
  }
}
```

There is no way to compile the generated Java class.

See: https://github.com/quarkiverse/quarkus-openapi-generator/issues/674

## Changes

This pull request adds a method that sanitize the schema name, while generating it.