### PR TITLE
Add comprehensive documentation and reference guides

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,70 +1,276 @@
 # Getting Started
 
-This guide will help you get up and running with Apitomy Codegen in just a few minutes.
+This guide walks you through generating Java code from an OpenAPI specification using the Apitomy Codegen Maven plugin.
 
 ## Prerequisites
 
-Before you begin, ensure you have:
+- **Java 11 or later** (tested with Java 11, 17, and 21)
+- **Maven 3.6+**
 
-- **Java 11 or later** installed
-- **Maven 3.6+** for building projects
-- **An OpenAPI specification** (we'll provide a simple example)
+## Step 1: Write an OpenAPI Specification
 
-## Hello World Example
+Create a file called `src/main/resources/openapi.json`:
 
-Let's create a simple "Hello World" API and generate code from it.
-
-### Step 1: Create a Simple OpenAPI Specification
-
-Create a file called `hello-api.yaml`:
-
-```yaml
-openapi: 3.0.3
-info:
-  title: Hello World API
-  description: A simple Hello World API
-  version: 1.0.0
-servers:
-  - url: http://localhost:8080
-    description: Development server
-paths:
-  /hello:
-    get:
-      summary: Say hello
-      operationId: sayHello
-      parameters:
-        - name: name
-          in: query
-          required: false
-          schema:
-            type: string
-            default: "World"
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Greeting'
-components:
-  schemas:
-    Greeting:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Hello, World!"
-        timestamp:
-          type: string
-          format: date-time
-      required:
-        - message
-        - timestamp
+```json
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Beer API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/beers": {
+      "get": {
+        "operationId": "listBeers",
+        "summary": "List all beers",
+        "responses": {
+          "200": {
+            "description": "A list of beers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Beer" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "addBeer",
+        "summary": "Add a beer",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Beer" }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Beer created" }
+        }
+      }
+    },
+    "/beers/{beerId}": {
+      "get": {
+        "operationId": "getBeer",
+        "summary": "Get a beer by ID",
+        "parameters": [
+          {
+            "name": "beerId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single beer",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Beer" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Beer": {
+        "type": "object",
+        "required": ["name", "style"],
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "style": { "type": "string" },
+          "abv": { "type": "number", "format": "double" }
+        }
+      }
+    }
+  }
+}
 ```
 
-### Step 2: Set Up Maven Project
+## Step 2: Add the Maven Plugin
 
-Create a new Maven project with the following `pom.xml`:
+Add the Apitomy Codegen plugin to your `pom.xml`:
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.apitomy</groupId>
+            <artifactId>apitomy-codegen-maven-plugin</artifactId>
+            <version>1.3.0</version>
+            <executions>
+                <execution>
+                    <phase>generate-sources</phase>
+                    <goals>
+                        <goal>generate</goal>
+                    </goals>
+                    <configuration>
+                        <projectSettings>
+                            <javaPackage>com.example.beer</javaPackage>
+                        </projectSettings>
+                        <inputSpec>src/main/resources/openapi.json</inputSpec>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+You'll also need these dependencies for the generated code to compile:
+
+```xml
+<dependencies>
+    <!-- JAX-RS API -->
+    <dependency>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>4.0.0</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <!-- Jackson annotations (used by generated beans) -->
+    <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.18.0</version>
+    </dependency>
+
+    <!-- MicroProfile OpenAPI annotations (used by generated interfaces) -->
+    <dependency>
+        <groupId>org.eclipse.microprofile.openapi</groupId>
+        <artifactId>microprofile-openapi-api</artifactId>
+        <version>4.0</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <!-- Bean Validation API (for @NotNull on request bodies) -->
+    <dependency>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>3.1.0</version>
+        <scope>provided</scope>
+    </dependency>
+</dependencies>
+```
+
+!!! tip "Using Quarkus?"
+    If you're using Quarkus, these dependencies are already managed by the Quarkus BOM. See [Using with Quarkus](#using-with-quarkus) below.
+
+## Step 3: Generate Code
+
+```bash
+mvn clean generate-sources
+```
+
+The plugin generates code into `target/generated-sources/jaxrs/` and automatically registers it as a compile source root:
+
+```
+target/generated-sources/jaxrs/
+└── com/example/beer/
+    ├── BeersResource.java          # JAX-RS interface
+    └── beans/
+        └── Beer.java               # Data model bean
+```
+
+### Generated Interface
+
+The generated `BeersResource.java` is a JAX-RS **interface** with all the annotations and method signatures derived from your OpenAPI spec:
+
+```java
+@Path("/beers")
+public interface BeersResource {
+
+    @Operation(summary = "List all beers", operationId = "listBeers")
+    @GET
+    @Produces("application/json")
+    List<Beer> listBeers();
+
+    @Operation(summary = "Add a beer", operationId = "addBeer")
+    @POST
+    @Consumes("application/json")
+    void addBeer(@NotNull Beer data);
+
+    @Operation(summary = "Get a beer by ID", operationId = "getBeer")
+    @Path("/{beerId}")
+    @GET
+    @Produces("application/json")
+    Beer getBeer(@PathParam("beerId") int beerId);
+}
+```
+
+### Generated Bean
+
+The `Beer.java` bean class includes Jackson annotations for JSON serialization:
+
+```java
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"id", "name", "style", "abv"})
+@Generated("jsonschema2pojo")
+public class Beer {
+
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("style")
+    private String style;
+
+    @JsonProperty("abv")
+    private Double abv;
+
+    // Getters and setters...
+}
+```
+
+## Step 4: Implement the Interface
+
+Create an implementation class that implements the generated interface:
+
+```java
+package com.example.beer;
+
+import com.example.beer.beans.Beer;
+import java.util.*;
+
+public class BeersResourceImpl implements BeersResource {
+
+    private final Map<Integer, Beer> beers = new LinkedHashMap<>();
+    private int nextId = 1;
+
+    @Override
+    public List<Beer> listBeers() {
+        return new ArrayList<>(beers.values());
+    }
+
+    @Override
+    public void addBeer(Beer data) {
+        data.setId(nextId++);
+        beers.put(data.getId(), data);
+    }
+
+    @Override
+    public Beer getBeer(int beerId) {
+        return beers.get(beerId);
+    }
+}
+```
+
+Your implementation handles the business logic while the generated interface handles the JAX-RS wiring — paths, HTTP methods, content types, and parameter binding are all derived from the OpenAPI spec.
+
+## Using with Quarkus
+
+Quarkus is the recommended runtime for Apitomy Codegen. Here's a minimal `pom.xml` for a Quarkus project:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -75,14 +281,13 @@ Create a new Maven project with the following `pom.xml`:
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
-    <artifactId>hello-world-api</artifactId>
+    <artifactId>beer-api</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <quarkus.platform.version>3.2.8.Final</quarkus.platform.version>
-        <apitomy-codegen.version>1.2.6.Final</apitomy-codegen.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <quarkus.platform.version>3.17.0</quarkus.platform.version>
     </properties>
 
     <dependencyManagement>
@@ -100,7 +305,19 @@ Create a new Maven project with the following `pom.xml`:
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -109,19 +326,34 @@ Create a new Maven project with the following `pom.xml`:
             <plugin>
                 <groupId>io.apitomy</groupId>
                 <artifactId>apitomy-codegen-maven-plugin</artifactId>
-                <version>${apitomy-codegen.version}</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>hello-api.yaml</inputSpec>
-                            <output>target/generated-sources/apitomy</output>
                             <projectSettings>
-                                <javaPackage>com.example.hello</javaPackage>
+                                <javaPackage>com.example.beer</javaPackage>
                             </projectSettings>
+                            <inputSpec>src/main/resources/openapi.json</inputSpec>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -130,71 +362,35 @@ Create a new Maven project with the following `pom.xml`:
 </project>
 ```
 
