### PR TITLE
Normalize quarkus.platform.version in test golden file comparison

### DIFF
--- a/core/src/test/java/io/apitomy/hub/api/codegen/OpenApi2TestBase.java
+++ b/core/src/test/java/io/apitomy/hub/api/codegen/OpenApi2TestBase.java
@@ -59,7 +59,9 @@ class OpenApi2TestBase {
                         System.out.println("-----");
                     }
 
-                    Assert.assertEquals("Expected vs. actual failed for entry: " + name, normalizeJdkVersion(normalizeLines(expected), name), normalizeLines(actual));
+                    Assert.assertEquals("Expected vs. actual failed for entry: " + name,
+                            normalizeQuarkusPlatformVersion(normalizeJdkVersion(normalizeLines(expected), name), name),
+                            normalizeQuarkusPlatformVersion(normalizeLines(actual), name));
                 }
                 zipEntry = zipInputStream.getNextEntry();
             }
@@ -77,6 +79,15 @@ class OpenApi2TestBase {
             content = content.replaceAll(
                     "openjdk-\\d+-runtime",
                     "openjdk-" + jdkVersion + "-runtime");
+        }
+        return content;
+    }
+
+    private static String normalizeQuarkusPlatformVersion(String content, String fileName) {
+        if (fileName.endsWith("pom.xml")) {
+            content = content.replaceAll(
+                    "(<quarkus.platform.version>)[^<]+(</quarkus.platform.version>)",
+                    "$1QUARKUS_VERSION$2");
         }
         return content;
     }


### PR DESCRIPTION
## Summary
- Adds `normalizeQuarkusPlatformVersion()` to `OpenApi2TestBase` that replaces
  `<quarkus.platform.version>` values with a fixed placeholder before assertion,
  making the 22 golden pom.xml fixtures version-agnostic
- Follows the same pattern as the existing `normalizeJdkVersion()` method
- Prevents future Renovate version bumps from breaking `OpenApi2QuarkusTest`

Fixes #454

## Test plan
- [x] Full build passes via `build.sh` — all 10 `OpenApi2QuarkusTest` tests green
- [ ] CI passes on this PR
- [ ] After merge, rebase Renovate PR #453 and confirm its CI passes