### PR TITLE
Add configurable generic return type wrapper for JAX-RS codegen

### DIFF
--- a/core/src/main/java/io/apitomy/hub/api/codegen/JaxRsProjectSettings.java
+++ b/core/src/main/java/io/apitomy/hub/api/codegen/JaxRsProjectSettings.java
@@ -33,6 +33,7 @@ public class JaxRsProjectSettings {
     public String javaPackage = "org.example.api";
     public String classNamePrefix = "";
     public String classNameSuffix = "";
+    public String genericReturnType = null;
     protected boolean useJsr303 = false;
     protected boolean generateBuilders = false;
     protected boolean generatesOpenApi = true;
@@ -170,6 +171,14 @@ public class JaxRsProjectSettings {
 
     public void setClassNameSuffix(String classNameSuffix) {
         this.classNameSuffix = classNameSuffix;
+    }
+
+    public String getGenericReturnType() {
+        return genericReturnType;
+    }
+
+    public void setGenericReturnType(String genericReturnType) {
+        this.genericReturnType = genericReturnType;
     }
 
     public boolean isUseJsr303() {

--- a/core/src/main/java/io/apitomy/hub/api/codegen/OpenApi2JaxRs.java
+++ b/core/src/main/java/io/apitomy/hub/api/codegen/OpenApi2JaxRs.java
@@ -623,16 +623,19 @@ public class OpenApi2JaxRs {
                 reactive = Boolean.TRUE.equals(methodInfo.getAsync());
             }
 
+            final String genericReturnType = getSettings().getGenericReturnType();
+
             Optional.ofNullable(methodInfo.getReturn())
                 .map(rt -> generateTypeName(
                         rt,
                         true,
                         String.format("%s.ws.rs.core.Response", topLevelPackage)))
+                .map(rt -> generateGenericReturnType(rt, genericReturnType))
                 .map(rt -> reactive ? generateReactiveTypeName(rt) : rt)
                 .map(Object::toString)
                 .ifPresentOrElse(
                         operationMethod::setReturnType,
-                        () -> setVoidReturnType(operationMethod, reactive));
+                        () -> setVoidReturnType(operationMethod, reactive, genericReturnType));
 
             Optional.ofNullable(methodInfo.getArguments())
                 .map(Collection::stream)
@@ -829,12 +832,18 @@ public class OpenApi2JaxRs {
         return parseType(defaultType);
     }
 
-    protected void setVoidReturnType(MethodSource<JavaInterfaceSource> operationMethod, boolean reactive) {
-        if (reactive) {
-            operationMethod.setReturnType(generateReactiveTypeName(VOID));
-        } else {
-            operationMethod.setReturnTypeVoid();
-        }
+    protected void setVoidReturnType(MethodSource<JavaInterfaceSource> operationMethod, boolean reactive,
+            String genericReturnType) {
+        Optional.of(VOID)
+            .map(type -> generateGenericReturnType(type, genericReturnType))
+            .map(type -> reactive ? generateReactiveTypeName(type) : type)
+            .ifPresent(type -> {
+                if (type != VOID) {
+                    operationMethod.setReturnType(type);
+                } else {
+                    operationMethod.setReturnTypeVoid();
+                }
+            });
     }
 
     /**
@@ -846,6 +855,19 @@ public class OpenApi2JaxRs {
     protected Type<?> generateReactiveTypeName(Type<?> coreType) {
         Type<?> currentType = Types.isPrimitive(coreType.toString()) ? getType(coreType) : coreType;
         return parseType("java.util.concurrent.CompletionStage<" + currentType + ">");
+    }
+
+    /**
+     * Wraps the given type in a generic return type wrapper, if configured.
+     *
+     * @param coreType
+     * @param genericReturnType
+     */
+    protected Type<?> generateGenericReturnType(Type<?> coreType, String genericReturnType) {
+        if (genericReturnType == null) {
+            return coreType;
+        }
+        return parseType(String.format("%s<%s>", genericReturnType, coreType.toString()));
     }
 
     public Type<?> getType(final Type<?> coreType) {

--- a/core/src/test/java/io/apitomy/hub/api/codegen/OpenApi2JaxRsTest.java
+++ b/core/src/test/java/io/apitomy/hub/api/codegen/OpenApi2JaxRsTest.java
@@ -105,6 +105,26 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
         doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.yes, "_expected-reactive-full/generated-api", false);
     }
 
+    /**
+     * Test method for {@link io.apitomy.hub.api.codegen.OpenApi2JaxRs#generate()}.
+     */
+    @Test
+    public void testGenerateFullGenericReturnType() throws IOException {
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.no, false,
+                "_expected-genericReturnType-full/generated-api", "", "",
+                "org.jboss.resteasy.reactive.RestResponse", false);
+    }
+
+    /**
+     * Test method for {@link io.apitomy.hub.api.codegen.OpenApi2JaxRs#generate()}.
+     */
+    @Test
+    public void testGenerateFullGenericReturnTypeReactive() throws IOException {
+        doFullTest("OpenApi2JaxRsTest/beer-api.json", UpdateOnly.no, Reactive.yes, false,
+                "_expected-genericReturnTypeReactive-full/generated-api", "", "",
+                "org.jboss.resteasy.reactive.RestResponse", false);
+    }
+
     @Test
     public void testGenerateFullReactiveWithPrimitives() throws IOException {
         doFullTest("OpenApi2JaxRsTest/reactive-with-primitives.json", UpdateOnly.no, Reactive.yes, "_expected-reactive-with-primitives/generated-api", false);
@@ -307,31 +327,25 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
 
     /**
      * Shared test method.
-     * @param apiDef
-     * @param updateOnly
-     * @param reactive
-     * @param expectedFilesPath
-     * @param debug
-     * @throws IOException
      */
     private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, String expectedFilesPath, boolean debug) throws IOException {
-        doFullTest(apiDef, updateOnly, reactive, false, expectedFilesPath, "", "", debug);
+        doFullTest(apiDef, updateOnly, reactive, false, expectedFilesPath, "", "", null, debug);
     }
 
     /**
      * Shared test method.
-     * @param apiDef
-     * @param updateOnly
-     * @param reactive
-     * @param generateCLiGenCI
-     * @param expectedFilesPath
-     * @param namePrefix
-     * @param nameSuffix
-     * @param debug
-     * @throws IOException
      */
     private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, boolean generateCLiGenCI,
             String expectedFilesPath, String namePrefix, String nameSuffix, boolean debug) throws IOException {
+        doFullTest(apiDef, updateOnly, reactive, generateCLiGenCI, expectedFilesPath, namePrefix, nameSuffix, null, debug);
+    }
+
+    /**
+     * Shared test method.
+     */
+    private void doFullTest(String apiDef, UpdateOnly updateOnly, Reactive reactive, boolean generateCLiGenCI,
+            String expectedFilesPath, String namePrefix, String nameSuffix, String genericReturnType,
+            boolean debug) throws IOException {
         JaxRsProjectSettings settings = new JaxRsProjectSettings();
         settings.codeOnly = false;
         settings.reactive = reactive == Reactive.yes;
@@ -341,6 +355,7 @@ public class OpenApi2JaxRsTest extends OpenApi2TestBase {
         settings.javaPackage = "org.example.api";
         settings.classNamePrefix = namePrefix;
         settings.classNameSuffix = nameSuffix;
+        settings.genericReturnType = genericReturnType;
 
         OpenApi2JaxRs generator = new OpenApi2JaxRs();
         generator.setSettings(settings);

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/pom.xml
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.example.api</groupId>
+    <artifactId>generated-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Beer API</name>
+    <description>The official Beer API!  Search for both beers and breweries.</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.jakarta.ws.rs-jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-jakarta.ws.rs-api>
+        <version.jakarta.validation-jakarta.validation-api>3.1.1</version.jakarta.validation-jakarta.validation-api>
+        <version.jakarta.enterprise-jakarta.enterprise.cdi-api>4.1.0</version.jakarta.enterprise-jakarta.enterprise.cdi-api>
+        <version.com.fasterxml.jackson.annotations>2.22</version.com.fasterxml.jackson.annotations>
+        <version.org.eclipse.microprofile.openapi-microprofile-openapi-api>4.1.1</version.org.eclipse.microprofile.openapi-microprofile-openapi-api>
+    </properties>
+
+    <dependencies>
+        <!-- Third Party Dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${version.com.fasterxml.jackson.annotations}</version>
+        </dependency>
+        <!-- Specification Dependencies -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${version.jakarta.ws.rs-jakarta.ws.rs-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${version.jakarta.enterprise-jakarta.enterprise.cdi-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${version.jakarta.validation-jakarta.validation-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+            <version>${version.org.eclipse.microprofile.openapi-microprofile-openapi-api}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -1,0 +1,82 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.example.api.beans.Beer;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/beers")
+public interface BeersResource {
+  /**
+   * <p>
+   * Returns full information about a single beer.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns full information about a single beer.", summary = "Get Info About a Beer", operationId = "getBeer")
+  @Path("/{beerId}")
+  @GET
+  @Produces("application/json")
+  RestResponse<Beer> getBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Updates information about a single beer.
+   * </p>
+   * 
+   */
+  @Operation(description = "Updates information about a single beer.", summary = "Update a Beer", operationId = "updateBeer")
+  @Path("/{beerId}")
+  @PUT
+  @Consumes("application/json")
+  RestResponse<Void> updateBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId, @NotNull Beer data);
+
+  /**
+   * <p>
+   * Removes a single beer from the data set.
+   * </p>
+   * 
+   */
+  @Operation(description = "Removes a single beer from the data set.", summary = "Delete a Beer", operationId = "deleteBeer")
+  @Path("/{beerId}")
+  @DELETE
+  RestResponse<Void> deleteBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Returns all of the beers in the database.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns all of the beers in the database.", summary = "Get All Beers", operationId = "listAllBeers")
+  @GET
+  @Produces("application/json")
+  RestResponse<List<Beer>> listAllBeers();
+
+  /**
+   * <p>
+   * Adds a single beer to the dataset.
+   * </p>
+   * 
+   */
+  @Operation(description = "Adds a single beer to the dataset.", summary = "Add a Beer", operationId = "addBeer")
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBeer(@NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -1,0 +1,104 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.example.api.beans.Beer;
+import org.example.api.beans.Brewery;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/breweries")
+public interface BreweriesResource {
+  /**
+   * <p>
+   * Returns a list of all the breweries.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns a list of all the breweries.", summary = "Get All Breweries", operationId = "listAllBreweries")
+  @GET
+  @Produces("application/json")
+  RestResponse<Set<Brewery>> listAllBreweries();
+
+  /**
+   * <p>
+   * Adds a single brewery to the data set.
+   * </p>
+   * 
+   */
+  @Operation(description = "Adds a single brewery to the data set.", summary = "Add a Brewery", operationId = "addBrewery")
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBrewery(@NotNull Brewery data);
+
+  /**
+   * <p>
+   * Returns full information about a single brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns full information about a single brewery.", summary = "Gets Info About a Brewery", operationId = "getBrewery")
+  @Path("/{breweryId}")
+  @GET
+  @Produces("application/json")
+  RestResponse<Brewery> getBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Updates information about a single brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Updates information about a single brewery.", summary = "Update a Brewery", operationId = "updateBrewery")
+  @Path("/{breweryId}")
+  @PUT
+  @Consumes("application/json")
+  RestResponse<Void> updateBrewery(@PathParam("breweryId") int breweryId, @NotNull Brewery data);
+
+  /**
+   * <p>
+   * Removes a single brewery from the data set.
+   * </p>
+   * 
+   */
+  @Operation(description = "Removes a single brewery from the data set.", summary = "Delete a Brewery", operationId = "deleteBrewery")
+  @Path("/{breweryId}")
+  @DELETE
+  RestResponse<Void> deleteBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Returns all of the beers made by the brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns all of the beers made by the brewery.", summary = "Gets Beers From a Brewery", operationId = "listBreweryBeers")
+  @Path("/{breweryId}/beers")
+  @GET
+  @Produces("application/json")
+  RestResponse<List<Beer>> listBreweryBeers(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Adds a single beer to the data set for this brewery.", summary = "Adds a Beer to the Brewery", operationId = "addBeerToBrewery")
+  @Path("/{breweryId}/beers")
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBeerToBrewery(@PathParam("breweryId") int breweryId, @NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
@@ -1,0 +1,13 @@
+package org.example.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * The JAX-RS application.
+ */
+@ApplicationScoped
+@ApplicationPath("/")
+public class JaxRsApplication extends Application {
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Beer.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Beer.java
@@ -1,0 +1,204 @@
+
+package org.example.api.beans;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Beer
+ * <p>
+ * The root of the Beer type's schema.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "abv",
+    "ibu",
+    "name",
+    "style",
+    "breweryId",
+    "ounces"
+})
+@Generated("jsonschema2pojo")
+public class Beer {
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("id")
+    private Integer id;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("abv")
+    private Double abv;
+    @JsonProperty("ibu")
+    private Double ibu;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("name")
+    private String name;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("style")
+    private String style;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("breweryId")
+    private Integer breweryId;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("ounces")
+    private Double ounces;
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("abv")
+    public Double getAbv() {
+        return abv;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("abv")
+    public void setAbv(Double abv) {
+        this.abv = abv;
+    }
+
+    @JsonProperty("ibu")
+    public Double getIbu() {
+        return ibu;
+    }
+
+    @JsonProperty("ibu")
+    public void setIbu(Double ibu) {
+        this.ibu = ibu;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("style")
+    public String getStyle() {
+        return style;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("style")
+    public void setStyle(String style) {
+        this.style = style;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("breweryId")
+    public Integer getBreweryId() {
+        return breweryId;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("breweryId")
+    public void setBreweryId(Integer breweryId) {
+        this.breweryId = breweryId;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("ounces")
+    public Double getOunces() {
+        return ounces;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("ounces")
+    public void setOunces(Double ounces) {
+        this.ounces = ounces;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
@@ -1,0 +1,101 @@
+
+package org.example.api.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Brewery
+ * <p>
+ * The root of the Brewery type's schema.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "name",
+    "city",
+    "state",
+    "sampleBeers"
+})
+@Generated("jsonschema2pojo")
+public class Brewery {
+
+    @JsonProperty("id")
+    private Integer id;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("city")
+    private String city;
+    @JsonProperty("state")
+    private String state;
+    /**
+     * 
+     */
+    @JsonProperty("sampleBeers")
+    @JsonPropertyDescription("")
+    private List<Beer> sampleBeers = new ArrayList<Beer>();
+
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("city")
+    public String getCity() {
+        return city;
+    }
+
+    @JsonProperty("city")
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    @JsonProperty("state")
+    public String getState() {
+        return state;
+    }
+
+    @JsonProperty("state")
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
+     * 
+     */
+    @JsonProperty("sampleBeers")
+    public List<Beer> getSampleBeers() {
+        return sampleBeers;
+    }
+
+    /**
+     * 
+     */
+    @JsonProperty("sampleBeers")
+    public void setSampleBeers(List<Beer> sampleBeers) {
+        this.sampleBeers = sampleBeers;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/resources/META-INF/openapi.json
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnType-full/generated-api/src/main/resources/META-INF/openapi.json
@@ -1,0 +1,381 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Beer API",
+        "version": "1.0.0",
+        "description": "The official Beer API!  Search for both beers and breweries.",
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    },
+    "paths": {
+        "/beers/{beerId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Beer"
+                                }
+                            }
+                        },
+                        "description": "A single beer."
+                    }
+                },
+                "operationId": "getBeer",
+                "summary": "Get Info About a Beer",
+                "description": "Returns full information about a single beer."
+            },
+            "put": {
+                "requestBody": {
+                    "description": "Updated beer information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "The beer was updated."
+                    }
+                },
+                "operationId": "updateBeer",
+                "summary": "Update a Beer",
+                "description": "Updates information about a single beer."
+            },
+            "delete": {
+                "responses": {
+                    "204": {
+                        "description": "The beer was deleted."
+                    }
+                },
+                "operationId": "deleteBeer",
+                "summary": "Delete a Beer",
+                "description": "Removes a single beer from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "beerId",
+                    "description": "Unique ID of a beer.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true,
+                    "x-codegen-annotations": [
+                        "@jakarta.validation.constraints.Positive(message = \"The beerId must be a natural number!\")"
+                    ]
+                }
+            ]
+        },
+        "/breweries": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Brewery"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Returns all breweries."
+                    }
+                },
+                "operationId": "listAllBreweries",
+                "summary": "Get All Breweries",
+                "description": "Returns a list of all the breweries."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "New brewery information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Brewery successfully added."
+                    }
+                },
+                "operationId": "addBrewery",
+                "summary": "Add a Brewery",
+                "description": "Adds a single brewery to the data set."
+            }
+        },
+        "/breweries/{breweryId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brewery"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "getBrewery",
+                "summary": "Gets Info About a Brewery",
+                "description": "Returns full information about a single brewery."
+            },
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {}
+                },
+                "operationId": "updateBrewery",
+                "summary": "Update a Brewery",
+                "description": "Updates information about a single brewery."
+            },
+            "delete": {
+                "responses": {
+                    "204": {}
+                },
+                "operationId": "deleteBrewery",
+                "summary": "Delete a Brewery",
+                "description": "Removes a single brewery from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "description": "Unique ID of a brewery.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/breweries/{breweryId}/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "listBreweryBeers",
+                "summary": "Gets Beers From a Brewery",
+                "description": "Returns all of the beers made by the brewery."
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {}
+                },
+                "operationId": "addBeerToBrewery",
+                "summary": "Adds a Beer to the Brewery",
+                "description": "Adds a single beer to the data set for this brewery.",
+                "x-codegen-async": false
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "All the beers!"
+                    }
+                },
+                "operationId": "listAllBeers",
+                "summary": "Get All Beers",
+                "description": "Returns all of the beers in the database."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "The beer to add to the data set.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "The beer was added."
+                    }
+                },
+                "operationId": "addBeer",
+                "summary": "Add a Beer",
+                "description": "Adds a single beer to the dataset."
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Beer": {
+                "title": "Root Type for Beer",
+                "description": "The root of the Beer type's schema.",
+                "required": [
+                    "abv",
+                    "id",
+                    "name",
+                    "style",
+                    "breweryId",
+                    "ounces"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "abv": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "ibu": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "style": {
+                        "type": "string"
+                    },
+                    "breweryId": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "ounces": {
+                        "format": "double",
+                        "type": "number"
+                    }
+                }
+            },
+            "Brewery": {
+                "title": "Root Type for Brewery",
+                "description": "The root of the Brewery type's schema.",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "city": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "sampleBeers": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Beer"
+                        }
+                    }
+                },
+                "example": {
+                    "id": 92,
+                    "name": "some text",
+                    "city": "some text",
+                    "state": "some text",
+                    "sampleBeers": [
+                        {
+                            "id": 16,
+                            "abv": 47.81,
+                            "ibu": 57.48,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 44,
+                            "ounces": 72.8
+                        },
+                        {
+                            "id": 72,
+                            "abv": 59.7,
+                            "ibu": 47.07,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 99,
+                            "ounces": 34.92
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "beer",
+            "description": ""
+        },
+        {
+            "name": "brewery",
+            "description": ""
+        }
+    ]
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/pom.xml
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.example.api</groupId>
+    <artifactId>generated-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Beer API</name>
+    <description>The official Beer API!  Search for both beers and breweries.</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.jakarta.ws.rs-jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-jakarta.ws.rs-api>
+        <version.jakarta.validation-jakarta.validation-api>3.1.1</version.jakarta.validation-jakarta.validation-api>
+        <version.jakarta.enterprise-jakarta.enterprise.cdi-api>4.1.0</version.jakarta.enterprise-jakarta.enterprise.cdi-api>
+        <version.com.fasterxml.jackson.annotations>2.22</version.com.fasterxml.jackson.annotations>
+        <version.org.eclipse.microprofile.openapi-microprofile-openapi-api>4.1.1</version.org.eclipse.microprofile.openapi-microprofile-openapi-api>
+    </properties>
+
+    <dependencies>
+        <!-- Third Party Dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${version.com.fasterxml.jackson.annotations}</version>
+        </dependency>
+        <!-- Specification Dependencies -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${version.jakarta.ws.rs-jakarta.ws.rs-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${version.jakarta.enterprise-jakarta.enterprise.cdi-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${version.jakarta.validation-jakarta.validation-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+            <version>${version.org.eclipse.microprofile.openapi-microprofile-openapi-api}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BeersResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BeersResource.java
@@ -1,0 +1,83 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.example.api.beans.Beer;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/beers")
+public interface BeersResource {
+  /**
+   * <p>
+   * Returns full information about a single beer.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns full information about a single beer.", summary = "Get Info About a Beer", operationId = "getBeer")
+  @Path("/{beerId}")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<Beer>> getBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Updates information about a single beer.
+   * </p>
+   * 
+   */
+  @Operation(description = "Updates information about a single beer.", summary = "Update a Beer", operationId = "updateBeer")
+  @Path("/{beerId}")
+  @PUT
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> updateBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId, @NotNull Beer data);
+
+  /**
+   * <p>
+   * Removes a single beer from the data set.
+   * </p>
+   * 
+   */
+  @Operation(description = "Removes a single beer from the data set.", summary = "Delete a Beer", operationId = "deleteBeer")
+  @Path("/{beerId}")
+  @DELETE
+  CompletionStage<RestResponse<Void>> deleteBeer(
+      @PathParam("beerId") @Positive(message = "The beerId must be a natural number!") int beerId);
+
+  /**
+   * <p>
+   * Returns all of the beers in the database.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns all of the beers in the database.", summary = "Get All Beers", operationId = "listAllBeers")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<List<Beer>>> listAllBeers();
+
+  /**
+   * <p>
+   * Adds a single beer to the dataset.
+   * </p>
+   * 
+   */
+  @Operation(description = "Adds a single beer to the dataset.", summary = "Add a Beer", operationId = "addBeer")
+  @POST
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> addBeer(@NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/BreweriesResource.java
@@ -1,0 +1,105 @@
+package org.example.api;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.example.api.beans.Beer;
+import org.example.api.beans.Brewery;
+import org.jboss.resteasy.reactive.RestResponse;
+
+/**
+ * A JAX-RS interface. An implementation of this interface must be provided.
+ */
+@Path("/breweries")
+public interface BreweriesResource {
+  /**
+   * <p>
+   * Returns a list of all the breweries.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns a list of all the breweries.", summary = "Get All Breweries", operationId = "listAllBreweries")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<Set<Brewery>>> listAllBreweries();
+
+  /**
+   * <p>
+   * Adds a single brewery to the data set.
+   * </p>
+   * 
+   */
+  @Operation(description = "Adds a single brewery to the data set.", summary = "Add a Brewery", operationId = "addBrewery")
+  @POST
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> addBrewery(@NotNull Brewery data);
+
+  /**
+   * <p>
+   * Returns full information about a single brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns full information about a single brewery.", summary = "Gets Info About a Brewery", operationId = "getBrewery")
+  @Path("/{breweryId}")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<Brewery>> getBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Updates information about a single brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Updates information about a single brewery.", summary = "Update a Brewery", operationId = "updateBrewery")
+  @Path("/{breweryId}")
+  @PUT
+  @Consumes("application/json")
+  CompletionStage<RestResponse<Void>> updateBrewery(@PathParam("breweryId") int breweryId, @NotNull Brewery data);
+
+  /**
+   * <p>
+   * Removes a single brewery from the data set.
+   * </p>
+   * 
+   */
+  @Operation(description = "Removes a single brewery from the data set.", summary = "Delete a Brewery", operationId = "deleteBrewery")
+  @Path("/{breweryId}")
+  @DELETE
+  CompletionStage<RestResponse<Void>> deleteBrewery(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Returns all of the beers made by the brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Returns all of the beers made by the brewery.", summary = "Gets Beers From a Brewery", operationId = "listBreweryBeers")
+  @Path("/{breweryId}/beers")
+  @GET
+  @Produces("application/json")
+  CompletionStage<RestResponse<List<Beer>>> listBreweryBeers(@PathParam("breweryId") int breweryId);
+
+  /**
+   * <p>
+   * Adds a single beer to the data set for this brewery.
+   * </p>
+   * 
+   */
+  @Operation(description = "Adds a single beer to the data set for this brewery.", summary = "Adds a Beer to the Brewery", operationId = "addBeerToBrewery")
+  @Path("/{breweryId}/beers")
+  @POST
+  @Consumes("application/json")
+  RestResponse<Void> addBeerToBrewery(@PathParam("breweryId") int breweryId, @NotNull Beer data);
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/JaxRsApplication.java
@@ -1,0 +1,13 @@
+package org.example.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * The JAX-RS application.
+ */
+@ApplicationScoped
+@ApplicationPath("/")
+public class JaxRsApplication extends Application {
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Beer.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Beer.java
@@ -1,0 +1,204 @@
+
+package org.example.api.beans;
+
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Beer
+ * <p>
+ * The root of the Beer type's schema.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "abv",
+    "ibu",
+    "name",
+    "style",
+    "breweryId",
+    "ounces"
+})
+@Generated("jsonschema2pojo")
+public class Beer {
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("id")
+    private Integer id;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("abv")
+    private Double abv;
+    @JsonProperty("ibu")
+    private Double ibu;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("name")
+    private String name;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("style")
+    private String style;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("breweryId")
+    private Integer breweryId;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("ounces")
+    private Double ounces;
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("abv")
+    public Double getAbv() {
+        return abv;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("abv")
+    public void setAbv(Double abv) {
+        this.abv = abv;
+    }
+
+    @JsonProperty("ibu")
+    public Double getIbu() {
+        return ibu;
+    }
+
+    @JsonProperty("ibu")
+    public void setIbu(Double ibu) {
+        this.ibu = ibu;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("style")
+    public String getStyle() {
+        return style;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("style")
+    public void setStyle(String style) {
+        this.style = style;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("breweryId")
+    public Integer getBreweryId() {
+        return breweryId;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("breweryId")
+    public void setBreweryId(Integer breweryId) {
+        this.breweryId = breweryId;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("ounces")
+    public Double getOunces() {
+        return ounces;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("ounces")
+    public void setOunces(Double ounces) {
+        this.ounces = ounces;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/java/org/example/api/beans/Brewery.java
@@ -1,0 +1,101 @@
+
+package org.example.api.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * Root Type for Brewery
+ * <p>
+ * The root of the Brewery type's schema.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "name",
+    "city",
+    "state",
+    "sampleBeers"
+})
+@Generated("jsonschema2pojo")
+public class Brewery {
+
+    @JsonProperty("id")
+    private Integer id;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("city")
+    private String city;
+    @JsonProperty("state")
+    private String state;
+    /**
+     * 
+     */
+    @JsonProperty("sampleBeers")
+    @JsonPropertyDescription("")
+    private List<Beer> sampleBeers = new ArrayList<Beer>();
+
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("city")
+    public String getCity() {
+        return city;
+    }
+
+    @JsonProperty("city")
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    @JsonProperty("state")
+    public String getState() {
+        return state;
+    }
+
+    @JsonProperty("state")
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
+     * 
+     */
+    @JsonProperty("sampleBeers")
+    public List<Beer> getSampleBeers() {
+        return sampleBeers;
+    }
+
+    /**
+     * 
+     */
+    @JsonProperty("sampleBeers")
+    public void setSampleBeers(List<Beer> sampleBeers) {
+        this.sampleBeers = sampleBeers;
+    }
+
+}

--- a/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/resources/META-INF/openapi.json
+++ b/core/src/test/resources/OpenApi2JaxRsTest/_expected-genericReturnTypeReactive-full/generated-api/src/main/resources/META-INF/openapi.json
@@ -1,0 +1,381 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Beer API",
+        "version": "1.0.0",
+        "description": "The official Beer API!  Search for both beers and breweries.",
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    },
+    "paths": {
+        "/beers/{beerId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Beer"
+                                }
+                            }
+                        },
+                        "description": "A single beer."
+                    }
+                },
+                "operationId": "getBeer",
+                "summary": "Get Info About a Beer",
+                "description": "Returns full information about a single beer."
+            },
+            "put": {
+                "requestBody": {
+                    "description": "Updated beer information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "The beer was updated."
+                    }
+                },
+                "operationId": "updateBeer",
+                "summary": "Update a Beer",
+                "description": "Updates information about a single beer."
+            },
+            "delete": {
+                "responses": {
+                    "204": {
+                        "description": "The beer was deleted."
+                    }
+                },
+                "operationId": "deleteBeer",
+                "summary": "Delete a Beer",
+                "description": "Removes a single beer from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "beerId",
+                    "description": "Unique ID of a beer.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true,
+                    "x-codegen-annotations": [
+                        "@jakarta.validation.constraints.Positive(message = \"The beerId must be a natural number!\")"
+                    ]
+                }
+            ]
+        },
+        "/breweries": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Brewery"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Returns all breweries."
+                    }
+                },
+                "operationId": "listAllBreweries",
+                "summary": "Get All Breweries",
+                "description": "Returns a list of all the breweries."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "New brewery information.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Brewery successfully added."
+                    }
+                },
+                "operationId": "addBrewery",
+                "summary": "Add a Brewery",
+                "description": "Adds a single brewery to the data set."
+            }
+        },
+        "/breweries/{breweryId}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brewery"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "getBrewery",
+                "summary": "Gets Info About a Brewery",
+                "description": "Returns full information about a single brewery."
+            },
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Brewery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {}
+                },
+                "operationId": "updateBrewery",
+                "summary": "Update a Brewery",
+                "description": "Updates information about a single brewery."
+            },
+            "delete": {
+                "responses": {
+                    "204": {}
+                },
+                "operationId": "deleteBrewery",
+                "summary": "Delete a Brewery",
+                "description": "Removes a single brewery from the data set."
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "description": "Unique ID of a brewery.",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/breweries/{breweryId}/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "listBreweryBeers",
+                "summary": "Gets Beers From a Brewery",
+                "description": "Returns all of the beers made by the brewery."
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {}
+                },
+                "operationId": "addBeerToBrewery",
+                "summary": "Adds a Beer to the Brewery",
+                "description": "Adds a single beer to the data set for this brewery.",
+                "x-codegen-async": false
+            },
+            "parameters": [
+                {
+                    "name": "breweryId",
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/beers": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Beer"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "All the beers!"
+                    }
+                },
+                "operationId": "listAllBeers",
+                "summary": "Get All Beers",
+                "description": "Returns all of the beers in the database."
+            },
+            "post": {
+                "requestBody": {
+                    "description": "The beer to add to the data set.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Beer"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "The beer was added."
+                    }
+                },
+                "operationId": "addBeer",
+                "summary": "Add a Beer",
+                "description": "Adds a single beer to the dataset."
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Beer": {
+                "title": "Root Type for Beer",
+                "description": "The root of the Beer type's schema.",
+                "required": [
+                    "abv",
+                    "id",
+                    "name",
+                    "style",
+                    "breweryId",
+                    "ounces"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "abv": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "ibu": {
+                        "format": "double",
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "style": {
+                        "type": "string"
+                    },
+                    "breweryId": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "ounces": {
+                        "format": "double",
+                        "type": "number"
+                    }
+                }
+            },
+            "Brewery": {
+                "title": "Root Type for Brewery",
+                "description": "The root of the Brewery type's schema.",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "city": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "sampleBeers": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Beer"
+                        }
+                    }
+                },
+                "example": {
+                    "id": 92,
+                    "name": "some text",
+                    "city": "some text",
+                    "state": "some text",
+                    "sampleBeers": [
+                        {
+                            "id": 16,
+                            "abv": 47.81,
+                            "ibu": 57.48,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 44,
+                            "ounces": 72.8
+                        },
+                        {
+                            "id": 72,
+                            "abv": 59.7,
+                            "ibu": 47.07,
+                            "name": "some text",
+                            "style": "some text",
+                            "breweryId": 99,
+                            "ounces": 34.92
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "beer",
+            "description": ""
+        },
+        {
+            "name": "brewery",
+            "description": ""
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Adds a `genericReturnType` setting to `JaxRsProjectSettings` that wraps all generated JAX-RS return types in a user-specified generic class (e.g. `org.jboss.resteasy.reactive.RestResponse`)
- Enables type-safe HTTP status code control: `Beer getBeer(...)` becomes `RestResponse<Beer> getBeer(...)`, void methods become `RestResponse<Void>`, and reactive mode produces `CompletionStage<RestResponse<T>>`
- Based on the approach from stale PR #295, reimplemented against the current codebase

## Changes
- **`JaxRsProjectSettings.java`** — new `genericReturnType` field (default `null` = no wrapping)
- **`OpenApi2JaxRs.java`** — new `generateGenericReturnType()` method, inserted into the return type chain between type generation and reactive wrapping; updated `setVoidReturnType()` to handle the wrapper
- **`OpenApi2JaxRsTest.java`** — 2 new test methods (generic-only and generic+reactive), new `doFullTest` overload
- **Test fixtures** — 2 new expected output directories

## Test plan
- [x] All 42 existing + new tests pass (`mvn test -pl core`)
- [x] Verified generated output: `RestResponse<Beer>`, `RestResponse<Void>`, `CompletionStage<RestResponse<T>>`
- [x] Quarkus codegen inherits the feature automatically (no changes needed)
- [ ] Verify CI passes

Resolves #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)