### PR TITLE
broken link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://www.apicur.io/codegen/docs/
 
 repo_name: apicurio/apicurio-codegen
 repo_url: https://github.com/apicurio/apicurio-codegen
+use_directory_urls: false
 
 theme:
   name: material


### PR DESCRIPTION
link at bottom of https://www.apicur.io/codegen/docs/getting-started/ doesn't work.
Alternative is to change links like that to  `[User Guide](../user-guide/)`