### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: 'Checkout'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout apitomy-codegen
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -32,7 +32,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Checkout website repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: Apitomy/apitomy.github.io
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       snapshot-version: ${{ steps.versions.outputs.snapshot-version }}
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.branch }}
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
     if: always() && needs.release.result == 'success'
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.branch }}
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -27,7 +27,7 @@ jobs:
           - '21'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:


### PR DESCRIPTION
## Summary
- Update actions/checkout from v6 to v7 across all workflows

## Context
This dependency upgrade was split from Renovate PR #444 for easier review and testing.

The only breaking change in v7 is blocking fork PR checkouts for `pull_request_target` and
`workflow_run` event triggers — none of our workflows use those triggers.

## Test Plan
- [ ] CI workflows pass