-### Step 3: Generate Code
-
-Run the code generation:
-
-```bash
-mvn clean generate-sources
-```
-
-This will generate:
-
-- **JAX-RS resource interfaces** in `target/generated-sources/apitomy/`
-- **Data model classes** (`Greeting.java`)
-- **API interfaces** ready for implementation
-
-### Step 4: Implement the Generated Interface
-
-Create `src/main/java/com/example/hello/HelloResource.java`:
+Make your implementation a CDI bean:
 
 ```java
-package com.example.hello;
+package com.example.beer;
 
-import java.time.OffsetDateTime;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class HelloResource implements HelloApi {
-
-    @Override
-    public Greeting sayHello(String name) {
-        Greeting greeting = new Greeting();
-        greeting.setMessage("Hello, " + (name != null ? name : "World") + "!");
-        greeting.setTimestamp(OffsetDateTime.now());
-        return greeting;
-    }
+public class BeersResourceImpl implements BeersResource {
+    // ... implementation
 }
 ```
 
-### Step 5: Run Your Application
+Run with Quarkus dev mode:
 
 ```bash
 mvn quarkus:dev
 ```
 
-Your API is now running at `http://localhost:8080`!
-
 Test it:
-```bash
-curl "http://localhost:8080/hello?name=Developer"
-```
 
