### PR TITLE
Mark codegen Maven plugin as thread-safe

### DIFF
--- a/core/src/main/java/io/apitomy/hub/api/codegen/OpenApi2JaxRs.java
+++ b/core/src/main/java/io/apitomy/hub/api/codegen/OpenApi2JaxRs.java
@@ -33,9 +33,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -109,7 +109,7 @@ import io.apitomy.hub.api.codegen.util.IndexedCodeWriter;
  */
 public class OpenApi2JaxRs {
 
-    static final Map<String, Type<?>> TYPE_CACHE = new HashMap<>();
+    static final Map<String, Type<?>> TYPE_CACHE = new ConcurrentHashMap<>();
     static final String OPENAPI_OPERATION_ANNOTATION = "org.eclipse.microprofile.openapi.annotations.Operation";
     private static final String MEDIA_TYPE_CONSTANT_PREFIX = "MediaType.";
 

--- a/maven-plugin/src/main/java/io/apitomy/codegen/maven/GenerateCodeMojo.java
+++ b/maven-plugin/src/main/java/io/apitomy/codegen/maven/GenerateCodeMojo.java
@@ -25,7 +25,7 @@ import io.apitomy.hub.api.codegen.OpenApi2JaxRs;
  * 
  * @author eric.wittmann@gmail.com
  */
-@Mojo(name = "generate")
+@Mojo(name = "generate", threadSafe = true)
 public class GenerateCodeMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
## Summary
- Add `threadSafe = true` to the `@Mojo` annotation on `GenerateCodeMojo` to eliminate the
  Maven warning when parallel builds (`-T`) are enabled.
- Switch the static `TYPE_CACHE` in `OpenApi2JaxRs` from `HashMap` to `ConcurrentHashMap` to
  ensure correctness under concurrent access.

## Test plan
- [ ] Build the project successfully (`./build.sh`)
- [ ] Use the plugin in a downstream project with `mvn -T 4 install` and confirm the warning
      no longer appears