### PR TITLE
Update actions/setup-python to v6

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.14.6'
 


### PR DESCRIPTION
## Summary
- Update actions/setup-python from v5 to v6 in publish-docs workflow

## Context
This dependency upgrade was split from Renovate PR #444 for easier review and testing.

The breaking change in v6 is the upgrade to Node 24 runtime, which requires GitHub Actions
runner v2.327.1+. GitHub-hosted runners already meet this requirement.

## Test Plan
- [ ] publish-docs workflow passes