-Response:
-```json
-{
-  "message": "Hello, Developer!",
-  "timestamp": "2024-01-15T10:30:00Z"
-}
+```bash
+curl http://localhost:8080/beers
 ```
 
 ## What's Next?
 
-Now that you have a working example, explore more advanced features:
-
-- **Configuration Options** - Customize package names, add validation, etc.
-- **Multiple Output Formats** - Generate clients, async APIs, and more
-- **Integration Patterns** - Learn about different ways to integrate the generator
-- **Advanced OpenAPI Features** - Work with complex schemas, security, and more
-
-Check out the [User Guide](user-guide/) for detailed documentation on all features.
+- **[Maven Plugin Reference](user-guide/maven-plugin.md)** — all plugin configuration options
+- **[Configuration Reference](user-guide/configuration-reference.md)** — detailed documentation of all project settings
+- **[OpenAPI Extensions](user-guide/openapi-extensions.md)** — customize code generation from your API contract
+- **[Generated Output](user-guide/generated-output.md)** — understand what the generator produces
+- **[Examples](user-guide/examples.md)** — practical recipes for common use cases

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,39 +1,42 @@
 # Apitomy Codegen
 
-Welcome to **Apitomy Codegen** - an open source API design code generator that helps you generate high-quality code from OpenAPI specifications.
+Welcome to **Apitomy Codegen** — an open source API design code generator that produces high-quality Java code from OpenAPI specifications.
 
 ## What is Apitomy Codegen?
 
-Apitomy Codegen is a powerful tool that automatically generates code from OpenAPI (formerly Swagger) specifications. It specializes in generating:
+Apitomy Codegen reads an OpenAPI 3.x specification and generates:
 
-- **JAX-RS server stubs** for Java applications
-- **Quarkus-optimized code** with reactive and blocking variants
-- **Data models and DTOs** from OpenAPI schemas
-- **Client libraries** for consuming APIs
+- **JAX-RS interfaces** — fully annotated resource interfaces ready for you to implement
+- **Data model beans** — Jackson-annotated Java classes from your schema definitions
+- **Quarkus-optimized projects** — optional full project scaffolding with Dockerfiles, config, and Maven wrapper
+
+You write the OpenAPI spec and the business logic. Apitomy Codegen handles the boilerplate.
 
 ## Key Features
 
-- 🚀 **Quarkus Native** - Optimized for Quarkus applications with native compilation support
-- 📝 **OpenAPI 3.x Support** - Full support for modern OpenAPI specifications
-- ⚡ **Multiple Integration Options** - Maven plugin, CLI tool, or programmatic API
-- 🔧 **Highly Configurable** - Extensive customization options for generated code
-- 🏗️ **Production Ready** - Battle-tested in enterprise environments
+- **OpenAPI 3.x Support** — full support for modern OpenAPI specifications
+- **Interface-Based Design** — generated interfaces define the API contract; you implement the behavior
+- **Maven Plugin** — integrates code generation into your build lifecycle
+- **Highly Configurable** — 14+ project settings, 10+ OpenAPI extensions for fine-grained control
+- **Reactive Support** — optional `CompletionStage<>` wrapping for async endpoints
+- **Bean Validation** — optional JSR-303 annotations from OpenAPI constraints
+- **Production Ready** — battle-tested in enterprise environments
 
 ## Project Structure
 
-This project consists of several modules:
-
-- **`core/`** - Core code generation engine
-- **`maven-plugin/`** - Maven plugin for build integration
-- **`cli/`** - Command-line interface
-- **`quarkus-extension/`** - Quarkus extension for seamless integration
+- **`core/`** — core code generation engine (can also be used as a library)
+- **`maven-plugin/`** — Maven plugin for build integration
+- **`maven-plugin-tests/`** — integration tests for the Maven plugin
 
 ## Quick Links
 
-- [Getting Started](getting-started.md) - Jump right in with a simple example
-- [User Guide](user-guide/) - Comprehensive documentation
-- [GitHub Repository](https://github.com/Apitomy/apitomy-codegen) - Source code and issues
-- [Apitomy Project](https://www.apitomy.io/) - Main project website
+- [Getting Started](getting-started.md) — generate your first API in minutes
+- [Maven Plugin](user-guide/maven-plugin.md) — plugin setup and configuration
+- [Configuration Reference](user-guide/configuration-reference.md) — all project settings
+- [OpenAPI Extensions](user-guide/openapi-extensions.md) — customize generation from your spec
+- [Generated Output](user-guide/generated-output.md) — what the generator produces
+- [Examples](user-guide/examples.md) — practical recipes for common use cases
+- [GitHub Repository](https://github.com/Apitomy/apitomy-codegen) — source code and issues
 
 ## License
 
@@ -42,9 +45,9 @@ This project is licensed under the Apache License 2.0. See the [LICENSE](https:/
 ## Community
 
 - **Issues**: Report bugs and request features on [GitHub Issues](https://github.com/Apitomy/apitomy-codegen/issues)
-- **Discussions**: Join the conversation in our community forums
-- **Contributing**: We welcome contributions! Check out our contribution guidelines
+- **Discussions**: [GitHub Discussions](https://github.com/Apitomy/apitomy-codegen/discussions)
+- **Contributing**: See the [Contributing Guidelines](https://github.com/Apitomy/apitomy-codegen/blob/main/CONTRIBUTING.md)
 
 ---
 
-*Developed by Red Hat as part of the Apitomy project.*
+*Part of the [Apitomy](https://www.apitomy.io) project. Licensed under the Apache License 2.0.*

--- a/docs/user-guide/configuration-reference.md
+++ b/docs/user-guide/configuration-reference.md
@@ -1,0 +1,407 @@
+# Configuration Reference
+
+This page documents all configuration properties available in the Apitomy Codegen Maven plugin's `<projectSettings>` block.
+
+## Project Settings
+
+All properties are configured inside the `<projectSettings>` element of the Maven plugin configuration:
+
+```xml
+<plugin>
+    <groupId>io.apitomy</groupId>
+    <artifactId>apitomy-codegen-maven-plugin</artifactId>
+    <version>1.3.0</version>
+    <executions>
+        <execution>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+            <configuration>
+                <projectSettings>
+                    <!-- Properties go here -->
+                </projectSettings>
+                <inputSpec>src/main/resources/openapi.json</inputSpec>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+### Property Summary
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| [`javaPackage`](#javapackage) | `String` | `org.example.api` | Base Java package for generated code |
+| [`reactive`](#reactive) | `boolean` | `false` | Wrap return types in `CompletionStage<>` |
+| [`genericReturnType`](#genericreturntype) | `String` | `null` | Wrap return types in a custom generic type |
+| [`classNamePrefix`](#classnameprefix) | `String` | `""` | Prefix added to all generated class names |
+| [`classNameSuffix`](#classnamesuffix) | `String` | `""` | Suffix added to all generated class names |
+| [`useJsr303`](#usejsr303) | `boolean` | `false` | Add Bean Validation annotations to generated beans |
+| [`generateBuilders`](#generatebuilders) | `boolean` | `false` | Generate builder methods on bean classes |
+| [`capitalizeEnumValues`](#capitalizeenumvalues) | `boolean` | `true` | Uppercase enum constant names |
+| [`generatesOpenApi`](#generatesopenapi) | `boolean` | `true` | Add MicroProfile `@Operation` annotations |
+| [`codeOnly`](#codeonly) | `boolean` | `true` | Generate only Java sources (no project scaffold) |
+| [`includeSpec`](#includespec) | `boolean` | `false` | Include the OpenAPI spec file in output |
+| [`mavenFileStructure`](#mavenfilestructure) | `boolean` | `false` | Use `src/main/java/` directory layout |
+| [`groupId`](#groupid) | `String` | `org.example` | Maven groupId (when generating full project) |
+| [`artifactId`](#artifactid) | `String` | `example-api` | Maven artifactId (when generating full project) |
+
+!!! note "Default values"
+    The defaults listed above are the **Maven plugin defaults**. When using the core library programmatically, some defaults differ (e.g. `codeOnly` defaults to `false`, `includeSpec` defaults to `true`, `mavenFileStructure` defaults to `true`).
+
+---
+
+## Property Details
+
+### `javaPackage`
+
+The base Java package for all generated interfaces and bean classes.
+
+- **Type:** `String`
+- **Default:** `org.example.api`
+
+Generated interfaces are placed directly in this package. Bean classes are placed in a `beans` sub-package (e.g. `com.example.api.beans`).
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.myapi</javaPackage>
+</projectSettings>
+```
+
+**Generated structure:**
+
+```
+com/example/myapi/
+├── UsersResource.java
+├── OrdersResource.java
+└── beans/
+    ├── User.java
+    └── Order.java
+```
+
+Individual schemas can override their package using the [`x-codegen-package`](openapi-extensions.md#x-codegen-package) OpenAPI extension.
+
+---
+
+### `reactive`
+
+When enabled, all generated interface method return types are wrapped in `CompletionStage<>`.
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <reactive>true</reactive>
+</projectSettings>
+```
+
+**Without `reactive`:**
+
+```java
+@GET
+@Produces("application/json")
+List<Beer> listAllBeers();
+```
+
+**With `reactive` enabled:**
+
+```java
+@GET
+@Produces("application/json")
+CompletionStage<List<Beer>> listAllBeers();
+```
+
+Methods that would return `void` become `CompletionStage<Void>`.
+
+!!! tip
+    When targeting Quarkus with reactive endpoints, consider using [`genericReturnType`](#genericreturntype) with `io.smallrye.mutiny.Uni` instead.
+
+---
+
+### `genericReturnType`
+
+Wraps all generated interface method return types in a specified generic type. This is useful for framework-specific response wrappers.
+
+- **Type:** `String`
+- **Default:** `null` (disabled)
+
+The value should be the fully qualified class name of a generic type that takes one type parameter.
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <genericReturnType>org.jboss.resteasy.reactive.RestResponse</genericReturnType>
+</projectSettings>
+```
+
+**Generated code:**
+
+```java
+@GET
+@Produces("application/json")
+RestResponse<List<Beer>> listAllBeers();
+
+@DELETE
+@Path("/{beerId}")
+RestResponse<Void> deleteBeer(@PathParam("beerId") int beerId);
+```
+
+Can be combined with `reactive` for types like `CompletionStage<RestResponse<T>>`.
+
+---
+
+### `classNamePrefix`
+
+A prefix added to all generated class names (interfaces and beans).
+
+- **Type:** `String`
+- **Default:** `""` (no prefix)
+
+```xml
+<projectSettings>
+    <javaPackage>org.example.api</javaPackage>
+    <classNamePrefix>Test</classNamePrefix>
+</projectSettings>
+```
+
+**Effect:** `BeersResource` becomes `TestBeersResource`, `Beer` becomes `TestBeer`.
+
+---
+
+### `classNameSuffix`
+
+A suffix added to all generated class names (interfaces and beans).
+
+- **Type:** `String`
+- **Default:** `""` (no suffix)
+
+```xml
+<projectSettings>
+    <javaPackage>org.example.api</javaPackage>
+    <classNameSuffix>Dto</classNameSuffix>
+</projectSettings>
+```
+
+**Effect:** `BeersResource` becomes `BeersResourceDto`, `Beer` becomes `BeerDto`.
+
+---
+
+### `useJsr303`
+
+When enabled, adds [Bean Validation](https://beanvalidation.org/) (JSR 303 / Jakarta Validation) annotations to generated bean properties based on OpenAPI schema constraints.
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <useJsr303>true</useJsr303>
+</projectSettings>
+```
+
+OpenAPI constraints are mapped to validation annotations:
+
+| OpenAPI Constraint | Validation Annotation |
+|---|---|
+| `required` | `@NotNull` |
+| `minLength` / `maxLength` | `@Size(min=, max=)` |
+| `minimum` | `@Min` or `@DecimalMin` |
+| `maximum` | `@Max` or `@DecimalMax` |
+| `pattern` | `@Pattern` |
+| `minimum` with `exclusiveMinimum` | `@DecimalMin(inclusive=false)` |
+| `maximum` with `exclusiveMaximum` | `@DecimalMax(inclusive=false)` |
+
+!!! note
+    Validation annotations on interface method parameters (e.g. `@NotNull` on request bodies, `@Positive` from custom constraints) are always generated regardless of this setting.
+
+---
+
+### `generateBuilders`
+
+When enabled, generates builder-pattern methods on bean classes in addition to the standard getters and setters.
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <generateBuilders>true</generateBuilders>
+</projectSettings>
+```
+
+---
+
+### `capitalizeEnumValues`
+
+Controls whether generated Java enum constants are converted to uppercase.
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+When `true` (default), an OpenAPI enum value like `"active"` becomes `ACTIVE` in the generated Java enum. When `false`, the original casing from the OpenAPI spec is preserved (with minimal sanitization for Java identifier rules).
+
+```xml
+<projectSettings>
+    <capitalizeEnumValues>false</capitalizeEnumValues>
+</projectSettings>
+```
+
+---
+
+### `generatesOpenApi`
+
+Controls whether MicroProfile OpenAPI `@Operation` annotations are added to generated JAX-RS interface methods.
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+When enabled, each generated method includes an `@Operation` annotation with the `summary`, `description`, and `operationId` from the OpenAPI spec:
+
+```java
+@Operation(
+    description = "Returns all beers in the database.",
+    summary = "Get All Beers",
+    operationId = "listAllBeers"
+)
+@GET
+@Produces("application/json")
+List<Beer> listAllBeers();
+```
+
+Set to `false` if you don't use MicroProfile OpenAPI and want to avoid the dependency:
+
+```xml
+<projectSettings>
+    <generatesOpenApi>false</generatesOpenApi>
+</projectSettings>
+```
+
+---
+
+### `codeOnly`
+
+Controls whether only Java source code is generated, or a complete project scaffold including `pom.xml` and supporting files.
+
+- **Type:** `boolean`
+- **Default:** `true` (Maven plugin), `false` (core library)
+
+When `true`, only Java interfaces and bean classes are generated. When `false`, the output also includes a `pom.xml`, and for Quarkus targets: Dockerfiles, `application.properties`, Maven wrapper, `.gitignore`, and a README.
+
+```xml
+<projectSettings>
+    <codeOnly>true</codeOnly>
+</projectSettings>
+```
+
+!!! tip
+    When using the Maven plugin, `codeOnly` should almost always be `true` since you already have your own `pom.xml`. Full project generation is intended for scaffolding new projects from scratch.
+
+---
+
+### `includeSpec`
+
+Controls whether the original OpenAPI specification file is included in the generated output.
+
+- **Type:** `boolean`
+- **Default:** `false` (Maven plugin), `true` (core library)
+
+When enabled, the OpenAPI spec is written to `META-INF/openapi.json` (or `src/main/resources/META-INF/openapi.json` when `mavenFileStructure` is `true`).
+
+```xml
+<projectSettings>
+    <includeSpec>true</includeSpec>
+</projectSettings>
+```
+
+This is useful when using frameworks like Quarkus with SmallRye OpenAPI, which can serve the spec at runtime from `META-INF/openapi.json`.
+
+---
+
+### `mavenFileStructure`
+
+Controls whether generated files use Maven's standard directory layout (`src/main/java/...`).
+
+- **Type:** `boolean`
+- **Default:** `false` (Maven plugin), `true` (core library)
+
+When `false`, Java files are placed directly under the package directory structure. When `true`, the output includes the `src/main/java/` prefix.
+
+```xml
+<projectSettings>
+    <mavenFileStructure>true</mavenFileStructure>
+</projectSettings>
+```
+
+!!! tip
+    When using the Maven plugin with a custom `<outputDir>`, keep this `false` (the default) since the plugin already sets the output directory as a compile source root.
+
+---
+
+### `groupId`
+
+The Maven `groupId` used when generating a full project scaffold (`codeOnly=false`).
+
+- **Type:** `String`
+- **Default:** `org.example`
+
+```xml
+<projectSettings>
+    <codeOnly>false</codeOnly>
+    <groupId>com.example</groupId>
+</projectSettings>
+```
+
+---
+
+### `artifactId`
+
+The Maven `artifactId` used when generating a full project scaffold (`codeOnly=false`).
+
+- **Type:** `String`
+- **Default:** `example-api`
+
+```xml
+<projectSettings>
+    <codeOnly>false</codeOnly>
+    <artifactId>my-api</artifactId>
+</projectSettings>
+```
+
+---
+
+## Plugin-Level Configuration
+
+In addition to `<projectSettings>`, the Maven plugin accepts these top-level configuration properties:
+
+### `inputSpec`
+
+**(Required)** Path to the OpenAPI specification file (JSON or YAML).
+
+- **Type:** `File`
+- Can be an absolute path or relative to the Maven project base directory.
+
+```xml
+<configuration>
+    <inputSpec>src/main/resources/openapi.json</inputSpec>
+</configuration>
+```
+
+### `outputDir`
+
+The directory where generated code is written.
+
+- **Type:** `File`
+- **Default:** `${project.build.directory}/generated-sources/jaxrs`
+
+The plugin automatically registers this directory as a compile source root.
+
+```xml
+<configuration>
+    <outputDir>${project.build.directory}/generated-sources/apitomy</outputDir>
+</configuration>
+```

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -1,0 +1,478 @@
+# Examples
+
+Practical recipes for common Apitomy Codegen use cases.
+
+## Reactive Endpoints
+
+Wrap all generated return types in `CompletionStage<>` for non-blocking, asynchronous endpoints:
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <reactive>true</reactive>
+</projectSettings>
+```
+
+**Generated interface:**
+
+```java
+@Path("/beers")
+public interface BeersResource {
+
+    @GET
+    @Produces("application/json")
+    CompletionStage<List<Beer>> listAllBeers();
+
+    @POST
+    @Consumes("application/json")
+    CompletionStage<Void> addBeer(@NotNull Beer data);
+
+    @DELETE
+    @Path("/{beerId}")
+    CompletionStage<Void> deleteBeer(@PathParam("beerId") int beerId);
+}
+```
+
+## Generic Return Type Wrapper
+
+Wrap return types in a framework-specific response type like RESTEasy Reactive's `RestResponse`:
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <genericReturnType>org.jboss.resteasy.reactive.RestResponse</genericReturnType>
+</projectSettings>
+```
+
+**Generated interface:**
+
+```java
+@GET
+@Produces("application/json")
+RestResponse<List<Beer>> listAllBeers();
+
+@DELETE
+@Path("/{beerId}")
+RestResponse<Void> deleteBeer(@PathParam("beerId") int beerId);
+```
+
+This lets your implementation control HTTP status codes and headers:
+
+```java
+@Override
+public RestResponse<Void> deleteBeer(int beerId) {
+    beerService.delete(beerId);
+    return RestResponse.noContent();
+}
+```
+
+### Combining Reactive + Generic Return Type
+
+Both can be used together:
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <reactive>true</reactive>
+    <genericReturnType>org.jboss.resteasy.reactive.RestResponse</genericReturnType>
+</projectSettings>
+```
+
+Produces `CompletionStage<RestResponse<T>>` return types.
+
+## Adding Lombok Annotations to All Beans
+
+Use the `x-codegen.bean-annotations` extension in your OpenAPI spec to add Lombok (or any other) annotations globally:
+
+```json
+{
+  "openapi": "3.0.3",
+  "info": { "title": "My API", "version": "1.0.0" },
+  "paths": { },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "email": { "type": "string" }
+        }
+      }
+    }
+  },
+  "x-codegen": {
+    "bean-annotations": [
+      "lombok.ToString",
+      {
+        "annotation": "lombok.EqualsAndHashCode",
+        "excludeEnums": true
+      }
+    ]
+  }
+}
+```
+
+**Generated bean:**
+
+```java
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("jsonschema2pojo")
+@lombok.ToString
+@lombok.EqualsAndHashCode
+public class User {
+    // ...
+}
+```
+
+The `excludeEnums: true` option on `@EqualsAndHashCode` means that annotation won't be added to generated enum classes.
+
+## Per-Schema Annotations
+
+Add annotations to specific schemas using `x-codegen-annotations`:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "Event": {
+        "type": "object",
+        "x-codegen-annotations": [
+          "io.quarkus.runtime.annotations.RegisterForReflection"
+        ],
+        "properties": {
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+## Schema Inheritance
+
+Use `x-codegen-extendsClass` to make a generated bean extend an existing class:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "RuleViolationError": {
+        "type": "object",
+        "x-codegen-extendsClass": "com.example.api.beans.Error",
+        "x-codegen-annotations": ["lombok.AllArgsConstructor", "lombok.Builder"],
+        "properties": {
+          "causes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RuleViolationCause" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated bean:**
+
+```java
+@lombok.AllArgsConstructor
+@lombok.Builder
+public class RuleViolationError extends Error {
+    // Only properties specific to this subclass
+}
+```
+
+## Context Root Prefix
+
+Prepend a base path to all generated `@Path` annotations without modifying every path in your spec:
+
+```json
+{
+  "paths": {
+    "/users": {
+      "get": { "operationId": "listUsers", "..." : "..." }
+    },
+    "/orders": {
+      "get": { "operationId": "listOrders", "..." : "..." }
+    },
+    "x-codegen-contextRoot": "/api/v2"
+  }
+}
+```
+
+**Generated interfaces:**
+
+```java
+@Path("/api/v2/users")
+public interface UsersResource { }
+
+@Path("/api/v2/orders")
+public interface OrdersResource { }
+```
+
+## Custom Return Type per Operation
+
+Override the return type for a specific operation using `x-codegen-returnType` on the media type:
+
+```json
+{
+  "paths": {
+    "/files/{fileId}": {
+      "get": {
+        "operationId": "downloadFile",
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": { "type": "string", "format": "binary" },
+                "x-codegen-returnType": "jakarta.ws.rs.core.Response"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated method:**
+
+```java
+@GET
+@Path("/{fileId}")
+@Produces("application/octet-stream")
+Response downloadFile(@PathParam("fileId") String fileId);
+```
+
+## Selective Async Operations
+
+Make specific operations async without enabling `reactive` globally:
+
+```yaml
+paths:
+  /reports:
+    post:
+      operationId: generateReport
+      x-codegen-async: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportRequest"
+      responses:
+        "202":
+          description: Report generation started
+  /health:
+    get:
+      operationId: healthCheck
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthStatus"
+```
+
+**Generated interface:**
+
+```java
+// Async — returns CompletionStage
+@POST
+@Consumes("application/json")
+CompletionStage<Void> generateReport(@NotNull ReportRequest data);
+
+// Synchronous — returns directly
+@GET
+@Produces("application/json")
+HealthStatus healthCheck();
+```
+
+## Class Name Prefix/Suffix
+
+Namespace generated classes to avoid collisions when generating from multiple specs:
+
+```xml
+<!-- First API -->
+<execution>
+    <id>internal-api</id>
+    <configuration>
+        <projectSettings>
+            <javaPackage>com.example.api</javaPackage>
+            <classNamePrefix>Internal</classNamePrefix>
+        </projectSettings>
+        <inputSpec>internal-api.json</inputSpec>
+        <outputDir>${project.build.directory}/generated-sources/internal</outputDir>
+    </configuration>
+</execution>
+
+<!-- Second API -->
+<execution>
+    <id>public-api</id>
+    <configuration>
+        <projectSettings>
+            <javaPackage>com.example.api</javaPackage>
+            <classNamePrefix>Public</classNamePrefix>
+        </projectSettings>
+        <inputSpec>public-api.json</inputSpec>
+        <outputDir>${project.build.directory}/generated-sources/public</outputDir>
+    </configuration>
+</execution>
+```
+
+Produces `InternalUsersResource`, `InternalUser` vs. `PublicUsersResource`, `PublicUser`.
+
+## Bean Validation (JSR-303)
+
+Enable validation annotations on generated beans based on OpenAPI schema constraints:
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <useJsr303>true</useJsr303>
+</projectSettings>
+```
+
+With this OpenAPI schema:
+
+```yaml
+User:
+  type: object
+  required: [name, email]
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 100
+    email:
+      type: string
+      pattern: "^[\\w.-]+@[\\w.-]+\\.\\w+$"
+    age:
+      type: integer
+      minimum: 0
+      maximum: 150
+```
+
+The generated bean includes validation annotations:
+
+```java
+public class User {
+
+    @NotNull
+    @Size(min = 1, max = 100)
+    @JsonProperty("name")
+    private String name;
+
+    @NotNull
+    @Pattern(regexp = "^[\\w.-]+@[\\w.-]+\\.\\w+$")
+    @JsonProperty("email")
+    private String email;
+
+    @Min(0)
+    @Max(150)
+    @JsonProperty("age")
+    private Integer age;
+}
+```
+
+## Custom Date-Time Format
+
+Override the default `@JsonFormat` pattern for a specific date-time property:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "Event": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "scheduledAt": {
+            "type": "string",
+            "format": "date-time",
+            "x-codegen-formatPattern": "yyyy-MM-dd HH:mm:ss"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated bean:**
+
+```java
+// Default pattern
+@JsonFormat(shape = JsonFormat.Shape.STRING,
+    pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+@JsonProperty("createdAt")
+private Date createdAt;
+
+// Custom pattern
+@JsonFormat(shape = JsonFormat.Shape.STRING,
+    pattern = "yyyy-MM-dd HH:mm:ss", timezone = "UTC")
+@JsonProperty("scheduledAt")
+private Date scheduledAt;
+```
+
+To suppress date-time formatting entirely, use the global extension:
+
+```json
+{
+  "x-codegen": {
+    "suppress-date-time-formatting": true
+  }
+}
+```
+
+## Inline Simple Types
+
+Prevent a simple schema from generating its own class by marking it as inline:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "UserId": {
+        "type": "string",
+        "x-codegen-inline": true
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/components/schemas/UserId" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+Instead of generating a `UserId` class, references to it are replaced with `String` directly.
+
+## Custom Bean Package
+
+Place specific beans in a different package:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "AuditEvent": {
+        "type": "object",
+        "x-codegen-package": "com.example.api.audit",
+        "properties": {
+          "action": { "type": "string" },
+          "timestamp": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}
+```
+
+The `AuditEvent` class is generated in `com.example.api.audit` instead of the default `com.example.api.beans`.

--- a/docs/user-guide/generated-output.md
+++ b/docs/user-guide/generated-output.md
@@ -1,0 +1,225 @@
+# Generated Output
+
+This page explains what Apitomy Codegen generates and how the generated code is structured.
+
+## Overview
+
+Apitomy Codegen reads your OpenAPI specification and produces:
+
+1. **JAX-RS Interfaces** — one per resource (grouped by the first path segment)
+2. **Bean Classes** — one per schema defined in `#/components/schemas`
+3. **OpenAPI spec file** — optionally included as `META-INF/openapi.json`
+
+When `codeOnly` is `false`, additional project scaffold files are also generated (see [Full Project Generation](#full-project-generation)).
+
+## JAX-RS Interfaces
+
+Each group of paths that share a common first segment produces a separate Java interface. For example, paths `/beers`, `/beers/{beerId}`, and `/beers/{beerId}/reviews` all produce a single `BeersResource` interface.
+
+### Interface Characteristics
+
+- Interfaces are placed in the configured `javaPackage` (e.g. `com.example.api`)
+- Each method corresponds to an OpenAPI operation
+- Method names come from `operationId` in the spec
+- JAX-RS annotations (`@GET`, `@POST`, `@Path`, `@Produces`, `@Consumes`) are derived from the operation
+- MicroProfile `@Operation` annotations include `summary`, `description`, and `operationId` (unless `generatesOpenApi` is `false`)
+
+### Example
+
+Given this OpenAPI path:
+
+```yaml
+/beers/{beerId}:
+  get:
+    operationId: getBeer
+    summary: Get Info About a Beer
+    description: Returns full information about a single beer.
+    parameters:
+      - name: beerId
+        in: path
+        required: true
+        schema:
+          type: integer
+    responses:
+      "200":
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Beer"
+```
+
+Apitomy generates:
+
+```java
+@Path("/beers")
+public interface BeersResource {
+
+    @Operation(
+        description = "Returns full information about a single beer.",
+        summary = "Get Info About a Beer",
+        operationId = "getBeer"
+    )
+    @Path("/{beerId}")
+    @GET
+    @Produces("application/json")
+    Beer getBeer(@PathParam("beerId") int beerId);
+}
+```
+
+### Parameter Handling
+
+| OpenAPI Parameter | Generated Code |
+|-------------------|----------------|
+| `in: path` | `@PathParam("name")` |
+| `in: query` | `@QueryParam("name")` |
+| `in: header` | `@HeaderParam("name")` |
+| Request body (`required: true`) | `@NotNull TypeName data` |
+| Request body (`required: false`) | `TypeName data` |
+
+### Return Types
+
+By default, methods return the Java type mapped from the response schema. This can be modified with:
+
+- **[`reactive`](configuration-reference.md#reactive)** — wraps in `CompletionStage<T>`
+- **[`genericReturnType`](configuration-reference.md#genericreturntype)** — wraps in a custom generic type like `RestResponse<T>`
+- **[`x-codegen-async`](openapi-extensions.md#x-codegen-async)** — makes individual operations async
+- **[`x-codegen-returnType`](openapi-extensions.md#x-codegen-returntype)** — overrides the return type for a specific operation
+
+### Implementing Interfaces
+
+You provide the business logic by implementing the generated interface:
+
+```java
+@ApplicationScoped
+public class BeersResourceImpl implements BeersResource {
+
+    @Override
+    public Beer getBeer(int beerId) {
+        // Your implementation here
+    }
+}
+```
+
+The framework (e.g. Quarkus, WildFly) discovers your implementation class and handles HTTP routing based on the JAX-RS annotations from the interface.
+
+## Bean Classes
+
+Each schema in `#/components/schemas` that has `type: object` generates a Java bean class. Schemas with `type: string` and an `enum` array generate Java enum classes.
+
+### Bean Characteristics
+
+- Beans are placed in a `beans` sub-package (e.g. `com.example.api.beans`)
+- Generated using the [jsonschema2pojo](https://www.jsonschema2pojo.org/) library
+- Include Jackson annotations for JSON serialization: `@JsonProperty`, `@JsonInclude`, `@JsonPropertyOrder`
+- Include `@Generated("jsonschema2pojo")` annotation
+- Follow standard JavaBean conventions with getters and setters
+
+### Type Mapping
+
+| OpenAPI Type | Format | Java Type |
+|-------------|--------|-----------|
+| `string` | — | `String` |
+| `string` | `date` | `Date` |
+| `string` | `date-time` | `Date` (with `@JsonFormat`) |
+| `string` | `byte` | `byte[]` |
+| `integer` | — | `Integer` |
+| `integer` | `int32` | `Integer` |
+| `integer` | `int64` | `Long` |
+| `number` | — | `Double` |
+| `number` | `float` | `Float` |
+| `number` | `double` | `Double` |
+| `boolean` | — | `Boolean` |
+| `array` | — | `List<T>` |
+| `object` | — | Generated bean class |
+| `$ref` | — | Referenced bean class |
+
+### Required Properties
+
+Properties listed in the schema's `required` array are annotated with a `(Required)` Javadoc comment. When [`useJsr303`](configuration-reference.md#usejsr303) is enabled, they also get `@NotNull` annotations.
+
+### Enum Generation
+
+String schemas with `enum` values generate Java enums:
+
+```yaml
+Status:
+  type: string
+  enum: [active, inactive, pending]
+```
+
+Generates:
+
+```java
+public enum Status {
+    ACTIVE, INACTIVE, PENDING
+}
+```
+
+Enum constant casing is controlled by [`capitalizeEnumValues`](configuration-reference.md#capitalizeenumvalues).
+
+### Customizing Beans
+
+Beans can be customized using:
+
+- **[`x-codegen-annotations`](openapi-extensions.md#x-codegen-annotations)** — add annotations to specific beans
+- **[`x-codegen.bean-annotations`](openapi-extensions.md#x-codegenbean-annotations)** — add annotations to all beans globally
+- **[`x-codegen-extendsClass`](openapi-extensions.md#x-codegen-extendsclass)** — specify a superclass
+- **[`x-codegen-package`](openapi-extensions.md#x-codegen-package)** — override the package
+- **[`generateBuilders`](configuration-reference.md#generatebuilders)** — add builder methods
+
+## Multipart Form Data
+
+When an operation's request body uses `multipart/form-data` content type, the generator creates a dedicated bean class for the multipart form fields rather than using individual parameters.
+
+## Output Directory Structure
+
+### Code-Only Mode (default)
+
+With `codeOnly=true` (the Maven plugin default), only Java source files are generated:
+
+```
+<outputDir>/
+└── com/example/api/
+    ├── BeersResource.java
+    ├── BreweriesResource.java
+    └── beans/
+        ├── Beer.java
+        ├── Brewery.java
+        └── Style.java
+```
+
+### With `includeSpec=true`
+
+```
+<outputDir>/
+├── com/example/api/
+│   ├── BeersResource.java
+│   └── beans/
+│       └── Beer.java
+└── META-INF/
+    └── openapi.json
+```
+
+## Full Project Generation
+
+When `codeOnly` is `false`, the generator produces a complete, runnable project. This mode is primarily used for scaffolding new projects rather than for Maven plugin integration.
+
+### JAX-RS Target
+
+Generates a standard JAX-RS project:
+
+- `pom.xml` with required dependencies
+- `JaxRsApplication.java` — JAX-RS application class
+- All interfaces and beans
+- OpenAPI spec in `META-INF/openapi.json`
+
+### Quarkus Target
+
+Generates a Quarkus-ready project with additional files:
+
+- `pom.xml` with Quarkus BOM and dependencies
+- `src/main/resources/application.properties`
+- `src/main/docker/Dockerfile.jvm`, `.native`, `.legacy-jar`, `.native-micro`
+- Maven wrapper (`mvnw`, `mvnw.cmd`)
+- `.gitignore`, `.dockerignore`
+- `README.md`

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,119 +1,23 @@
 # User Guide
 
-Welcome to the comprehensive user guide for Apitomy Codegen. This section provides detailed documentation for all features and capabilities.
+Comprehensive documentation for Apitomy Codegen.
 
-## Table of Contents
+## Setup & Configuration
 
-### Basic Usage
-- **Installation & Setup** - Different ways to install and configure Apitomy Codegen
-- **Maven Plugin** - Detailed Maven plugin configuration and usage
-- **CLI Usage** - Command-line interface documentation
-- **Configuration Reference** - Complete configuration options
+- **[Maven Plugin](maven-plugin.md)** — plugin setup, required dependencies, multiple specs, and IDE integration
+- **[Configuration Reference](configuration-reference.md)** — all 14 `<projectSettings>` properties with types, defaults, and examples
 
-### Code Generation
-- **OpenAPI Support** - Supported OpenAPI features and specifications
-- **Output Formats** - Different types of code you can generate
-- **Customization** - How to customize generated code
-- **Templates** - Working with custom templates
+## Customizing Generation
 
-### Integration
-- **Quarkus Integration** - Deep integration with Quarkus applications
-- **Build Integration** - Integrating with various build systems
-- **CI/CD Pipelines** - Using Apitomy Codegen in automated workflows
+- **[OpenAPI Extensions](openapi-extensions.md)** — all `x-codegen-*` vendor extensions for controlling code generation from your API contract
+- **[Generated Output](generated-output.md)** — what the generator produces: interfaces, beans, enums, project scaffold
 
-### Advanced Topics
-- **Performance Tuning** - Optimizing code generation for large APIs
-- **Troubleshooting** - Common issues and solutions
-- **Contributing** - How to contribute to the project
+## Recipes
 
----
-
-*This user guide is under active development. More sections will be added as the documentation evolves.*
+- **[Examples](examples.md)** — practical, copy-paste recipes for common use cases: reactive endpoints, Lombok annotations, schema inheritance, validation, custom return types, and more
 
 ## Quick Navigation
 
-- [← Back to Getting Started](../getting-started.md)
-- [← Back to Home](../index.md)
-- [View on GitHub →](https://github.com/Apitomy/apitomy-codegen)
-
-## Apitomy Codegen OpenAPI Extensions
-
-Apitomy Codegen uses [OpenAPI specification extensions](https://spec.openapis.org/oas/v3.0.3.html#specification-extensions) to allow customization of the generated source code based on your API contract.
-
-### `x-codegen`
-
-The `x-codegen` extension can be defined at the root level of the OpenAPI document.  
-
-It is applied globally and allows you to customize the generated bean classes by:
-- Adding annotations to all generated beans.
-- Controlling date/time formatting.
-- Configuring the application context root.
-
-### `x-codegen.bean-annotations`
-
-Adding annotations to generated bean classes:
-
-```json
-{
-  "x-codegen": {
-    "bean-annotations": [
-      "@lombok.ToString", // (1)
-      {
-        "annotation": "@lombok.EqualsAndHashCode", // (2)
-        "excludeEnums": true
-      }
-    ]
-  }
-}
-```
-
-1. Adds the `@lombok.ToString` annotation to all generated bean classes.
-2. Adds the `@lombok.EqualsAndHashCode` annotation to all generated bean classes, except for Java enums (when excludeEnums is set to `true`).
-
-### `x-codegen.contextRoot`
-
-Additionally, you can configure the application context root using the `x-codegen.contextRoot` property.  
-
-This property defines a base path that will be automatically prefixed to all generated JAX-RS resource classes.
-
-For example, if you set the context root to `/apis/studio/v1`, all generated resource paths will include this prefix.
-
-```json
-{
-  "x-codegen": {
-    "contextRoot": "/apis/studio/v1",
-    "bean-annotations": []
-  }
-}
-```
-
-Corresponding JAX-RS code:
-
-```java
-@Path("/apis/studio/v1/users")
-public class UserResource {}
-```
-
-!!! note "Note"
-
-    You can use the `x-codegen-contextRoot` property to apply a context root prefix to a specific JAX-RS resource instead of using the global one.
-
-### `x-codegen.suppress-date-time-formatting`
-
-By default, Apitomy Codegen generates properties of type `string` with the format `date-time` as shown below:
-
-```java
-@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
-@JsonProperty("shipDate")
-private Date shipDate;
-```
-
-If you want to disable this behavior, you can use the `x-codegen.suppress-date-time-formatting` property to remove the `@JsonFormat` annotation from generated fields.
-
-```json
-{
-  "x-codegen": {
-    "suppress-date-time-formatting": true
-  }
-}
-```
+- [Getting Started](../getting-started.md) — generate your first API in minutes
+- [Home](../index.md) — project overview
+- [GitHub](https://github.com/Apitomy/apitomy-codegen) — source code and issues

--- a/docs/user-guide/maven-plugin.md
+++ b/docs/user-guide/maven-plugin.md
@@ -1,0 +1,216 @@
+# Maven Plugin
+
+The Apitomy Codegen Maven plugin integrates code generation into your Maven build lifecycle, generating JAX-RS interfaces and data model beans from an OpenAPI specification.
+
+## Maven Coordinates
+
+```xml
+<plugin>
+    <groupId>io.apitomy</groupId>
+    <artifactId>apitomy-codegen-maven-plugin</artifactId>
+    <version>1.3.0</version>
+</plugin>
+```
+
+## Goal: `generate`
+
+The plugin provides a single goal, `generate`, which reads an OpenAPI specification file and produces Java source code.
+
+**Default lifecycle phase:** none (must be explicitly bound, typically to `generate-sources`)
+
+## Basic Configuration
+
+```xml
+<plugin>
+    <groupId>io.apitomy</groupId>
+    <artifactId>apitomy-codegen-maven-plugin</artifactId>
+    <version>1.3.0</version>
+    <executions>
+        <execution>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+            <configuration>
+                <projectSettings>
+                    <javaPackage>com.example.api</javaPackage>
+                </projectSettings>
+                <inputSpec>src/main/resources/openapi.json</inputSpec>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+## Configuration Parameters
+
+### `inputSpec` (required)
+
+Path to the OpenAPI specification file. Supports JSON and YAML formats. Can be an absolute path or relative to the Maven project base directory.
+
+```xml
+<inputSpec>src/main/resources/openapi.json</inputSpec>
+```
+
+### `outputDir`
+
+Directory where generated source code is written. The plugin automatically registers this directory as a compile source root, so generated code is included in compilation.
+
+**Default:** `${project.build.directory}/generated-sources/jaxrs`
+
+```xml
+<outputDir>${project.build.directory}/generated-sources/apitomy</outputDir>
+```
+
+### `projectSettings`
+
+Configuration block controlling what code is generated and how. See the [Configuration Reference](configuration-reference.md) for all available properties.
+
+**Minimal example** (only `javaPackage` is typically needed):
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+</projectSettings>
+```
+
+**Full example** with all properties shown:
+
+```xml
+<projectSettings>
+    <javaPackage>com.example.api</javaPackage>
+    <reactive>false</reactive>
+    <genericReturnType>org.jboss.resteasy.reactive.RestResponse</genericReturnType>
+    <classNamePrefix></classNamePrefix>
+    <classNameSuffix></classNameSuffix>
+    <useJsr303>true</useJsr303>
+    <generateBuilders>false</generateBuilders>
+    <capitalizeEnumValues>true</capitalizeEnumValues>
+    <generatesOpenApi>true</generatesOpenApi>
+    <codeOnly>true</codeOnly>
+    <includeSpec>false</includeSpec>
+    <mavenFileStructure>false</mavenFileStructure>
+    <groupId>com.example</groupId>
+    <artifactId>my-api</artifactId>
+</projectSettings>
+```
+
+## Required Dependencies
+
+The generated code uses annotations from several libraries. Add these dependencies to your project:
+
+=== "Standalone JAX-RS"
+
+    ```xml
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>4.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+            <version>4.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    ```
+
+=== "Quarkus"
+
+    ```xml
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+    </dependencies>
+    ```
+
+!!! note "MicroProfile OpenAPI"
+    If you set `generatesOpenApi` to `false`, the MicroProfile OpenAPI dependency is not required.
+
+## Multiple Specifications
+
+To generate code from multiple OpenAPI specs, add multiple `<execution>` blocks. Use separate output directories or Java packages to avoid class name collisions:
+
+```xml
+<plugin>
+    <groupId>io.apitomy</groupId>
+    <artifactId>apitomy-codegen-maven-plugin</artifactId>
+    <version>1.3.0</version>
+    <executions>
+        <execution>
+            <id>generate-users-api</id>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+            <configuration>
+                <projectSettings>
+                    <javaPackage>com.example.users</javaPackage>
+                </projectSettings>
+                <inputSpec>src/main/resources/users-api.json</inputSpec>
+                <outputDir>${project.build.directory}/generated-sources/users</outputDir>
+            </configuration>
+        </execution>
+        <execution>
+            <id>generate-orders-api</id>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+            <configuration>
+                <projectSettings>
+                    <javaPackage>com.example.orders</javaPackage>
+                </projectSettings>
+                <inputSpec>src/main/resources/orders-api.json</inputSpec>
+                <outputDir>${project.build.directory}/generated-sources/orders</outputDir>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+## Build Lifecycle Integration
+
+The plugin is typically bound to the `generate-sources` phase so that generated code is available for compilation:
+
+```
+validate → generate-sources (codegen runs here) → compile → test → package
+```
+
+When using with Quarkus, make sure the Apitomy Codegen plugin is declared **before** the Quarkus Maven plugin in your `pom.xml`, so code is generated before Quarkus processes it.
+
+## IDE Support
+
+The generated code is placed in `target/generated-sources/jaxrs` by default. Most IDEs (IntelliJ IDEA, Eclipse, VS Code) automatically recognize Maven-registered source roots. If your IDE doesn't pick up the generated sources:
+
+- **IntelliJ IDEA:** Right-click `target/generated-sources/jaxrs` → Mark Directory as → Generated Sources Root
+- **Eclipse:** Run Maven → Update Project (Alt+F5)
+- **VS Code:** The Java extension picks up source roots automatically after a Maven reload

--- a/docs/user-guide/openapi-extensions.md
+++ b/docs/user-guide/openapi-extensions.md
@@ -1,0 +1,483 @@
+# OpenAPI Extensions Reference
+
+Apitomy Codegen uses [OpenAPI specification extensions](https://spec.openapis.org/oas/v3.0.3.html#specification-extensions) (vendor extensions) to customize code generation directly from your API contract.
+
+All extensions use the `x-codegen` prefix.
+
+## Extension Summary
+
+| Extension | Placement | Description |
+|-----------|-----------|-------------|
+| [`x-codegen`](#x-codegen) | Document root | Global codegen configuration block |
+| [`x-codegen-contextRoot`](#x-codegen-contextroot) | `paths` object | Base path prefix for all generated JAX-RS resources |
+| [`x-codegen-package`](#x-codegen-package) | Schema definition | Custom Java package for a specific bean class |
+| [`x-codegen-annotations`](#x-codegen-annotations) | Schema definition | Extra Java annotations on a specific bean class |
+| [`x-codegen-extendsClass`](#x-codegen-extendsclass) | Schema definition | Superclass for a generated bean class |
+| [`x-codegen-type`](#x-codegen-type) | Schema definition | Override the Java type for a schema (map types) |
+| [`x-codegen-inline`](#x-codegen-inline) | Schema definition | Inline a schema instead of generating a separate class |
+| [`x-codegen-async`](#x-codegen-async) | Operation | Mark an operation's return type as asynchronous |
+| [`x-codegen-returnType`](#x-codegen-returntype) | Media type (in response) | Override the return type for a specific operation |
+| [`x-codegen-formatPattern`](#x-codegen-formatpattern) | Schema property (`date-time`) | Custom date-time format pattern |
+
+---
+
+## Global Configuration
+
+### `x-codegen`
+
+A root-level configuration block that controls global code generation behavior. This extension is placed at the top level of the OpenAPI document (alongside `openapi`, `info`, `paths`, etc.).
+
+**Sub-properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `bean-annotations` | Array | Annotations to add to all generated bean classes |
+| `contextRoot` | String | Global context root path (alternative to `x-codegen-contextRoot` on `paths`) |
+| `suppress-date-time-formatting` | Boolean | Disable `@JsonFormat` on date-time fields |
+
+#### `x-codegen.bean-annotations`
+
+Adds Java annotations to **all** generated bean classes. Each array element can be either:
+
+- A **string** — the fully qualified annotation (e.g. `"lombok.ToString"`)
+- An **object** with `annotation` and optional `excludeEnums` properties
+
+=== "JSON"
+
+    ```json
+    {
+      "x-codegen": {
+        "bean-annotations": [
+          "jakarta.enterprise.context.ApplicationScoped",
+          {
+            "annotation": "lombok.ToString(callSuper=true, includeFieldNames=true)",
+            "excludeEnums": true
+          }
+        ]
+      }
+    }
+    ```
+
+=== "YAML"
+
+    ```yaml
+    x-codegen:
+      bean-annotations:
+        - jakarta.enterprise.context.ApplicationScoped
+        - annotation: "lombok.ToString(callSuper=true, includeFieldNames=true)"
+          excludeEnums: true
+    ```
+
+**Generated bean class:**
+
+```java
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("jsonschema2pojo")
+@jakarta.enterprise.context.ApplicationScoped
+@lombok.ToString(callSuper=true, includeFieldNames=true)
+public class FooBean {
+    // ...
+}
+```
+
+When `excludeEnums` is `true`, the annotation is not added to generated Java enum classes.
+
+#### `x-codegen.contextRoot`
+
+Defines a global base path prefix that is prepended to all generated JAX-RS resource `@Path` annotations. This is an alternative to using [`x-codegen-contextRoot`](#x-codegen-contextroot) on the `paths` object.
+
+```json
+{
+  "x-codegen": {
+    "contextRoot": "/apis/studio/v1"
+  }
+}
+```
+
+**Generated resource:**
+
+```java
+@Path("/apis/studio/v1/users")
+public interface UsersResource {
+    // ...
+}
+```
+
+#### `x-codegen.suppress-date-time-formatting`
+
+By default, Apitomy Codegen generates `@JsonFormat` annotations on properties of type `string` with format `date-time`:
+
+```java
+@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+@JsonProperty("shipDate")
+private Date shipDate;
+```
+
+Set `suppress-date-time-formatting` to `true` to remove these `@JsonFormat` annotations:
+
+```json
+{
+  "x-codegen": {
+    "suppress-date-time-formatting": true
+  }
+}
+```
+
+---
+
+## Path-Level Extensions
+
+### `x-codegen-contextRoot`
+
+Placed on the `paths` object, this extension defines a base path prefix that is prepended to all generated JAX-RS resource `@Path` annotations.
+
+=== "JSON"
+
+    ```json
+    {
+      "paths": {
+        "/widgets": {
+          "get": { "..." : "..." }
+        },
+        "x-codegen-contextRoot": "/api/v3"
+      }
+    }
+    ```
+
+=== "YAML"
+
+    ```yaml
+    paths:
+      /widgets:
+        get: ...
+      x-codegen-contextRoot: /api/v3
+    ```
+
+**Without context root:**
+
+```java
+@Path("/widgets")
+public interface WidgetsResource { }
+```
+
+**With context root `/api/v3`:**
+
+```java
+@Path("/api/v3/widgets")
+public interface WidgetsResource { }
+```
+
+!!! tip
+    Use this to align generated code with your application's deployment path without modifying every path in the OpenAPI spec.
+
+---
+
+## Schema-Level Extensions
+
+### `x-codegen-package`
+
+Overrides the Java package for a specific generated bean class. By default, beans are placed in the `beans` sub-package of your configured `javaPackage`.
+
+```json
+{
+  "components": {
+    "schemas": {
+      "AuditEvent": {
+        "type": "object",
+        "x-codegen-package": "com.example.api.audit",
+        "properties": {
+          "action": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+**Effect:** The `AuditEvent` class is generated in `com.example.api.audit` instead of the default `com.example.api.beans`.
+
+---
+
+### `x-codegen-annotations`
+
+Adds Java annotations to a **specific** bean class. This is the per-schema equivalent of the global `x-codegen.bean-annotations`.
+
+The value is an array of fully qualified annotation class names:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "MyBean": {
+        "type": "object",
+        "x-codegen-annotations": [
+          "io.quarkus.runtime.annotations.RegisterForReflection"
+        ],
+        "properties": {
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated bean:**
+
+```java
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("jsonschema2pojo")
+@io.quarkus.runtime.annotations.RegisterForReflection
+public class MyBean {
+    // ...
+}
+```
+
+!!! note
+    Per-schema annotations are applied in addition to any global `x-codegen.bean-annotations`.
+
+---
+
+### `x-codegen-extendsClass`
+
+Makes a generated bean class extend a specified superclass.
+
+```json
+{
+  "components": {
+    "schemas": {
+      "RuleViolationError": {
+        "type": "object",
+        "x-codegen-extendsClass": "com.example.api.beans.Error",
+        "properties": {
+          "causes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RuleViolationCause" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated bean:**
+
+```java
+public class RuleViolationError extends Error {
+    // Only properties specific to RuleViolationError
+}
+```
+
+Can be combined with `x-codegen-annotations`:
+
+```json
+{
+  "MySchema": {
+    "type": "object",
+    "x-codegen-extendsClass": "org.example.api.beans.AbstractSchema",
+    "x-codegen-annotations": ["lombok.AllArgsConstructor", "lombok.Builder"],
+    "properties": { "..." : "..." }
+  }
+}
+```
+
+---
+
+### `x-codegen-type`
+
+Overrides the Java type mapping for a schema. This is primarily used for map types where you want to use a specific Java map implementation.
+
+Supported type values:
+
+| Extension Value | Java Type |
+|----------------|-----------|
+| `map` | `java.util.Map<String, Object>` |
+
+```json
+{
+  "components": {
+    "schemas": {
+      "Metadata": {
+        "type": "object",
+        "x-codegen-type": "map",
+        "additionalProperties": true
+      }
+    }
+  }
+}
+```
+
+---
+
+### `x-codegen-inline`
+
+Marks a schema definition as "inline", meaning it will not generate a separate bean class. Instead, its type will be inlined wherever it is referenced.
+
+```json
+{
+  "components": {
+    "schemas": {
+      "SimpleId": {
+        "type": "string",
+        "x-codegen-inline": true
+      }
+    }
+  }
+}
+```
+
+When `SimpleId` is referenced elsewhere (e.g. as a property type or parameter type), it will be replaced with `String` directly rather than generating a `SimpleId` class.
+
+This is useful for trivial wrapper types that don't warrant their own class.
+
+---
+
+## Operation-Level Extensions
+
+### `x-codegen-async`
+
+Marks an individual operation's return type as asynchronous by wrapping it in `CompletionStage<>`. This is the per-operation equivalent of the global [`reactive`](configuration-reference.md#reactive) setting.
+
+Place this extension on the operation object:
+
+=== "JSON"
+
+    ```json
+    {
+      "paths": {
+        "/items": {
+          "get": {
+            "operationId": "listItems",
+            "x-codegen-async": true,
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Item" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
+=== "YAML"
+
+    ```yaml
+    paths:
+      /items:
+        get:
+          operationId: listItems
+          x-codegen-async: true
+          responses:
+            "200":
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Item"
+    ```
+
+**Generated interface method:**
+
+```java
+@GET
+@Produces("application/json")
+CompletionStage<List<Item>> listItems();
+```
+
+!!! tip
+    Use `x-codegen-async` when you want async behavior on specific operations rather than enabling [`reactive`](configuration-reference.md#reactive) globally.
+
+---
+
+### `x-codegen-returnType`
+
+Overrides the Java return type of a generated JAX-RS interface method. Place this extension on the **media type object** inside a response.
+
+```json
+{
+  "paths": {
+    "/widgets/{widgetId}": {
+      "get": {
+        "operationId": "getWidget",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Widget" },
+                "x-codegen-returnType": "jakarta.ws.rs.core.Response"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated interface method:**
+
+```java
+@GET
+@Path("/{widgetId}")
+@Produces("application/json")
+Response getWidget(@PathParam("widgetId") String widgetId);
+```
+
+This is useful when you need full control over the HTTP response (status codes, headers, etc.) for specific operations.
+
+---
+
+## Property-Level Extensions
+
+### `x-codegen-formatPattern`
+
+Overrides the default date-time format pattern for a specific `date-time` property.
+
+By default, `date-time` properties are annotated with:
+
+```java
+@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+```
+
+Use `x-codegen-formatPattern` to change the pattern:
+
+```json
+{
+  "components": {
+    "schemas": {
+      "Event": {
+        "type": "object",
+        "properties": {
+          "scheduledAt": {
+            "type": "string",
+            "format": "date-time",
+            "x-codegen-formatPattern": "yyyy-MM-dd HH:mm:ss.SSSZ"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Generated property:**
+
+```java
+@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSSZ", timezone = "UTC")
+@JsonProperty("scheduledAt")
+private Date scheduledAt;
+```
+
+!!! note
+    To suppress date-time formatting entirely (remove all `@JsonFormat` annotations), use the global [`x-codegen.suppress-date-time-formatting`](#x-codegensuppress-date-time-formatting) setting instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,12 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - User Guide:
-    - user-guide/index.md
+    - Overview: user-guide/index.md
+    - Maven Plugin: user-guide/maven-plugin.md
+    - Configuration Reference: user-guide/configuration-reference.md
+    - OpenAPI Extensions: user-guide/openapi-extensions.md
+    - Generated Output: user-guide/generated-output.md
+    - Examples: user-guide/examples.md
 
 docs_dir: ./docs
 site_dir: ./site


### PR DESCRIPTION
## Summary
- Rewrite getting-started with current versions and streamlined 4-step flow showing generated output
- Add 5 new reference pages: Maven plugin, config reference (14 properties), OpenAPI extensions (10+), generated output guide, and practical examples
- Fix inaccurate project structure in index.md, replace placeholder user-guide TOC with real content

## Test plan
- [ ] Run `mkdocs serve` and verify all pages render
- [ ] Verify internal cross-links between pages work
- [ ] Confirm nav shows all 6 user guide sections